### PR TITLE
feat(acquire): emit pipeline.raw.new Kafka message after B2 landing (#28)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "tqdm>=4.66",
     "tenacity>=8.2",
     "rapidfuzz>=3.6",
+    "kafka-python>=2.3.1",
 ]
 
 [project.scripts]
@@ -104,6 +105,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["kaggle", "kaggle.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["kafka", "kafka.*"]
 ignore_missing_imports = true
 
 [tool.pydantic-mypy]

--- a/src/acquire/fawaz.py
+++ b/src/acquire/fawaz.py
@@ -19,6 +19,7 @@ from src.acquire.base import (
     fetch_json,
     write_manifest,
 )
+from src.messaging import emit_raw_new_for_manifest
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -79,6 +80,7 @@ def run(raw_dir: Path) -> Path:
             ara_count=len(existing_ara),
         )
         write_manifest(dest, all_existing)
+        emit_raw_new_for_manifest(source="fawaz", local_dir=dest, files=all_existing)
         return dest
 
     # 2. Download editions.json (small catalog file)
@@ -129,4 +131,5 @@ def run(raw_dir: Path) -> Path:
         ara_count=len(ara_files),
     )
     write_manifest(dest, downloaded)
+    emit_raw_new_for_manifest(source="fawaz", local_dir=dest, files=downloaded)
     return dest

--- a/src/acquire/lk_corpus.py
+++ b/src/acquire/lk_corpus.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from src.acquire.base import clone_repo, ensure_dir, write_manifest
+from src.messaging import emit_raw_new_for_manifest
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -27,4 +28,5 @@ def run(raw_dir: Path) -> Path:
         raise AssertionError(msg)
     logger.info("lk_acquired", file_count=len(csv_files))
     write_manifest(dest, csv_files)
+    emit_raw_new_for_manifest(source="lk_corpus", local_dir=dest, files=csv_files)
     return dest

--- a/src/acquire/muhaddithat.py
+++ b/src/acquire/muhaddithat.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from src.acquire.base import clone_repo, ensure_dir, write_manifest
+from src.messaging import emit_raw_new_for_manifest
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -32,4 +33,5 @@ def run(raw_dir: Path) -> Path:
     all_csvs = list(dest.rglob("*.csv"))
     logger.info("muhaddithat_acquired", file_count=len(all_csvs))
     write_manifest(dest, all_csvs)
+    emit_raw_new_for_manifest(source="muhaddithat", local_dir=dest, files=all_csvs)
     return dest

--- a/src/acquire/open_hadith.py
+++ b/src/acquire/open_hadith.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from src.acquire.base import clone_repo, ensure_dir, write_manifest
+from src.messaging import emit_raw_new_for_manifest
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -32,4 +33,5 @@ def run(raw_dir: Path) -> Path:
 
     logger.info("open_hadith_acquired", file_count=len(csv_files))
     write_manifest(dest, csv_files)
+    emit_raw_new_for_manifest(source="open_hadith", local_dir=dest, files=csv_files)
     return dest

--- a/src/acquire/sanadset.py
+++ b/src/acquire/sanadset.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 from src.acquire.base import download_file, ensure_dir, write_manifest
 from src.config import get_settings
+from src.messaging import emit_raw_new_for_manifest
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -224,4 +225,5 @@ def download_sanadset(dest: Path | None = None) -> Path:
 
     all_files = [*hadith_csvs, *narrators_csvs]
     write_manifest(dest, all_files)
+    emit_raw_new_for_manifest(source="sanadset", local_dir=dest, files=all_files)
     return dest

--- a/src/acquire/sunnah_api.py
+++ b/src/acquire/sunnah_api.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from src.acquire.base import ensure_dir, fetch_json_paginated, write_manifest
 from src.config import get_settings
+from src.messaging import emit_raw_new_for_manifest
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -84,6 +85,7 @@ def run(raw_dir: Path) -> Path | None:
         time.sleep(RATE_LIMIT_SECONDS)
 
     write_manifest(dest, saved_files)
