### PR TITLE
ops: enable ruff autofix on commit

### DIFF
--- a/.claude/team/roster.json
+++ b/.claude/team/roster.json
@@ -8,5 +8,10 @@
   "Kwesi Boateng": "parametrization+Kwesi.Boateng@gmail.com",
   "Oyunbileg Batbayar": "parametrization+Oyunbileg.Batbayar@gmail.com",
   "Tarek Mansour": "parametrization+Tarek.Mansour@gmail.com",
-  "Sofia Cardoso": "parametrization+Sofia.Cardoso@gmail.com"
+  "Sofia Cardoso": "parametrization+Sofia.Cardoso@gmail.com",
+
+  "Nadia Khoury": "parametrization+Nadia.Khoury@gmail.com",
+  "Wanjiku Mwangi": "parametrization+Wanjiku.Mwangi@gmail.com",
+  "Santiago Ferreira": "parametrization+Santiago.Ferreira@gmail.com",
+  "Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,14 +14,14 @@
 
 repos:
   # --- Ruff formatter & linter ---
+  # ruff-format runs first so format fixes don't trigger re-lint.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.6
     hooks:
       - id: ruff-format
-        args: [--check]
         name: ruff-format
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix]
         name: ruff-lint
 
   # --- Secret detection ---

--- a/src/graph/validate.py
+++ b/src/graph/validate.py
@@ -63,7 +63,7 @@ def _classify_collection_coverage(
     failures: list[str] = []
     for row in rows:
         dev = row.get("deviation_pct")
-        if dev is not None and isinstance(dev, (int, float)) and dev > deviation_threshold:
+        if dev is not None and isinstance(dev, int | float) and dev > deviation_threshold:
             cid = row.get("collection_id", "?")
             failures.append(f"{cid}: {dev:.1f}% deviation")
     passed = len(failures) == 0


### PR DESCRIPTION
## Summary

Implements [`noorinalabs/noorinalabs-main#110`](https://github.com/noorinalabs/noorinalabs-main/issues/110) for `noorinalabs-data-acquisition`: lint and format errors now autofix at commit time instead of failing CI.

## Changes

1. **`.pre-commit-config.yaml`** — drop `args: [--check]` from `ruff-format` and `args: [--exit-non-zero-on-fix]` from `ruff` so the hooks rewrite files instead of just reporting. ruff-format runs first so format fixes don't trigger re-lint.

2. **`src/graph/validate.py`** — `pre-commit run ruff --all-files` surfaced one UP038 fix (`isinstance(x, (int, float))` → `isinstance(x, int | float)`). After this, both `ruff-format` and `ruff` are clean across the repo.

`pre-commit run ruff-format --all-files` produced no diff against current main, so there is no format-noise commit here.

## Prerequisite commit

The branch starts with `infra: Add org-level coordinators to roster` (Aino Virtanen, sha `98f62cd`), which adds Nadia Khoury, Wanjiku, Santiago, and Aino to `.claude/team/roster.json` so org-level coordinators can land repo-spanning ops PRs. Steven approved this expansion. A separate W9 tech-debt issue will track making the cross-repo roster detection automatic so we don't have to sync names by hand.

## Test plan

- [x] `uvx pre-commit run ruff-format --all-files` → Passed
- [x] `uvx pre-commit run ruff --all-files` → Passed
- [ ] CI green
- [ ] Reviewer to spot-check the UP038 fix in `src/graph/validate.py`

## Issue

Refs noorinalabs/noorinalabs-main#110

🤖 Generated with [Claude Code](https://claude.com/claude-code)