### PR TITLE
fix(data-acquisition #38): settings.json matcher parity with noorinalabs-main

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,58 +6,199 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_commit_identity.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_no_verify.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_git_config.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/auto_set_env_test.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_labels.py",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/dispatcher.py",
             "timeout": 30
           }
         ]
       },
       {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_wave_context.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_ontology_context.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "SendMessage",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_shutdown_without_retro.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_wave_audit.py",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_pr_ci_status.py",
-            "timeout": 15
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/auto_add_issue_to_board.py",
+            "timeout": 20
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/annunaki_monitor.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/ontology_tracker.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/suggest_generic_prompt.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/ontology_tracker.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/suggest_generic_prompt.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_start.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_start.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_handoff.py",
+            "timeout": 30
           }
         ]
       }


### PR DESCRIPTION
Closes #38.

## Summary

Phase-2 followup to noorinalabs/noorinalabs-main#263 (matcher-coverage dimension). PR #37 closed the copy-resident dimension; this PR closes the matcher-coverage gap by mirroring noorinalabs-main `.claude/settings.json` exactly. Both security-tier (Hook 15: `enforce_librarian_consulted` on Edit/Write/NotebookEdit + `validate_edit_completion`) and policy-tier (Agent context, SendMessage, Skill, PostToolUse Bash/Edit/Write/NotebookEdit, SessionStart, Stop) matchers are added in a single PR per the issue's tier-framing guidance.

## Side-by-side diff (parent → child)

| Hook event | Matcher | Parent (noorinalabs-main) | Child before | Child after |
|---|---|---|---|---|
| PreToolUse | `Bash` | `dispatcher.py` (consolidated) | 6 individual matchers (validate_commit_identity, block_no_verify, block_git_config, auto_set_env_test, validate_labels, validate_pr_ci_status) | `dispatcher.py` (consolidated) |
| PreToolUse | `Agent` | validate_wave_context, enforce_ontology_context | (none) | validate_wave_context, enforce_ontology_context |
| PreToolUse | `SendMessage` | block_shutdown_without_retro, validate_edit_completion | (none) | block_shutdown_without_retro, validate_edit_completion |
| PreToolUse | `Skill` | validate_wave_audit | (none) | validate_wave_audit |
| PreToolUse | `Edit` | enforce_librarian_consulted, validate_edit_completion | (none) | enforce_librarian_consulted, validate_edit_completion |
| PreToolUse | `Write` | enforce_librarian_consulted, validate_edit_completion | (none) | enforce_librarian_consulted, validate_edit_completion |
| PreToolUse | `NotebookEdit` | enforce_librarian_consulted, validate_edit_completion | (none) | enforce_librarian_consulted, validate_edit_completion |
| PostToolUse | `Bash` | auto_add_issue_to_board, annunaki_monitor | (none) | auto_add_issue_to_board, annunaki_monitor |
| PostToolUse | `Edit` | ontology_tracker, suggest_generic_prompt, validate_edit_completion | (none) | ontology_tracker, suggest_generic_prompt, validate_edit_completion |
| PostToolUse | `Write` | ontology_tracker, suggest_generic_prompt, validate_edit_completion | (none) | ontology_tracker, suggest_generic_prompt, validate_edit_completion |
| PostToolUse | `NotebookEdit` | validate_edit_completion | (none) | validate_edit_completion |
| SessionStart | `startup` | session_start | (none) | session_start |
| SessionStart | `resume` | session_start | (none) | session_start |
| Stop | `""` | session_handoff | (none) | session_handoff |

All commands resolve to `python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/<name>.py` (canonical absolute paths — no copy-resident).

## Bit-exact parity

```
$ diff /home/parameterization/code/noorinalabs-main/.claude/settings.json /tmp/wave6-alejandra-da-38/.claude/settings.json && echo "PARITY: BIT-EXACT MATCH"
PARITY: BIT-EXACT MATCH
```

Both files now ship the same 7 PreToolUse matchers, 5 PostToolUse matchers, 2 SessionStart matchers, and 1 Stop matcher — identical hook commands, timeouts, and ordering.

## Smoke tests

