### PR TITLE
ci: bump Node-20 actions to Node-24 (setup-uv/setup-python) (#57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
@@ -50,12 +50,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
@@ -72,12 +72,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
@@ -97,12 +97,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true


### PR DESCRIPTION
## Summary
GitHub forces all GitHub Actions to the Node.js 24 runtime on **2026-06-02**; actions still on the Node-20 runtime are deprecated and may break. This bumps the two remaining Node-20 actions in `ci.yml` to their Node-24 majors.

## Bumps (`.github/workflows/ci.yml`, 4 jobs each)
- `astral-sh/setup-uv@v5` -> `@v7` (4 occurrences)
- `actions/setup-python@v5` -> `@v6` (4 occurrences)

`actions/checkout` was **already** on `@v6` (Node-24) from #49, so no change there. Grep confirms zero `@v4`/`@v5` pins remain for checkout/setup-uv/setup-python.

## Verification
- Both target tags confirmed to exist upstream (`setup-uv@v7`, `setup-python@v6`).
- `grep` shows exactly 4 occurrences of each new pin and zero stale pins.

TechDebt: none

Closes #57
Refs noorinalabs/noorinalabs-main#536
