### PR TITLE
feat(messaging): rename pipeline.raw topic to .landed + add topics module

### DIFF
--- a/src/messaging/kafka_producer.py
+++ b/src/messaging/kafka_producer.py
@@ -1,8 +1,9 @@
-"""Kafka producer for the ``pipeline.raw.new`` signal topic.
+"""Kafka producer for the ``pipeline.raw.landed`` signal topic.
 
 After an acquire connector lands a raw artifact in B2, emit one
-``pipeline.raw.new`` message per file so downstream pipeline workers
-(dedup, enrich, normalize, graph-load) can consume.
+``pipeline.raw.landed`` message per file so downstream pipeline workers
+(dedup, enrich, normalize, graph-load) can consume. The topic string
+is defined in :mod:`src.messaging.topics` as ``PIPELINE_RAW_LANDED``.
 
 Message schema (JSON, UTF-8, one message per file)
 ---------------------------------------------------
@@ -26,10 +27,10 @@ allowed to re-emit and is intentionally not deduplicated here
 
 Configuration (env)
 -------------------
-``KAFKA_BOOTSTRAP_SERVERS``   — comma-separated host:port list
-                                (e.g. ``kafka:9092`` locally,
-                                 ``broker-1:9092,broker-2:9092`` in prod)
-``KAFKA_RAW_NEW_TOPIC``       — topic name (default ``pipeline.raw.new``)
+``KAFKA_BOOTSTRAP_SERVERS``    — comma-separated host:port list
+                                 (e.g. ``kafka:9092`` locally,
+                                  ``broker-1:9092,broker-2:9092`` in prod)
+``KAFKA_RAW_LANDED_TOPIC``     — topic name (default ``pipeline.raw.landed``)
 
 If ``KAFKA_BOOTSTRAP_SERVERS`` is unset/empty the producer is a no-op —
 messages are logged at debug level and dropped. This keeps the acquire
@@ -69,6 +70,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from src.messaging.topics import PIPELINE_RAW_LANDED
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -82,7 +84,7 @@ __all__ = [
     "sha256_of_file",
 ]
 