+    emit_raw_new_for_manifest(source="sunnah_api", local_dir=dest, files=saved_files)
     logger.info(
         "sunnah_acquired",
         collections=len(raw_collections),

--- a/src/acquire/sunnah_scraper.py
+++ b/src/acquire/sunnah_scraper.py
@@ -20,6 +20,7 @@ import httpx
 from bs4 import BeautifulSoup, Tag
 
 from src.acquire.base import ensure_dir, select_first, write_manifest
+from src.messaging import emit_raw_new_for_manifest
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -306,6 +307,7 @@ def run(raw_dir: Path) -> Path | None:
 
         if saved_files:
             write_manifest(dest, saved_files)
+            emit_raw_new_for_manifest(source="sunnah_scraper", local_dir=dest, files=saved_files)
 
         logger.info(
             "sunnah_scraper_acquired",

--- a/src/acquire/thaqalayn.py
+++ b/src/acquire/thaqalayn.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from src.acquire.base import clone_repo, ensure_dir, write_manifest
+from src.messaging import emit_raw_new_for_manifest
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -44,6 +45,7 @@ def run(raw_dir: Path) -> Path:
             file_count=len(all_files),
         )
         write_manifest(dest, all_files)
+        emit_raw_new_for_manifest(source="thaqalayn", local_dir=dest, files=all_files)
         return dest
 
     saved = _download_via_github(dest)
@@ -57,5 +59,6 @@ def run(raw_dir: Path) -> Path:
         raise AssertionError(msg)
 
     write_manifest(dest, json_files)
+    emit_raw_new_for_manifest(source="thaqalayn", local_dir=dest, files=json_files)
     logger.info("thaqalayn_acquired", total_files=len(json_files))
     return dest

--- a/src/messaging/__init__.py
+++ b/src/messaging/__init__.py
@@ -1,0 +1,17 @@
+"""Messaging helpers — Kafka producer for pipeline signal topics."""
+
+from __future__ import annotations
+
+from src.messaging.kafka_producer import (
+    RAW_NEW_MESSAGE_SCHEMA,
+    RawNewMessage,
+    emit_raw_new,
+    emit_raw_new_for_manifest,
+)
+
+__all__ = [
+    "RAW_NEW_MESSAGE_SCHEMA",
+    "RawNewMessage",
+    "emit_raw_new",
+    "emit_raw_new_for_manifest",
+]

--- a/src/messaging/kafka_producer.py
+++ b/src/messaging/kafka_producer.py
@@ -1,0 +1,293 @@
+"""Kafka producer for the ``pipeline.raw.new`` signal topic.
+
+After an acquire connector lands a raw artifact in B2, emit one
+``pipeline.raw.new`` message per file so downstream pipeline workers
+(dedup, enrich, normalize, graph-load) can consume.
+
+Message schema (JSON, UTF-8, one message per file)
+---------------------------------------------------
+
+::
+
+    {
+      "source":         "<connector_name>",          // e.g. sunnah_api, lk_corpus
+      "b2_key":         "raw/<source>/<date>/<filename>",
+      "content_type":   "application/json|text/csv|...",
+      "size_bytes":     12345,
+      "acquired_at":    "2026-04-21T12:34:56.789012+00:00",  // ISO-8601 UTC
+      "checksum_sha256": "<hex>"
+    }
+
+The message is a purely "eventually consistent" signal — emit failure
+MUST NOT fail the acquire. The downstream dedup worker is responsible
+for handling duplicate messages; re-acquisition of the same B2 key is
+allowed to re-emit and is intentionally not deduplicated here
+(:issue:`28`).
+
+Configuration (env)
+-------------------
+``KAFKA_BOOTSTRAP_SERVERS``   — comma-separated host:port list
+                                (e.g. ``kafka:9092`` locally,
+                                 ``broker-1:9092,broker-2:9092`` in prod)
+``KAFKA_RAW_NEW_TOPIC``       — topic name (default ``pipeline.raw.new``)
+
+If ``KAFKA_BOOTSTRAP_SERVERS`` is unset/empty the producer is a no-op —
+messages are logged at debug level and dropped. This keeps the acquire
+stage runnable in dev/test environments without a running Kafka broker.
+
+Retry semantics
+---------------
+``kafka-python`` applies its own bounded in-process retry (producer
+``retries=3``, linger_ms=100). Once exhausted, we log at ``error`` level
+and return — the acquire continues. Rationale: B2 is the source of
+truth; a missed Kafka emit can be reconciled by replaying keys from B2.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "DEFAULT_TOPIC",
+    "RAW_NEW_MESSAGE_SCHEMA",
+    "RawNewMessage",
+    "emit_raw_new",
+    "emit_raw_new_for_manifest",
+    "sha256_of_file",
+]
+
+DEFAULT_TOPIC = "pipeline.raw.new"
+
+RAW_NEW_MESSAGE_SCHEMA: dict[str, str] = {
+    "source": "connector name (e.g. sunnah_api)",
+    "b2_key": "full B2 object key, e.g. raw/sunnah_api/2026-04-21/collections.json",
+    "content_type": "MIME type of the raw object",
+    "size_bytes": "object size in bytes (int)",
+    "acquired_at": "ISO-8601 UTC timestamp of acquisition",
+    "checksum_sha256": "SHA-256 hex digest of raw bytes",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RawNewMessage:
+    """Typed payload for the ``pipeline.raw.new`` topic."""
+
+    source: str
+    b2_key: str
+    content_type: str
+    size_bytes: int
+    acquired_at: str
+    checksum_sha256: str
+
+    def to_json(self) -> bytes:
+        """Serialize to canonical JSON bytes (sorted keys, UTF-8)."""
+        return json.dumps(asdict(self), sort_keys=True, ensure_ascii=False).encode("utf-8")
+
+
+def _bootstrap_servers() -> str:
+    """Return configured brokers or empty string when unset."""
+    return os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "").strip()
+
+
+def _topic() -> str:
+    return os.environ.get("KAFKA_RAW_NEW_TOPIC", DEFAULT_TOPIC).strip() or DEFAULT_TOPIC
+
+
+def _build_producer() -> Any:  # noqa: ANN401 — KafkaProducer has no public stub
+    """Construct a ``kafka.KafkaProducer`` or return ``None`` when unconfigured.
+
+    Import is deferred so test runs that never emit never import ``kafka``.
+    """
+    servers = _bootstrap_servers()
+    if not servers:
+        return None
+
+    from kafka import KafkaProducer  # noqa: PLC0415 — deferred import
+
+    return KafkaProducer(
+        bootstrap_servers=[s.strip() for s in servers.split(",") if s.strip()],
+        value_serializer=lambda v: v,  # we pass bytes already
+        acks="all",
+        retries=3,
+        linger_ms=100,
+        request_timeout_ms=10_000,
+        max_block_ms=5_000,
+    )
+
+
+def emit_raw_new(
+    *,
+    source: str,
+    b2_key: str,
+    content_type: str,
+    size_bytes: int,
+    checksum_sha256: str,
+    acquired_at: str | None = None,
+    producer: Any | None = None,  # noqa: ANN401
+) -> bool:
+    """Emit a single ``pipeline.raw.new`` message.
+
+    Returns ``True`` on successful emit (including producer no-op when
+    ``KAFKA_BOOTSTRAP_SERVERS`` is unset), ``False`` when emit was
+    attempted but failed. Never raises — failure is logged and swallowed
+    (see module docstring § Retry semantics).
+
+    Parameters
+    ----------
+    source, b2_key, content_type, size_bytes, checksum_sha256
+        See :data:`RAW_NEW_MESSAGE_SCHEMA`.
+    acquired_at
+        ISO-8601 timestamp. Defaults to now (UTC).
+    producer
+        Injected producer — used only by tests. Production callers omit
+        this; a fresh producer is built per emit batch via
+        :func:`emit_raw_new_for_manifest`.
+    """
+    msg = RawNewMessage(
+        source=source,
+        b2_key=b2_key,
+        content_type=content_type,
+        size_bytes=size_bytes,
+        acquired_at=acquired_at or datetime.now(UTC).isoformat(),
+        checksum_sha256=checksum_sha256,
+    )
+
+    topic = _topic()
+    owns_producer = False
+    if producer is None:
+        producer = _build_producer()
+        owns_producer = True
+        if producer is None:
+            logger.debug(
+                "kafka_emit_skipped",
+                reason="KAFKA_BOOTSTRAP_SERVERS unset",
+                topic=topic,
+                b2_key=b2_key,
+            )
+            return True
+
+    try:
+        future = producer.send(topic, value=msg.to_json(), key=b2_key.encode("utf-8"))
+        future.get(timeout=10)
+        logger.info(
+            "kafka_emit_ok",
+            topic=topic,
+            source=source,
+            b2_key=b2_key,
+            size_bytes=size_bytes,
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — must never propagate
+        logger.error(
+            "kafka_emit_failed",
+            topic=topic,
+            source=source,
+            b2_key=b2_key,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return False
+    finally:
+        if owns_producer:
+            try:
+                producer.flush(timeout=5)
+                producer.close(timeout=5)
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def emit_raw_new_for_manifest(
+    *,
+    source: str,
+    local_dir: Path,
+    files: list[Path],
+    b2_prefix: str | None = None,
+    acquired_at: str | None = None,
+) -> int:
+    """Emit one ``pipeline.raw.new`` message per file.
+
+    Computes the ``b2_key`` as ``<b2_prefix>/<relative-path>`` where
+    ``b2_prefix`` defaults to ``raw/<source>/<YYYY-MM-DD>/``. ``size_bytes``
+    and ``checksum_sha256`` are read from the local file on disk — the
+    acquire stage writes locally before the pipeline's B2 upload shim
+    mirrors to the bucket, so the local file is the authoritative
+    artifact.
+
+    Emission failures are logged per-file and do NOT abort the batch.
+    Returns the count of messages successfully sent.
+    """
+    if not files:
+        return 0
+
+    date_utc = (
+        datetime.now(UTC).strftime("%Y-%m-%d")
+        if acquired_at is None
+        else acquired_at[:10]  # ISO-8601 date prefix
+    )
+    prefix = (b2_prefix or f"raw/{source}/{date_utc}").rstrip("/")
+
+    producer = _build_producer()
+    owns_producer = producer is not None
+    try:
+        sent = 0
+        ts = acquired_at or datetime.now(UTC).isoformat()
+        for f in files:
+            if not f.is_file():
+                logger.warning("kafka_emit_skipped_missing_file", path=str(f), source=source)
+                continue
+            rel = f.relative_to(local_dir) if f.is_relative_to(local_dir) else Path(f.name)
+            b2_key = f"{prefix}/{rel.as_posix()}"
+            if emit_raw_new(
+                source=source,
+                b2_key=b2_key,
+                content_type=_guess_content_type(f),
+                size_bytes=f.stat().st_size,
+                checksum_sha256=sha256_of_file(f),
+                acquired_at=ts,
+                producer=producer,
+            ):
+                sent += 1
+        return sent
+    finally:
+        if owns_producer and producer is not None:
+            try:
+                producer.flush(timeout=10)
+                producer.close(timeout=5)
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def sha256_of_file(path: Path) -> str:
+    """SHA-256 hex digest of a file on disk."""
+    h = hashlib.sha256()
+    with path.open("rb") as fp:
+        for chunk in iter(lambda: fp.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+_EXT_TO_CT = {
+    ".json": "application/json",
+    ".csv": "text/csv",
+    ".tsv": "text/tab-separated-values",
+    ".parquet": "application/x-parquet",
+    ".xml": "application/xml",
+    ".html": "text/html",
+    ".txt": "text/plain",
+    ".zip": "application/zip",
+    ".gz": "application/gzip",
+}
+
+
+def _guess_content_type(path: Path) -> str:
+    return _EXT_TO_CT.get(path.suffix.lower(), "application/octet-stream")

--- a/src/messaging/kafka_producer.py
+++ b/src/messaging/kafka_producer.py
@@ -37,10 +37,25 @@ stage runnable in dev/test environments without a running Kafka broker.
 
 Retry semantics
 ---------------
-``kafka-python`` applies its own bounded in-process retry (producer
-``retries=3``, linger_ms=100). Once exhausted, we log at ``error`` level
-and return — the acquire continues. Rationale: B2 is the source of
-truth; a missed Kafka emit can be reconciled by replaying keys from B2.
+``kafka-python`` applies its own bounded in-process retry. We configure
+``retries=3`` and ``retry_backoff_ms=500``. The wrapper does NOT add
+client-side jitter — if multiple connectors recover simultaneously they
+may briefly stampede the broker. This is acceptable at current scale
+(8 connectors, bounded throughput); revisit if connector count grows.
+
+Delivery semantics
+------------------
+Emit is fire-and-forget: ``send()`` returns without blocking on the
+broker ACK. Durability is guaranteed only by calling ``producer.flush()``
+before process exit. :func:`emit_raw_new_for_manifest` flushes the
+owned producer on its way out; callers that inject their own producer
+(or invoke :func:`emit_raw_new` one-off) must flush themselves to
+guarantee delivery.
+
+Rationale: a per-emit ``future.get()`` would serialize sends and defeat
+``linger_ms`` batching — 1k files would become 1k serial round-trips.
+B2 is the source of truth; a missed Kafka emit can be reconciled by
+replaying keys from B2.
 """
 
 from __future__ import annotations
@@ -48,6 +63,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -67,6 +83,8 @@ __all__ = [
 ]
 
 DEFAULT_TOPIC = "pipeline.raw.new"
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 RAW_NEW_MESSAGE_SCHEMA: dict[str, str] = {
     "source": "connector name (e.g. sunnah_api)",
@@ -88,6 +106,24 @@ class RawNewMessage:
     size_bytes: int
     acquired_at: str
     checksum_sha256: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source, str) or not self.source:
+            raise ValueError("source must be a non-empty string")
+        if not isinstance(self.b2_key, str) or not self.b2_key:
+            raise ValueError("b2_key must be a non-empty string")
+        if not isinstance(self.size_bytes, int) or isinstance(self.size_bytes, bool):
+            raise ValueError("size_bytes must be an int")
+        if self.size_bytes < 0:
+            raise ValueError("size_bytes must be >= 0")
+        if not isinstance(self.checksum_sha256, str) or not _SHA256_RE.match(self.checksum_sha256):
+            raise ValueError("checksum_sha256 must be a 64-char lowercase hex SHA-256 digest")
+        if not isinstance(self.acquired_at, str):
+            raise ValueError("acquired_at must be an ISO-8601 string")
+        try:
+            datetime.fromisoformat(self.acquired_at)
+        except ValueError as exc:
+            raise ValueError(f"acquired_at must be ISO-8601 parseable: {exc}") from exc
 
     def to_json(self) -> bytes:
         """Serialize to canonical JSON bytes (sorted keys, UTF-8)."""
@@ -119,6 +155,7 @@ def _build_producer() -> Any:  # noqa: ANN401 — KafkaProducer has no public st
         value_serializer=lambda v: v,  # we pass bytes already
         acks="all",
         retries=3,
+        retry_backoff_ms=500,
         linger_ms=100,
         request_timeout_ms=10_000,
         max_block_ms=5_000,
@@ -137,9 +174,15 @@ def emit_raw_new(
 ) -> bool:
     """Emit a single ``pipeline.raw.new`` message.
 
-    Returns ``True`` on successful emit (including producer no-op when
-    ``KAFKA_BOOTSTRAP_SERVERS`` is unset), ``False`` when emit was
-    attempted but failed. Never raises — failure is logged and swallowed
+    Emit is fire-and-forget — ``send()`` returns without blocking on the
+    broker ACK. Callers that inject their own ``producer`` are responsible
+    for calling ``producer.flush()`` to guarantee delivery. When this
+    function owns the producer (no injection, broker configured), it
+    flushes before returning so durability holds for the one-off path.
+
+    Returns ``True`` on successful enqueue (or producer no-op when
+    ``KAFKA_BOOTSTRAP_SERVERS`` is unset), ``False`` when the send call
+    itself raised. Never raises — failures are logged and swallowed
     (see module docstring § Retry semantics).
 
     Parameters
@@ -149,9 +192,9 @@ def emit_raw_new(
     acquired_at
         ISO-8601 timestamp. Defaults to now (UTC).
     producer
-        Injected producer — used only by tests. Production callers omit
-        this; a fresh producer is built per emit batch via
-        :func:`emit_raw_new_for_manifest`.
+        Injected producer — used by tests and by
+        :func:`emit_raw_new_for_manifest` to share a producer across
+        many per-file emits. Production one-off callers omit this.
     """
     msg = RawNewMessage(
         source=source,
@@ -177,10 +220,9 @@ def emit_raw_new(
             return True
 
     try:
-        future = producer.send(topic, value=msg.to_json(), key=b2_key.encode("utf-8"))
-        future.get(timeout=10)
+        producer.send(topic, value=msg.to_json(), key=b2_key.encode("utf-8"))
         logger.info(
-            "kafka_emit_ok",
+            "kafka_emit_enqueued",
             topic=topic,
             source=source,
             b2_key=b2_key,
@@ -200,7 +242,7 @@ def emit_raw_new(
     finally:
         if owns_producer:
             try:
-                producer.flush(timeout=5)
+                producer.flush(timeout=10)
                 producer.close(timeout=5)
             except Exception:  # noqa: BLE001
                 pass
@@ -229,11 +271,14 @@ def emit_raw_new_for_manifest(
     if not files:
         return 0
 
-    date_utc = (
-        datetime.now(UTC).strftime("%Y-%m-%d")
-        if acquired_at is None
-        else acquired_at[:10]  # ISO-8601 date prefix
-    )
+    if acquired_at is None:
+        date_utc = datetime.now(UTC).strftime("%Y-%m-%d")
+    else:
+        # Parse via fromisoformat (handles `Z` suffix on 3.11+) to extract
+        # a guaranteed YYYY-MM-DD date — slicing `acquired_at[:10]` would
+        # silently mis-slice non-ISO inputs.
+        iso = acquired_at.replace("Z", "+00:00") if acquired_at.endswith("Z") else acquired_at
+        date_utc = datetime.fromisoformat(iso).date().isoformat()
     prefix = (b2_prefix or f"raw/{source}/{date_utc}").rstrip("/")
 
     producer = _build_producer()

--- a/tests/test_messaging/test_acquire_wireins.py
+++ b/tests/test_messaging/test_acquire_wireins.py
@@ -270,7 +270,7 @@ class TestFailureInjection:
             b2_key="raw/lk_corpus/2026-04-21/a.csv",
             content_type="text/csv",
             size_bytes=1,
-            checksum_sha256="x",
+            checksum_sha256="a" * 64,
             producer=broken,
         )
         assert ok is False

--- a/tests/test_messaging/test_acquire_wireins.py
+++ b/tests/test_messaging/test_acquire_wireins.py
@@ -1,0 +1,276 @@
+"""Wire-in tests: every acquire connector calls ``emit_raw_new_for_manifest``.
+
+These tests stub out network and git operations so each connector's
+``run()`` reaches the emit call on the happy path. The assertion is
+narrow: the emit helper was called with the expected ``source=`` value.
+The per-file payload correctness is covered by
+``test_kafka_producer.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _seed_csvs(dest: Path, names: list[str]) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    for n in names:
+        (dest / n).write_text("a,b\n1,2\n", encoding="utf-8")
+
+
+def _seed_jsons(dest: Path, names: list[str]) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    for n in names:
+        (dest / n).write_text("{}", encoding="utf-8")
+
+
+class TestLkCorpusWireIn:
+    def test_run_emits_with_source_lk_corpus(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        csvs = [
+            "bukhari.csv",
+            "muslim.csv",
+            "abudawud.csv",
+            "tirmidhi.csv",
+            "nasai.csv",
+            "ibnmajah.csv",
+        ]
+
+        def fake_clone_repo(url: str, dest: Path, **kw: Any) -> Path:
+            _seed_csvs(dest, csvs)
+            return dest
+
+        with (
+            patch("src.acquire.lk_corpus.clone_repo", side_effect=fake_clone_repo),
+            patch("src.acquire.lk_corpus.emit_raw_new_for_manifest") as emit,
+        ):
+            from src.acquire import lk_corpus
+
+            lk_corpus.run(raw)
+
+        emit.assert_called_once()
+        assert emit.call_args.kwargs["source"] == "lk_corpus"
+        assert len(emit.call_args.kwargs["files"]) >= 6
+
+
+class TestOpenHadithWireIn:
+    def test_run_emits_with_source_open_hadith(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        names = [f"book{i}.csv" for i in range(9)]
+
+        def fake_clone_repo(url: str, dest: Path, **kw: Any) -> Path:
+            _seed_csvs(dest, names)
+            return dest
+
+        with (
+            patch("src.acquire.open_hadith.clone_repo", side_effect=fake_clone_repo),
+            patch("src.acquire.open_hadith.emit_raw_new_for_manifest") as emit,
+        ):
+            from src.acquire import open_hadith
+
+            open_hadith.run(raw)
+
+        emit.assert_called_once()
+        assert emit.call_args.kwargs["source"] == "open_hadith"
+
+
+class TestMuhaddithatWireIn:
+    def test_run_emits_with_source_muhaddithat(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+
+        def fake_clone_repo(url: str, dest: Path, **kw: Any) -> Path:
+            _seed_csvs(dest, ["hadiths.csv", "narrators.csv"])
+            return dest
+
+        with (
+            patch("src.acquire.muhaddithat.clone_repo", side_effect=fake_clone_repo),
+            patch("src.acquire.muhaddithat.emit_raw_new_for_manifest") as emit,
+        ):
+            from src.acquire import muhaddithat
+
+            muhaddithat.run(raw)
+
+        emit.assert_called_once()
+        assert emit.call_args.kwargs["source"] == "muhaddithat"
+
+
+class TestThaqalaynWireIn:
+    def test_run_emits_with_source_thaqalayn_on_skip_path(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        dest = raw / "thaqalayn"
+        # Pre-seed enough book_*.json files to hit the idempotent skip branch.
+        _seed_jsons(dest, [f"book_{i:03d}.json" for i in range(16)])
+
+        with patch("src.acquire.thaqalayn.emit_raw_new_for_manifest") as emit:
+            from src.acquire import thaqalayn
+
+            thaqalayn.run(raw)
+
+        emit.assert_called_once()
+        assert emit.call_args.kwargs["source"] == "thaqalayn"
+
+    def test_run_emits_with_source_thaqalayn_on_fresh_clone(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+
+        def fake_download(dest: Path) -> list[Path]:
+            clone_dest = dest / "github_clone"
+            _seed_jsons(clone_dest, [f"book_{i:03d}.json" for i in range(16)])
+            return list(clone_dest.glob("*.json"))
+
+        with (
+            patch(
+                "src.acquire.thaqalayn._download_via_github",
+                side_effect=fake_download,
+            ),
+            patch("src.acquire.thaqalayn.emit_raw_new_for_manifest") as emit,
+        ):
+            from src.acquire import thaqalayn
+
+            thaqalayn.run(raw)
+
+        emit.assert_called_once()
+        assert emit.call_args.kwargs["source"] == "thaqalayn"
+
+
+class TestSunnahApiWireIn:
+    def test_run_emits_with_source_sunnah_api(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SUNNAH_API_KEY", "test-key")
+        # Clear the settings cache so the env var is picked up.
+        from src.config import get_settings
+
+        get_settings.cache_clear()
+
+        raw = tmp_path / "raw"
+
+        def fake_fetch_json_paginated(url: str, **kw: Any) -> list[dict[str, Any]]:
+            if "/collections" in url and "/hadiths" not in url:
+                return [{"name": "bukhari"}, {"name": "muslim"}]
+            return [{"hadith": "x"}]
+
+        with (
+            patch(
+                "src.acquire.sunnah_api.fetch_json_paginated",
+                side_effect=fake_fetch_json_paginated,
+            ),
+            patch("src.acquire.sunnah_api.time.sleep"),
+            patch("src.acquire.sunnah_api.emit_raw_new_for_manifest") as emit,
+        ):
+            from src.acquire import sunnah_api
+
+            sunnah_api.run(raw)
+
+        emit.assert_called_once()
+        assert emit.call_args.kwargs["source"] == "sunnah_api"
+
+
+class TestFawazWireIn:
+    def test_run_emits_with_source_fawaz_on_skip_path(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        dest = raw / "fawaz"
+        _seed_jsons(dest, [f"eng-{i}.json" for i in range(10)])
+        _seed_jsons(dest, [f"ara-{i}.json" for i in range(10)])
+
+        with patch("src.acquire.fawaz.emit_raw_new_for_manifest") as emit:
+            from src.acquire import fawaz
+
+            fawaz.run(raw)
+
+        emit.assert_called_once()
+        assert emit.call_args.kwargs["source"] == "fawaz"
+
+
+class TestSanadsetWireIn:
+    def test_run_emits_with_source_sanadset(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        dest = raw / "sanadset"
+        _seed_csvs(dest, ["sanadset.csv", "books.csv"])
+        # Write ~MIN_EXPECTED_ROWS worth of rows so the warning path is stable.
+        (dest / "sanadset.csv").write_text("h,b\n" + "\n".join(["x,y"] * 10), encoding="utf-8")
+
+        with patch("src.acquire.sanadset.emit_raw_new_for_manifest") as emit:
+            from src.acquire import sanadset
+
+            sanadset.download_sanadset(dest=dest)
+
+        emit.assert_called_once()
+        assert emit.call_args.kwargs["source"] == "sanadset"
+
+
+class TestSunnahScraperWireIn:
+    def test_run_emits_with_source_sunnah_scraper(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+
+        def fake_scrape(client: Any, collection: str, dest_: Path) -> Path | None:
+            dest_.mkdir(parents=True, exist_ok=True)
+            path = dest_ / f"{collection}.json"
+            path.write_text("[]", encoding="utf-8")
+            return path
+
+        with (
+            patch("src.acquire.sunnah_scraper._check_robots_txt", return_value=True),
+            patch(
+                "src.acquire.sunnah_scraper._scrape_collection",
+                side_effect=fake_scrape,
+            ),
+            patch("src.acquire.sunnah_scraper.emit_raw_new_for_manifest") as emit,
+        ):
+            from src.acquire import sunnah_scraper
+
+            sunnah_scraper.run(raw)
+
+        emit.assert_called_once()
+        assert emit.call_args.kwargs["source"] == "sunnah_scraper"
+
+
+class TestFailureInjection:
+    """Emit failure must not fail acquire — documented invariant for all
+    connectors. We exercise the invariant on one representative connector
+    (lk_corpus) since the emit helper is shared code."""
+
+    def test_emit_failure_does_not_fail_lk_corpus_run(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        csvs = [f"book{i}.csv" for i in range(6)]
+
+        def fake_clone_repo(url: str, dest: Path, **kw: Any) -> Path:
+            _seed_csvs(dest, csvs)
+            return dest
+
+        # If the emit helper raised, acquire would bubble it. But the helper
+        # is contractually no-raise — the sentinel here is that a mock that
+        # returns 0 (total failure) still lets run() return normally.
+        with (
+            patch("src.acquire.lk_corpus.clone_repo", side_effect=fake_clone_repo),
+            patch(
+                "src.acquire.lk_corpus.emit_raw_new_for_manifest",
+                return_value=0,
+            ) as emit,
+        ):
+            from src.acquire import lk_corpus
+
+            result = lk_corpus.run(raw)
+
+        assert result == raw / "lk"
+        emit.assert_called_once()
+
+    def test_producer_exception_is_swallowed_by_emit_raw_new(self) -> None:
+        """Direct contract check: even if the injected producer explodes on
+        send, emit_raw_new returns False without raising."""
+        from src.messaging.kafka_producer import emit_raw_new
+
+        broken = MagicMock()
+        broken.send.side_effect = RuntimeError("broker down")
+        ok = emit_raw_new(
+            source="lk_corpus",
+            b2_key="raw/lk_corpus/2026-04-21/a.csv",
+            content_type="text/csv",
+            size_bytes=1,
+            checksum_sha256="x",
+            producer=broken,
+        )
+        assert ok is False

--- a/tests/test_messaging/test_kafka_producer.py
+++ b/tests/test_messaging/test_kafka_producer.py
@@ -18,18 +18,20 @@ from src.messaging.kafka_producer import (
     sha256_of_file,
 )
 
+_VALID_SHA = "a" * 64
+
 
 class _FakeFuture:
-    def __init__(self, exc: Exception | None = None) -> None:
-        self._exc = exc
-
-    def get(self, timeout: int) -> None:
-        if self._exc is not None:
-            raise self._exc
+    """Sentinel returned by ``_FakeProducer.send``; never awaited on the hot path."""
 
 
 class _FakeProducer:
-    """Mimics the kafka.KafkaProducer API the wrapper uses."""
+    """Mimics the kafka.KafkaProducer API the wrapper uses.
+
+    The wrapper no longer calls ``future.get`` on emit (fire-and-forget);
+    failures surface via ``send()`` raising, which mirrors kafka-python's
+    behavior when the producer is closed or the buffer is full.
+    """
 
     def __init__(self, *, fail_on_send: bool = False) -> None:
         self.sent: list[tuple[str, bytes, bytes]] = []
@@ -39,7 +41,7 @@ class _FakeProducer:
 
     def send(self, topic: str, *, value: bytes, key: bytes) -> _FakeFuture:
         if self.fail_on_send:
-            return _FakeFuture(exc=RuntimeError("simulated kafka failure"))
+            raise RuntimeError("simulated kafka failure")
         self.sent.append((topic, value, key))
         return _FakeFuture()
 
@@ -58,7 +60,7 @@ class TestRawNewMessage:
             content_type="application/json",
             size_bytes=42,
             acquired_at="2026-04-21T00:00:00+00:00",
-            checksum_sha256="deadbeef",
+            checksum_sha256=_VALID_SHA,
         )
         raw = msg.to_json()
         assert isinstance(raw, bytes)
@@ -69,10 +71,54 @@ class TestRawNewMessage:
             "content_type": "application/json",
             "size_bytes": 42,
             "acquired_at": "2026-04-21T00:00:00+00:00",
-            "checksum_sha256": "deadbeef",
+            "checksum_sha256": _VALID_SHA,
         }
         # keys sorted
         assert list(decoded.keys()) == sorted(decoded.keys())
+
+
+class TestRawNewMessageValidation:
+    def _base_kwargs(self, **overrides: Any) -> dict[str, Any]:
+        kwargs = {
+            "source": "sunnah_api",
+            "b2_key": "raw/sunnah_api/2026-04-21/c.json",
+            "content_type": "application/json",
+            "size_bytes": 1,
+            "acquired_at": "2026-04-21T00:00:00+00:00",
+            "checksum_sha256": _VALID_SHA,
+        }
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_valid_payload_constructs(self) -> None:
+        RawNewMessage(**self._base_kwargs())
+
+    def test_negative_size_bytes_raises(self) -> None:
+        with pytest.raises(ValueError, match="size_bytes must be >= 0"):
+            RawNewMessage(**self._base_kwargs(size_bytes=-1))
+
+    def test_size_bytes_zero_is_allowed(self) -> None:
+        RawNewMessage(**self._base_kwargs(size_bytes=0))
+
+    def test_non_iso_acquired_at_raises(self) -> None:
+        with pytest.raises(ValueError, match="acquired_at must be ISO-8601"):
+            RawNewMessage(**self._base_kwargs(acquired_at="yesterday"))
+
+    def test_wrong_length_checksum_raises(self) -> None:
+        with pytest.raises(ValueError, match="checksum_sha256"):
+            RawNewMessage(**self._base_kwargs(checksum_sha256="deadbeef"))
+
+    def test_uppercase_checksum_raises(self) -> None:
+        with pytest.raises(ValueError, match="checksum_sha256"):
+            RawNewMessage(**self._base_kwargs(checksum_sha256=("A" * 64)))
+
+    def test_empty_source_raises(self) -> None:
+        with pytest.raises(ValueError, match="source must be a non-empty string"):
+            RawNewMessage(**self._base_kwargs(source=""))
+
+    def test_empty_b2_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="b2_key must be a non-empty string"):
+            RawNewMessage(**self._base_kwargs(b2_key=""))
 
 
 class TestEmitRawNew:
@@ -86,7 +132,7 @@ class TestEmitRawNew:
             b2_key="raw/sunnah_api/2026-04-21/c.json",
             content_type="application/json",
             size_bytes=1,
-            checksum_sha256="abc",
+            checksum_sha256=_VALID_SHA,
         )
         assert ok is True
 
@@ -97,7 +143,7 @@ class TestEmitRawNew:
             b2_key="raw/sunnah_api/2026-04-21/c.json",
             content_type="application/json",
             size_bytes=10,
-            checksum_sha256="cafe",
+            checksum_sha256=_VALID_SHA,
             acquired_at="2026-04-21T12:00:00+00:00",
             producer=fake,
         )
@@ -109,7 +155,7 @@ class TestEmitRawNew:
         payload = json.loads(value)
         assert payload["source"] == "sunnah_api"
         assert payload["size_bytes"] == 10
-        assert payload["checksum_sha256"] == "cafe"
+        assert payload["checksum_sha256"] == _VALID_SHA
         assert payload["acquired_at"] == "2026-04-21T12:00:00+00:00"
 
     def test_custom_topic_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -120,7 +166,7 @@ class TestEmitRawNew:
             b2_key="raw/lk_corpus/2026-04-21/x.csv",
             content_type="text/csv",
             size_bytes=1,
-            checksum_sha256="f",
+            checksum_sha256=_VALID_SHA,
             producer=fake,
         )
         assert fake.sent[0][0] == "alt.raw.new"
@@ -132,10 +178,24 @@ class TestEmitRawNew:
             b2_key="raw/sunnah_api/2026-04-21/c.json",
             content_type="application/json",
             size_bytes=1,
-            checksum_sha256="abc",
+            checksum_sha256=_VALID_SHA,
             producer=fake,
         )
         assert ok is False  # failure is surfaced, not raised
+
+    def test_injected_producer_is_not_flushed_by_emit(self) -> None:
+        """Caller owns flush/close for injected producers — fire-and-forget semantics."""
+        fake = _FakeProducer()
+        emit_raw_new(
+            source="sunnah_api",
+            b2_key="raw/sunnah_api/2026-04-21/c.json",
+            content_type="application/json",
+            size_bytes=1,
+            checksum_sha256=_VALID_SHA,
+            producer=fake,
+        )
+        assert fake.flushed is False
+        assert fake.closed is False
 
     def test_builds_own_producer_and_closes_it(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
@@ -146,7 +206,7 @@ class TestEmitRawNew:
                 b2_key="raw/sunnah_api/2026-04-21/c.json",
                 content_type="application/json",
                 size_bytes=1,
-                checksum_sha256="abc",
+                checksum_sha256=_VALID_SHA,
             )
         assert ok is True
         assert build.call_count == 1
@@ -218,13 +278,63 @@ class TestEmitRawNewForManifest:
             def send(self, topic: str, *, value: bytes, key: bytes) -> _FakeFuture:
                 call_count["n"] += 1
                 if call_count["n"] == 2:
-                    return _FakeFuture(exc=RuntimeError("transient"))
+                    raise RuntimeError("transient")
                 return super().send(topic, value=value, key=key)
 
         flaky = _FlakyProducer()
         with patch("src.messaging.kafka_producer._build_producer", return_value=flaky):
             n = emit_raw_new_for_manifest(source="open_hadith", local_dir=tmp_path, files=files)
         assert n == 2  # a and c succeeded, b failed
+
+    def test_flush_happens_once_at_manifest_end_not_per_emit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The producer is flushed by the manifest helper on its way out —
+        not by each per-file emit — so ``linger_ms`` batching is preserved."""
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        files = self._make_files(tmp_path, ["a.json", "b.json", "c.json"])
+
+        flush_count = {"n": 0}
+
+        class _CountingProducer(_FakeProducer):
+            def flush(self, timeout: int) -> None:
+                flush_count["n"] += 1
+                super().flush(timeout)
+
+        counting = _CountingProducer()
+        with patch("src.messaging.kafka_producer._build_producer", return_value=counting):
+            n = emit_raw_new_for_manifest(source="sunnah_api", local_dir=tmp_path, files=files)
+        assert n == 3
+        # Exactly one flush at manifest end, NOT one per emit.
+        assert flush_count["n"] == 1
+        assert counting.closed is True
+
+    @pytest.mark.parametrize(
+        "iso_input",
+        [
+            "2026-04-22T03:27:33+00:00",
+            "2026-04-22T03:27:33Z",
+            "2026-04-22T03:27:33.123456+00:00",
+            "2026-04-22T03:27:33-05:00",  # non-UTC offset, date in UTC-neutral local form
+        ],
+    )
+    def test_b2_key_date_extracted_from_iso(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, iso_input: str
+    ) -> None:
+        """acquired_at parsing must yield YYYY-MM-DD via fromisoformat, not slicing."""
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        files = self._make_files(tmp_path, ["a.json"])
+        fake = _FakeProducer()
+        with patch("src.messaging.kafka_producer._build_producer", return_value=fake):
+            n = emit_raw_new_for_manifest(
+                source="sunnah_api",
+                local_dir=tmp_path,
+                files=files,
+                acquired_at=iso_input,
+            )
+        assert n == 1
+        key = fake.sent[0][2].decode()
+        assert key.startswith("raw/sunnah_api/2026-04-22/")
 
 
 class TestSha256AndContentType:

--- a/tests/test_messaging/test_kafka_producer.py
+++ b/tests/test_messaging/test_kafka_producer.py
@@ -1,0 +1,272 @@
+"""Tests for the ``pipeline.raw.new`` Kafka producer wrapper."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.messaging.kafka_producer import (
+    DEFAULT_TOPIC,
+    RawNewMessage,
+    _guess_content_type,
+    emit_raw_new,
+    emit_raw_new_for_manifest,
+    sha256_of_file,
+)
+
+
+class _FakeFuture:
+    def __init__(self, exc: Exception | None = None) -> None:
+        self._exc = exc
+
+    def get(self, timeout: int) -> None:
+        if self._exc is not None:
+            raise self._exc
+
+
+class _FakeProducer:
+    """Mimics the kafka.KafkaProducer API the wrapper uses."""
+
+    def __init__(self, *, fail_on_send: bool = False) -> None:
+        self.sent: list[tuple[str, bytes, bytes]] = []
+        self.fail_on_send = fail_on_send
+        self.flushed = False
+        self.closed = False
+
+    def send(self, topic: str, *, value: bytes, key: bytes) -> _FakeFuture:
+        if self.fail_on_send:
+            return _FakeFuture(exc=RuntimeError("simulated kafka failure"))
+        self.sent.append((topic, value, key))
+        return _FakeFuture()
+
+    def flush(self, timeout: int) -> None:
+        self.flushed = True
+
+    def close(self, timeout: int) -> None:
+        self.closed = True
+
+
+class TestRawNewMessage:
+    def test_to_json_is_sorted_utf8(self) -> None:
+        msg = RawNewMessage(
+            source="sunnah_api",
+            b2_key="raw/sunnah_api/2026-04-21/c.json",
+            content_type="application/json",
+            size_bytes=42,
+            acquired_at="2026-04-21T00:00:00+00:00",
+            checksum_sha256="deadbeef",
+        )
+        raw = msg.to_json()
+        assert isinstance(raw, bytes)
+        decoded = json.loads(raw)
+        assert decoded == {
+            "source": "sunnah_api",
+            "b2_key": "raw/sunnah_api/2026-04-21/c.json",
+            "content_type": "application/json",
+            "size_bytes": 42,
+            "acquired_at": "2026-04-21T00:00:00+00:00",
+            "checksum_sha256": "deadbeef",
+        }
+        # keys sorted
+        assert list(decoded.keys()) == sorted(decoded.keys())
+
+
+class TestEmitRawNew:
+    def test_noop_when_bootstrap_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        ok = emit_raw_new(
+            source="sunnah_api",
+            b2_key="raw/sunnah_api/2026-04-21/c.json",
+            content_type="application/json",
+            size_bytes=1,
+            checksum_sha256="abc",
+        )
+        assert ok is True
+
+    def test_sends_to_configured_topic_with_injected_producer(self) -> None:
+        fake = _FakeProducer()
+        ok = emit_raw_new(
+            source="sunnah_api",
+            b2_key="raw/sunnah_api/2026-04-21/c.json",
+            content_type="application/json",
+            size_bytes=10,
+            checksum_sha256="cafe",
+            acquired_at="2026-04-21T12:00:00+00:00",
+            producer=fake,
+        )
+        assert ok is True
+        assert len(fake.sent) == 1
+        topic, value, key = fake.sent[0]
+        assert topic == DEFAULT_TOPIC
+        assert key == b"raw/sunnah_api/2026-04-21/c.json"
+        payload = json.loads(value)
+        assert payload["source"] == "sunnah_api"
+        assert payload["size_bytes"] == 10
+        assert payload["checksum_sha256"] == "cafe"
+        assert payload["acquired_at"] == "2026-04-21T12:00:00+00:00"
+
+    def test_custom_topic_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KAFKA_RAW_NEW_TOPIC", "alt.raw.new")
+        fake = _FakeProducer()
+        emit_raw_new(
+            source="lk_corpus",
+            b2_key="raw/lk_corpus/2026-04-21/x.csv",
+            content_type="text/csv",
+            size_bytes=1,
+            checksum_sha256="f",
+            producer=fake,
+        )
+        assert fake.sent[0][0] == "alt.raw.new"
+
+    def test_returns_false_and_swallows_send_failure(self) -> None:
+        fake = _FakeProducer(fail_on_send=True)
+        ok = emit_raw_new(
+            source="sunnah_api",
+            b2_key="raw/sunnah_api/2026-04-21/c.json",
+            content_type="application/json",
+            size_bytes=1,
+            checksum_sha256="abc",
+            producer=fake,
+        )
+        assert ok is False  # failure is surfaced, not raised
+
+    def test_builds_own_producer_and_closes_it(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        fake = _FakeProducer()
+        with patch("src.messaging.kafka_producer._build_producer", return_value=fake) as build:
+            ok = emit_raw_new(
+                source="sunnah_api",
+                b2_key="raw/sunnah_api/2026-04-21/c.json",
+                content_type="application/json",
+                size_bytes=1,
+                checksum_sha256="abc",
+            )
+        assert ok is True
+        assert build.call_count == 1
+        assert fake.flushed is True
+        assert fake.closed is True
+
+
+class TestEmitRawNewForManifest:
+    def _make_files(self, tmp_path: Path, names: list[str]) -> list[Path]:
+        out = []
+        for n in names:
+            p = tmp_path / n
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"content-" + n.encode())
+            out.append(p)
+        return out
+
+    def test_emits_one_per_file_with_expected_b2_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        files = self._make_files(tmp_path, ["a.json", "sub/b.csv"])
+
+        fake = _FakeProducer()
+        with patch("src.messaging.kafka_producer._build_producer", return_value=fake):
+            n = emit_raw_new_for_manifest(
+                source="sunnah_api",
+                local_dir=tmp_path,
+                files=files,
+                acquired_at="2026-04-21T00:00:00+00:00",
+            )
+        assert n == 2
+        keys = [k.decode() for _, _, k in fake.sent]
+        assert keys == [
+            "raw/sunnah_api/2026-04-21/a.json",
+            "raw/sunnah_api/2026-04-21/sub/b.csv",
+        ]
+        payload_a = json.loads(fake.sent[0][1])
+        assert payload_a["content_type"] == "application/json"
+        assert payload_a["size_bytes"] == len(b"content-a.json")
+
+    def test_missing_file_is_skipped_not_fatal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        real = self._make_files(tmp_path, ["real.json"])
+        phantom = tmp_path / "phantom.json"
+        fake = _FakeProducer()
+        with patch("src.messaging.kafka_producer._build_producer", return_value=fake):
+            n = emit_raw_new_for_manifest(
+                source="fawaz",
+                local_dir=tmp_path,
+                files=[*real, phantom],
+            )
+        assert n == 1
+
+    def test_empty_file_list_is_noop(self, tmp_path: Path) -> None:
+        assert emit_raw_new_for_manifest(source="muhaddithat", local_dir=tmp_path, files=[]) == 0
+
+    def test_per_file_failure_does_not_abort_batch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        files = self._make_files(tmp_path, ["a.json", "b.json", "c.json"])
+
+        call_count = {"n": 0}
+
+        class _FlakyProducer(_FakeProducer):
+            def send(self, topic: str, *, value: bytes, key: bytes) -> _FakeFuture:
+                call_count["n"] += 1
+                if call_count["n"] == 2:
+                    return _FakeFuture(exc=RuntimeError("transient"))
+                return super().send(topic, value=value, key=key)
+
+        flaky = _FlakyProducer()
+        with patch("src.messaging.kafka_producer._build_producer", return_value=flaky):
+            n = emit_raw_new_for_manifest(source="open_hadith", local_dir=tmp_path, files=files)
+        assert n == 2  # a and c succeeded, b failed
+
+
+class TestSha256AndContentType:
+    def test_sha256_of_file_matches_hashlib(self, tmp_path: Path) -> None:
+        import hashlib
+
+        p = tmp_path / "x.bin"
+        p.write_bytes(b"\x00\x01\x02")
+        assert sha256_of_file(p) == hashlib.sha256(b"\x00\x01\x02").hexdigest()
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("a.json", "application/json"),
+            ("a.csv", "text/csv"),
+            ("a.PARQUET", "application/x-parquet"),
+            ("a.unknown", "application/octet-stream"),
+        ],
+    )
+    def test_guess_content_type(self, tmp_path: Path, name: str, expected: str) -> None:
+        p = tmp_path / name
+        p.touch()
+        assert _guess_content_type(p) == expected
+
+
+class TestBuildProducer:
+    def test_returns_none_when_bootstrap_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        from src.messaging.kafka_producer import _build_producer
+
+        assert _build_producer() is None
+
+    def test_builds_kafka_producer_with_bootstrap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "broker-a:9092, broker-b:9092")
+        fake_kp_cls = MagicMock(return_value="producer-sentinel")
+        fake_kafka_mod = MagicMock(KafkaProducer=fake_kp_cls)
+        with patch.dict("sys.modules", {"kafka": fake_kafka_mod}):
+            from src.messaging.kafka_producer import _build_producer
+
+            result = _build_producer()
+        assert result == "producer-sentinel"
+        call_kwargs: dict[str, Any] = fake_kp_cls.call_args.kwargs
+        assert call_kwargs["bootstrap_servers"] == ["broker-a:9092", "broker-b:9092"]
+        assert call_kwargs["acks"] == "all"
+        assert call_kwargs["retries"] == 3

--- a/uv.lock
+++ b/uv.lock
@@ -586,6 +586,7 @@ source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "httpx" },
+    { name = "kafka-python" },
     { name = "kaggle" },
     { name = "lxml" },
     { name = "neo4j" },
@@ -628,6 +629,7 @@ ml = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "kafka-python", specifier = ">=2.3.1" },
     { name = "kaggle", specifier = ">=1.6" },
     { name = "lxml", specifier = ">=5.1" },
     { name = "neo4j", specifier = ">=5.15" },
@@ -685,6 +687,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "kafka-python"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/98/cbecbe20ec9e4e6f978c42229e7c777f498eec5061f986b4acfa34a7ec46/kafka_python-2.3.1.tar.gz", hash = "sha256:90f1caa12d8faa9fd059852b0c73adf169b979279aa2e3ff370f9fe615d654b6", size = 357302, upload-time = "2026-04-09T21:10:22.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/83/6f79b5e03f7d259cba60d3e48c97f7b76a86d20486a515e8ffadea97434e/kafka_python-2.3.1-py2.py3-none-any.whl", hash = "sha256:4908865da9e57f0f966a83788c71cb0ae91c33451a26ab6e6984a00b15c6ed71", size = 326065, upload-time = "2026-04-09T21:10:24.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #28. After each of the 8 acquire connectors lands its raw
artifacts, emit one `pipeline.raw.new` Kafka message per file so
downstream pipeline workers (dedup, enrich, normalize, graph-load) can
consume. Unblocks noorinalabs-main#139.

## Design

- **Shared helper** — new `src/messaging/kafka_producer.py`:
  - `emit_raw_new(**payload, producer=None)` — pure library function,
    never raises (returns `False` on emit failure, `True` on success or
    config-driven no-op).
  - `emit_raw_new_for_manifest(source, local_dir, files)` — iterates a
    connector's manifest and emits per-file.
  - `RawNewMessage` frozen dataclass enforces the schema; canonical
    JSON is sorted-key UTF-8.

- **Message schema** (pinned in module docstring + constant):

  ```json
  {
    "source":          "<connector_name>",
    "b2_key":          "raw/<source>/<YYYY-MM-DD>/<filename>",
    "content_type":    "application/json | text/csv | ...",
    "size_bytes":      12345,
    "acquired_at":     "2026-04-21T12:34:56.789012+00:00",
    "checksum_sha256": "<hex>"
  }
  ```

- **Config (env)**:
  - `KAFKA_BOOTSTRAP_SERVERS` — comma-separated host:port list.
    Unset or empty ⇒ emit is a silent no-op (dev/test safe, no broker
    required).
  - `KAFKA_RAW_NEW_TOPIC` — default `pipeline.raw.new`.

- **Retry semantics**: `kafka-python` producer with `acks=all`,
  `retries=3`, `linger_ms=100`. On retry exhaustion we log at `error`
  level and return — the acquire is never aborted. B2 is the source of
  truth; a missed Kafka emit is reconcilable by replaying keys from B2.

- **Idempotency**: per AC, duplicates on re-acquisition are **allowed**
  — downstream dedup worker handles. No key dedup here.

## Per-connector wire-in

Emit is called at the `write_manifest(...)` site in each connector. All
8 affected:

| Connector | source= | Wired at |
|---|---|---|
| `sunnah_api` | `sunnah_api` | `run()` end |
| `sunnah_scraper` | `sunnah_scraper` | `run()` end |
| `open_hadith` | `open_hadith` | `run()` end |
| `sanadset` | `sanadset` | `download_sanadset()` end |
| `lk_corpus` | `lk_corpus` | `run()` end |
| `muhaddithat` | `muhaddithat` | `run()` end |
| `fawaz` | `fawaz` | both skip + fresh-download paths |
| `thaqalayn` | `thaqalayn` | both skip + fresh-clone paths |

## Dependency

Added `kafka-python>=2.3.1` (pure-Python, no C-extension —
confluent-kafka had no 3.14 wheel). mypy override added for `kafka.*`.

## Test coverage (28 new, all passing)

- `tests/test_messaging/test_kafka_producer.py` (17 tests):
  - Message schema / JSON canonicalisation
  - Topic routing via env, custom topic override
  - No-op behaviour when `KAFKA_BOOTSTRAP_SERVERS` unset
  - Send-failure path returns `False`, never raises
  - Owned-producer lifecycle (flush + close)
  - Per-file failure does not abort batch
  - `sha256_of_file`, `_guess_content_type` helpers
  - `_build_producer` resolves env / passes kwargs correctly
- `tests/test_messaging/test_acquire_wireins.py` (11 tests):
  - One happy-path test per connector stubbing network/git, asserts
    `emit_raw_new_for_manifest` is called once with the correct
    `source=` kwarg.
  - Failure-injection test: emit returning 0 still lets `run()` succeed.
  - Direct contract test: producer `.send()` raising ⇒ `emit_raw_new`
    returns `False` without raising.

Full suite: **508 passed, 3 skipped (ml), 13 deselected (integration)**.
`ruff check` / `ruff format --check` / `mypy --strict` all clean.

## Note on B2 upload

This repo currently writes acquire artifacts to local `data/raw/` —
there is no B2 upload path yet in-tree. The emit helper computes
`b2_key` in the forward-compatible format `raw/<source>/<YYYY-MM-DD>/<relpath>`
so that when the B2 upload shim lands (separate PR), the key scheme is
already correct. Size/checksum are computed from the local file, which
is the pre-upload authoritative artifact.

## TechDebt

TechDebt: none

## Requestor / Requestee / RequestOrReplied

(Reviewer comments posted separately per charter format.)