### PR TITLE
tech-debt(adr): update ADR-001 placeholder citations to merged charter (#50)

### DIFF
--- a/docs/adr/001-local-hook-policy-dispatcher-style.md
+++ b/docs/adr/001-local-hook-policy-dispatcher-style.md
@@ -11,14 +11,17 @@ Claude Code automation hooks are delegated to the parent canonical at
 
 The org-level charter recognizes a *dispatcher-style* exemption category for children in
 this topology — see `charter/hooks.md § Hook Authorship Requirements § 5 Parser-Fixture
-Coverage Requirements — dispatcher-children sub-clause` (pending
-noorinalabs/noorinalabs-main#311, charter PR #334). The classification command used in
-"Verification at HEAD" below is the one being added to `charter/hooks.md § Hook Audit
-Protocol` (pending noorinalabs/noorinalabs-main#313, also bundled in PR #334). The W7
-audit (parent#300) and Aino's W8 charter edits (parent#311 + #313) name
-data-acquisition as one of the canonical dispatcher-style exemplars. This ADR ratifies
-the local effect of those charter rules for `noorinalabs-data-acquisition`; it does not
-redefine them.
+Coverage Requirements`, dispatcher-children sub-clause: "Children that delegate all hook
+execution to the parent canonical via `settings.json` are exempt from per-child fixture
+requirements. Coverage obligations are fulfilled by the parent's test suite." The
+classification command used in "Verification at HEAD" below is codified in
+`charter/hooks.md § Hook Audit Protocol`. Both edits landed in
+noorinalabs/noorinalabs-main PR #334 (merge_sha `c7fd964c24a197317a700c90cdb5a0140a6050be`,
+2026-05-09), which bundled #311 (dispatcher-children sub-clause) and #313 (Hook Audit
+Protocol). The W7 audit (parent#300) and Aino's W8 charter edits (parent#311 + #313)
+name data-acquisition as one of the canonical dispatcher-style exemplars. This ADR
+ratifies the local effect of those charter rules for `noorinalabs-data-acquisition`; it
+does not redefine them.
 
 Issue #44 was filed in P3W7 originally framed as "remove dead-code child hook copies",
 then re-scoped during the W7 audit when committed-tree inspection confirmed there was
@@ -28,9 +31,9 @@ onboarding pattern?
 
 ### Verification at HEAD
 
-Applying the charter's dispatcher-style classification check (defined under `§ Hook Audit
-Protocol`, pending parent#313) to this repo at the wave-8 base SHA
-`f43b84d19d1e38f4b964c6ed313ce5cc58584914`:
+Applying the charter's dispatcher-style classification check (defined under
+`charter/hooks.md § Hook Audit Protocol`, merged via parent#334) to this repo at the
+wave-8 base SHA `f43b84d19d1e38f4b964c6ed313ce5cc58584914`:
 
 ```bash
 gh api repos/noorinalabs/noorinalabs-data-acquisition/git/trees/f43b84d19d1e38f4b964c6ed313ce5cc58584914?recursive=1 \
@@ -56,8 +59,7 @@ execution is delegated to the parent canonical at `noorinalabs-main/.claude/hook
 local hook files are committed to this repository. Coverage obligations under
 `charter/hooks.md § Hook Authorship Requirements § 5 Parser-Fixture Coverage
 Requirements` are fulfilled by the parent's test suite per the dispatcher-children
-sub-clause (pending parent#311 — citation will resolve to merged charter language once
-PR #334 lands).
+sub-clause (merged via parent#334 on 2026-05-09).
 
 The door is explicitly left open to revisit this decision if a concrete domain-specific
 hook need emerges that the parent does not naturally cover.


### PR DESCRIPTION
## Summary

Replaces 6 `pending` placeholder citations in `docs/adr/001-local-hook-policy-dispatcher-style.md` with direct references to merged charter language.

Parent PR [noorinalabs/noorinalabs-main#334](https://github.com/noorinalabs/noorinalabs-main/pull/334) merged at `c7fd964c24a197317a700c90cdb5a0140a6050be` on 2026-05-09T01:57:47Z, bundling:

- [#311](https://github.com/noorinalabs/noorinalabs-main/issues/311) — `charter/hooks.md § Hook Authorship Requirements § 5 Parser-Fixture Coverage Requirements`, dispatcher-children sub-clause (WHAT)
- [#313](https://github.com/noorinalabs/noorinalabs-main/issues/313) — `charter/hooks.md § Hook Audit Protocol` (HOW — classification command)

The ADR shipped on its own timeline before #334 landed (PR [#48](https://github.com/noorinalabs/noorinalabs-data-acquisition/pull/48), merge_sha `c681d0c4`), with deliberate `pending` qualifiers so it wouldn't preempt Aino's charter PR. Those qualifiers are now stale.

## Changes

Three `pending` clauses updated to merged-charter citations:

1. **Context (lines 12-24)** — replaced `(pending noorinalabs/noorinalabs-main#311, charter PR #334)` and `(pending noorinalabs/noorinalabs-main#313, also bundled in PR #334)` with a single merged-charter citation block that includes the verbatim dispatcher-children sub-clause text, the parent#334 merge_sha, and the merge date. The W7-audit framing line (parent#300 + parent#311 + #313) retained as historical pointer.
2. **Verification at HEAD (lines 34-36)** — `pending parent#313` → `merged via parent#334`.
3. **Decision (lines 57-62)** — `(pending parent#311 — citation will resolve to merged charter language once PR #334 lands)` → `(merged via parent#334 on 2026-05-09)`.

References section retained as historical-pointer list (per issue body: "reviewer's call on historical pointer vs merge_sha citation"). The merge_sha is now embedded in the Context section's prose where it's load-bearing.

**Decision / Rationale / Consequences unchanged** — prose-cleanup only as specified in the issue.

## Verification

```
$ grep -nE "pending" docs/adr/001-local-hook-policy-dispatcher-style.md
(no output — 0 hits)
```

All 6 `pending` strings from the issue's `grep -nE "pending|#311|#313|#334"` enumeration (lines 14, 15, 17, 32, 59, 60) are now removed or replaced.

## Test plan

- [ ] CI green (no functional change expected — pure prose edit, no code/test paths touched)
- [ ] Reviewers verify all 6 `pending` placeholders removed
- [ ] Reviewers verify Decision/Rationale/Consequences sections unchanged
- [ ] Reviewers verify retained `#311`/`#313`/`#334` mentions are in valid historical-pointer contexts (W7 audit history, References section), not active citations

Closes #50

Cross-links:
- Parent charter PR: [noorinalabs/noorinalabs-main#334](https://github.com/noorinalabs/noorinalabs-main/pull/334) (merged 2026-05-09, sha `c7fd964c`)
- Original ADR PR: [noorinalabs/noorinalabs-data-acquisition#48](https://github.com/noorinalabs/noorinalabs-data-acquisition/pull/48) (merged, sha `c681d0c4`)