-DEFAULT_TOPIC = "pipeline.raw.new"
+DEFAULT_TOPIC = PIPELINE_RAW_LANDED
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
@@ -98,7 +100,7 @@ RAW_NEW_MESSAGE_SCHEMA: dict[str, str] = {
 
 @dataclass(frozen=True, slots=True)
 class RawNewMessage:
-    """Typed payload for the ``pipeline.raw.new`` topic."""
+    """Typed payload for the ``pipeline.raw.landed`` topic."""
 
     source: str
     b2_key: str
@@ -136,7 +138,7 @@ def _bootstrap_servers() -> str:
 
 
 def _topic() -> str:
-    return os.environ.get("KAFKA_RAW_NEW_TOPIC", DEFAULT_TOPIC).strip() or DEFAULT_TOPIC
+    return os.environ.get("KAFKA_RAW_LANDED_TOPIC", DEFAULT_TOPIC).strip() or DEFAULT_TOPIC
 
 
 def _build_producer() -> Any:  # noqa: ANN401 — KafkaProducer has no public stub
@@ -172,7 +174,7 @@ def emit_raw_new(
     acquired_at: str | None = None,
     producer: Any | None = None,  # noqa: ANN401
 ) -> bool:
-    """Emit a single ``pipeline.raw.new`` message.
+    """Emit a single ``pipeline.raw.landed`` message.
 
     Emit is fire-and-forget — ``send()`` returns without blocking on the
     broker ACK. Callers that inject their own ``producer`` are responsible
@@ -256,7 +258,7 @@ def emit_raw_new_for_manifest(
     b2_prefix: str | None = None,
     acquired_at: str | None = None,
 ) -> int:
-    """Emit one ``pipeline.raw.new`` message per file.
+    """Emit one ``pipeline.raw.landed`` message per file.
 
     Computes the ``b2_key`` as ``<b2_prefix>/<relative-path>`` where
     ``b2_prefix`` defaults to ``raw/<source>/<YYYY-MM-DD>/``. ``size_bytes``

--- a/src/messaging/topics.py
+++ b/src/messaging/topics.py
@@ -1,0 +1,22 @@
+"""Pipeline topic constants — mirror of noorinalabs-isnad-ingest-platform/workers/lib/topics.py.
+
+Must stay in sync with ``noorinalabs-isnad-ingest-platform/workers/lib/topics.py``
+until a shared contracts package is extracted. Producers here and consumers
+in the ingest-platform read from these literals; drift means dropped messages.
+"""
+
+from __future__ import annotations
+
+PIPELINE_RAW_LANDED = "pipeline.raw.landed"
+PIPELINE_DEDUP_DONE = "pipeline.dedup.done"
+PIPELINE_ENRICH_DONE = "pipeline.enrich.done"
+PIPELINE_NORMALIZE_DONE = "pipeline.normalize.done"
+PIPELINE_DLQ = "pipeline.dlq"
+
+__all__ = [
+    "PIPELINE_DEDUP_DONE",
+    "PIPELINE_DLQ",
+    "PIPELINE_ENRICH_DONE",
+    "PIPELINE_NORMALIZE_DONE",
+    "PIPELINE_RAW_LANDED",
+]

--- a/tests/test_messaging/test_kafka_producer.py
+++ b/tests/test_messaging/test_kafka_producer.py
@@ -1,4 +1,4 @@
-"""Tests for the ``pipeline.raw.new`` Kafka producer wrapper."""
+"""Tests for the ``pipeline.raw.landed`` Kafka producer wrapper."""
 
 from __future__ import annotations
 
@@ -151,6 +151,7 @@ class TestEmitRawNew:
         assert len(fake.sent) == 1
         topic, value, key = fake.sent[0]
         assert topic == DEFAULT_TOPIC
+        assert topic == "pipeline.raw.landed"
         assert key == b"raw/sunnah_api/2026-04-21/c.json"
         payload = json.loads(value)
         assert payload["source"] == "sunnah_api"
@@ -158,8 +159,13 @@ class TestEmitRawNew:
         assert payload["checksum_sha256"] == _VALID_SHA
         assert payload["acquired_at"] == "2026-04-21T12:00:00+00:00"
 
+    def test_default_topic_matches_canonical_constant(self) -> None:
+        from src.messaging.topics import PIPELINE_RAW_LANDED
+
+        assert DEFAULT_TOPIC == PIPELINE_RAW_LANDED == "pipeline.raw.landed"
+
     def test_custom_topic_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("KAFKA_RAW_NEW_TOPIC", "alt.raw.new")
+        monkeypatch.setenv("KAFKA_RAW_LANDED_TOPIC", "alt.raw.landed")
         fake = _FakeProducer()
         emit_raw_new(
             source="lk_corpus",
@@ -169,7 +175,7 @@ class TestEmitRawNew:
             checksum_sha256=_VALID_SHA,
             producer=fake,
         )
-        assert fake.sent[0][0] == "alt.raw.new"
+        assert fake.sent[0][0] == "alt.raw.landed"
 
     def test_returns_false_and_swallows_send_failure(self) -> None:
         fake = _FakeProducer(fail_on_send=True)


### PR DESCRIPTION
## Summary

Rename the acquire-side Kafka signal topic from `pipeline.raw.new` -> `pipeline.raw.landed` to align with the canonical topic vocabulary established downstream in `noorinalabs-isnad-ingest-platform#21` (`workers/lib/topics.py`), merged 2026-04-22. Our prior #30 emitted on `pipeline.raw.new`, which was misaligned with the ingest-platform consumer -- messages would drop on the floor.

Reconciles inline per `noorinalabs-main#190`. No behavioural change beyond the string.

## Scope

- **New file:** `src/messaging/topics.py` -- mirrors the ingest-platform constants (`PIPELINE_RAW_LANDED`, `_DEDUP_DONE`, `_ENRICH_DONE`, `_NORMALIZE_DONE`, `_DLQ`). Docstring explicitly flags the sync requirement with `noorinalabs-isnad-ingest-platform/workers/lib/topics.py` until a shared contracts package is extracted. Ugly-but-pragmatic; cross-repo constant duplication is tracked as a separate concern.
- **`src/messaging/kafka_producer.py`:**
  - `DEFAULT_TOPIC` now resolves from `PIPELINE_RAW_LANDED` instead of the literal `"pipeline.raw.new"`.
  - Env override renamed `KAFKA_RAW_NEW_TOPIC` -> `KAFKA_RAW_LANDED_TOPIC`.
  - Module/class/function docstrings updated to reference the `.landed` topic.
- **`tests/test_messaging/test_kafka_producer.py`:**
  - Existing env-override test updated to the new env var name / value.
  - Added `test_default_topic_matches_canonical_constant` asserting `DEFAULT_TOPIC == PIPELINE_RAW_LANDED == "pipeline.raw.landed"` (belt-and-suspenders against silent drift from the mirrored constant).

## Non-goals (explicitly out of scope)

- Producer semantics -- batching, retry, validator, fire-and-forget, injected-producer flush contract -- all unchanged from #30.
- No client-side dedup.
- No new dependencies.
- Caller-facing symbol names (`emit_raw_new`, `emit_raw_new_for_manifest`, `RawNewMessage`, `RAW_NEW_MESSAGE_SCHEMA`) retained to avoid touching the 8 connector call sites and their wire-in tests -- this PR is strictly about the topic string.

## Test plan

- [x] `uv run pytest tests/ -v -k kafka` -- 32/32 pass
- [x] `uv run ruff check src/ tests/` -- clean
- [x] `uv run ruff format --check src/ tests/` -- 116 files already formatted
- [x] `uv run mypy src/` -- no issues in 62 source files
- [ ] Reviewer sanity-check: `src.messaging.topics.PIPELINE_RAW_LANDED` string matches `noorinalabs-isnad-ingest-platform/workers/lib/topics.py`

Closes `noorinalabs-main#190`.

Refs: `noorinalabs-main#191` (ontology rebuild follow-up, non-blocking), `noorinalabs-main#192` (design call), `noorinalabs-isnad-ingest-platform#21`, `#18`.

TechDebt: cross-repo topic-constant duplication between `noorinalabs-data-acquisition/src/messaging/topics.py` and `noorinalabs-isnad-ingest-platform/workers/lib/topics.py`. Resolution path is a shared contracts package, tracked separately (out of scope for this PR).
