### PR TITLE
ci: upgrade actions/checkout@v4 to @v6 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -48,7 +48,7 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -70,7 +70,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v5
         with:


### PR DESCRIPTION
## Summary

Upgrades all 4 `actions/checkout@v4` occurrences in `.github/workflows/ci.yml` to `@v6` to clear GitHub's Node 20 deprecation warning and align with the canonical reference state in `noorinalabs-isnad-graph` (already on `@v6` per the parent #309 audit table).

This is the smallest of the parallel Node 20 upgrades in P3W8 (4 sites, 1 action — only Node 20 surface in this repo). It establishes the per-action target version baseline for the design-system, deploy, and landing-page parallel upgrades.

## Reviewers

- **R1**: @Jean-Claude-Habimana (active on parent #44 ADR — Node 20 reference state)
- **R2**: @Dilara-Erdogan (manager — coordinated wave brief)

## Changes

- `.github/workflows/ci.yml` lines 26, 51, 73, 98: `actions/checkout@v4` → `actions/checkout@v6`
  - lint job (line 26)
  - typecheck job (line 51)
  - test job (line 73)
  - test-integration job (line 98)

Per-line edits (not sed) for audit clarity.

## Reference state

- `noorinalabs-isnad-graph` already runs `actions/checkout@v6` (parent #309 audit table).
- Verified at wave-8 sha `f43b84d1`, ci.yml blob `0ae59f4545a9f9e51d795ccf8802e2d3397834d4` — 4 sites confirmed via `gh api contents` before edit.
- This file is the **only Node 20 action surface** in this repo — confirmed via `grep -RnE 'checkout@v|setup-node@v|upload-artifact@v|github-script@v|cache@v'`. No other action families need upgrading.

## Validation

- `actionlint .github/workflows/ci.yml` clean (exit 0, no output) — with `shellcheck 0.10.0` on PATH per `feedback_actionlint_needs_shellcheck.md`.
- Post-edit grep confirms 4 sites at `@v6`, 0 sites at `@v4`.

## Test plan

- [ ] CI green on this PR (no Node 20 deprecation warning emitted by GitHub Actions).
- [ ] `lint`, `typecheck`, `test`, `test-integration` all pass under `actions/checkout@v6`.
- [ ] Reviewers verify diff at PR HEAD (per `feedback_origin_over_local_for_still_has_claims.md` / `feedback_review_against_artifact_not_framing.md`).

## Cross-links

- Closes noorinalabs/noorinalabs-data-acquisition#46
- Refs parent meta-issue noorinalabs/noorinalabs-main#309 (Node 20 deprecation audit)
- Sibling Node 20 upgrades in flight: design-system #74 (Astrid), deploy #280 (Aisha), landing-page #88 (Kofi)

## Charter compliance

- Branch: `T.Mansour/0046-actions-checkout-v6` (per charter naming `{FirstInitial}.{LastName}/{IIII}-{name}`)
- Base: `deployments/phase-3/wave-8`
- Commit identity verified: `Tarek Mansour <parametrization+Tarek.Mansour@gmail.com>` (per-commit `-c` flags, no global git config touched)
- Commit message via `-F` file (not inline heredoc)
- 2 reviewers tagged
