### PR TITLE
tech-debt(docs): CLAUDE.md branching-strategy backslash → slash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Copy `.env.example` to `.env`. Key variables:
 - **GitHub Issues** — story/task/bug tracking (created by Manager, assigned to team members)
 - **GitHub Actions** — CI/CD pipelines, automated tests, linting, deployment
 - These three (Projects, Issues, Actions) are the **core orchestration layer** — do not introduce alternative tools for these concerns
-- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}\{IIII}-{issue-name}` (e.g., `D.Erdogan\0001-extract-acquire-module`) merged to `main` via PR
+- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}/{IIII}-{issue-name}` (e.g., `D.Erdogan/0001-extract-acquire-module`) merged to `main` via PR
 
 ## Phase 1: Extraction from noorinalabs-isnad-graph
 


### PR DESCRIPTION
## Summary

Single-line documentation fix in `CLAUDE.md`: the branching-strategy line uses a literal backslash that git rejects in refnames. Replace `\` with `/` in both the template and the example.

```diff
-- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}\{IIII}-{issue-name}` (e.g., `D.Erdogan\0001-extract-acquire-module`) merged to `main` via PR
+- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}/{IIII}-{issue-name}` (e.g., `D.Erdogan/0001-extract-acquire-module`) merged to `main` via PR
```

## Why

Spawned implementers reading CLAUDE.md verbatim hit `git: 'X.Y\NNNN-...' is not a valid branch name` and have to fall back to repo convention. Two independent confirmations in P3W1 Round 1 (deploy aisha #179, deploy lucas #67). Repo convention is `/` everywhere in `git branch -a`.

## Sync source

- Parent meta-issue: noorinalabs/noorinalabs-main#232 (parent CLAUDE.md fix already landed on `deployments/phase-3/wave-1`).
- Pattern parallel to W10 Hook 14 fan-out (`noorinalabs-main#194`).

## Acceptance

- [x] The single affected line in `CLAUDE.md` uses `/` and a `/`-using example.
- [x] One PR per repo, matched to that repo's review/charter conventions.

## Wave / class

- Wave: P3W4 — base branch `deployments/phase-3/wave-4`.
- Class: `wave-bootstrap` — single-reviewer exception (Dilara Erdogan), per parent charter § Single-Reviewer Exception and W4 kickoff decision logged in `cross-repo-status.json` `wave_4_decisions.single_reviewer_exception`.

## Test plan

- [x] `grep -n 'Branching strategy' CLAUDE.md` shows the line uses `/` only.
- [x] No backslash residue on the affected line.
- [x] Single-file diff (no collateral changes).

Closes #33
