### PR TITLE
tech-debt(graph-loader): legacy load_nodes.py stop writing book/chapter/hadith_number to Hadith node (#59)

### DIFF
--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -142,6 +142,12 @@ def _load_narrators(
 # Hadith loader
 # ---------------------------------------------------------------------------
 
+# NOTE (#35, ratified P3W13): book_number / chapter_number / hadith_number are
+# positional facts of a hadith's place *within a collection*, so they live on the
+# APPEARS_IN edge (see load_edges.py ``_APPEARS_IN_QUERY``), NOT on the Hadith node.
+# The Kafka ingest-platform normalize path already complies; this legacy loader is
+# reconciled here. The staging schema still carries these columns — they feed the
+# edge loader — they are simply no longer copied onto the node.
 _HADITH_MERGE = """\
 UNWIND $batch AS row
 MERGE (n:Hadith {id: row.id})
@@ -152,10 +158,7 @@ SET n.matn_ar      = row.matn_ar,
     n.grade        = row.grade,
     n.source_corpus = row.source_corpus,
     n.sect         = row.sect,
-    n.collection_name = row.collection_name,
-    n.book_number  = row.book_number,
-    n.chapter_number = row.chapter_number,
-    n.hadith_number = row.hadith_number
+    n.collection_name = row.collection_name
 """
 
 
@@ -201,9 +204,8 @@ def _load_hadiths(
                     "source_corpus": _val(row, "source_corpus", ""),
                     "sect": _val(row, "sect", ""),
                     "collection_name": _val(row, "collection_name", ""),
-                    "book_number": _val(row, "book_number"),
-                    "chapter_number": _val(row, "chapter_number"),
-                    "hadith_number": _val(row, "hadith_number"),
+                    # book/chapter/hadith_number intentionally omitted — they belong
+                    # on the APPEARS_IN edge, not the Hadith node (#35). See _HADITH_MERGE.
                 }
             )
         if batch:

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -114,6 +114,29 @@ class TestLoadHadiths:
         assert len(hadith_batches) >= 1
         assert hadith_batches[0][0]["id"] == "hdt:bukhari-1"
 
+    def test_node_omits_collection_position_props(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """book/chapter/hadith_number live on the APPEARS_IN edge, not the node (#35)."""
+        write_hadiths(
+            staging_dir,
+            [{"source_id": "bukhari-1", "book_number": 1, "chapter_number": 1, "hadith_number": 1}],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        hadith_batches = [
+            batch
+            for _query, batch in mock_client.calls
+            if isinstance(batch, list)
+            and batch
+            and "id" in batch[0]
+            and batch[0]["id"].startswith("hdt:")
+        ]
+        assert len(hadith_batches) >= 1
+        row = hadith_batches[0][0]
+        assert "book_number" not in row
+        assert "chapter_number" not in row
+        assert "hadith_number" not in row
+
     def test_invalid_source_id_skipped(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
     ) -> None:


### PR DESCRIPTION
## Issue
Closes #59 — tech-debt(graph-loader): legacy `load_nodes.py` still writes `book/chapter/hadith_number` to the Hadith node (post-#35 node-prop removal).

## Determination: LIVE path → reconcile (not remove)
The decision tree's first question is whether `src/graph/` is a live ingest path or dead/superseded by the Kafka ingest-platform pipeline. Evidence it is **LIVE**:

- `src/cli.py:134` `_cmd_load` ("Run the Phase 3 graph loading pipeline") does `from src.graph import load_all`; `src/cli.py:239` `_cmd_validate` does `from src.graph.validate import run_validation`.
- `CLAUDE.md` documents `make load` (Phase 3: load into Neo4j) and `make validate` as active pipeline stages; `src/graph/` is the canonical Neo4j loader for this repo.
- It is the **legacy direct-load** path; the Kafka ingest-platform pipeline is the strategic replacement but does **not yet** supersede it.

So the right action is to reconcile the legacy loader with the post-#35 schema, not to delete it.

## Change
Per the #35 ruling (ratified P3W13): `book_number` / `chapter_number` / `hadith_number` are positional facts of a hadith's place *within a collection*, so they live on the **APPEARS_IN edge**, not the Hadith node.

- `load_edges.py` `_APPEARS_IN_QUERY` (lines 279–282) **already** writes all three onto the APPEARS_IN edge — dropping them from the node loses no data.
- Removed the three `SET n.* = row.*` writes from `_HADITH_MERGE` and the three fields from the Hadith batch row dict in `_load_hadiths`.
- Staging `HADITH_SCHEMA`, the integration sample data, and the edge loader are **unchanged** — the staging columns still feed the edge.

## Tests
- Added `test_node_omits_collection_position_props` asserting the Hadith node batch dict carries none of the three props.
- `tests/test_graph/` suite green locally (64 passed), ruff format/lint clean, mypy clean.
- `tests/integration/test_graph_loading.py` requires a live Neo4j via testcontainers and errors at fixture setup locally (no Docker daemon); it runs against the CI Neo4j service container.

## Structured review fields
Requestor: Nikolaos Papadopoulos
Requestee: Kavitha Sundaramurthy
TechDebt: none