**Hook 15 (`enforce_librarian_consulted`) — actively blocks edits to non-allow-listed source paths in this repo's cwd:**

```
$ echo '{"tool_name":"Edit","tool_input":{"file_path":".../noorinalabs-data-acquisition/src/acquire/foo.py"},"cwd":".../noorinalabs-data-acquisition","transcript_path":"/tmp/nonexistent-transcript.jsonl","session_id":"smoke"}' \
    | python3 .../enforce_librarian_consulted.py ; echo "exit=$?"
{"decision": "block", "reason": "BLOCKED: /ontology-librarian must be consulted before code edits in this session..."}
exit=2
```

That confirms the gap called out in #38's "smoke test" acceptance criterion (`Edit without first running /ontology-librarian → Hook 15 blocks (currently does NOT block — that's the gap)`) is now closed.

**Stop event (`session_handoff`):**

```
$ echo '{"hook_event_name":"Stop","cwd":"/tmp/wave6-alejandra-da-38","transcript_path":"/dev/null","session_id":"smoke-stop-1"}' \
    | python3 .../session_handoff.py ; echo "exit=$?"
exit=0
```

Hook fires from this repo's cwd. (No-op when transcript=/dev/null is expected.)

**Agent spawn (`validate_wave_context`):**

```
$ echo '{"tool_name":"Agent","tool_input":{"description":"foo","prompt":"do thing"},"cwd":"/tmp/wave6-alejandra-da-38","transcript_path":"/dev/null","session_id":"smoke-agent-1"}' \
    | python3 .../validate_wave_context.py ; echo "exit=$?"
exit=0
```

Hook fires when Agent is spawned from this repo cwd.

**Dispatcher consolidation (still blocks `git config`):**

```
$ echo '{"tool_name":"Bash","tool_input":{"command":"git config user.name foo"},...}' \
    | python3 .../dispatcher.py ; echo "exit=$?"
{"decision": "block", "reason": "BLOCKED: `git config` writes are prohibited..."}
exit=2
```

Confirms migration from 6-individual-matcher form to consolidated dispatcher preserves the prior charter-enforcement behavior.

## Acceptance checklist

- [x] PreToolUse matchers: Bash (migrated to `dispatcher.py`), Agent, SendMessage, Skill, Edit, Write, NotebookEdit
- [x] PostToolUse matchers: Bash (`auto_add_issue_to_board`, `annunaki_monitor`), Edit, Write, NotebookEdit
- [x] SessionStart (startup + resume) registered with `session_start.py`
- [x] Stop registered with `session_handoff.py`
- [x] All commands use parent-canonical paths (`/home/parameterization/code/noorinalabs-main/.claude/hooks/<name>.py`) — no copy-resident
- [x] Smoke test: Hook 15 blocks Edit on non-allow-listed src path with no librarian signal — verified above
- [x] Smoke test: Stop hook fires — verified above
- [x] Smoke test: Agent spawn validation fires — verified above

## Out of scope

No data-acquisition-specific hooks added (none currently exist; same as the issue's "Out of scope" note).

## Test Plan

- [ ] R1 (Kavitha) — verify diff against noorinalabs-main is bit-exact via `diff` command
- [ ] R1 — sanity-check that all 13 referenced hook scripts exist at canonical paths
- [ ] R2 (Nikolaos) — verify the migration from 6-individual-Bash-matchers to `dispatcher.py` does not silently drop any of the 6 prior validations (validate_commit_identity, block_no_verify, block_git_config, auto_set_env_test, validate_labels, validate_pr_ci_status)
- [ ] R2 — confirm pre-commit + CI gates pass on this branch

## Refs

- Issue: #38
- Phase 1 spec: noorinalabs/noorinalabs-main#214
- Phase 2 umbrella: noorinalabs/noorinalabs-main#263
- Phase 2 child PR (orphan-deletion only): #37
- Sibling drift-only: noorinalabs/noorinalabs-design-system#67
- Sibling full-migration template: noorinalabs/noorinalabs-isnad-graph#861 (security-tier only — this PR also covers policy-tier)
- Charter: parent `.claude/team/charter/hooks.md § Hook Sync Across Child Repos`
