### PR TITLE
ci(docs): pin actionlint installer to v1.7.12 + SHA256 verify (Refs #578)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -153,10 +153,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Download and verify actionlint
+        env:
+          # Pinned: version + linux_amd64 tarball SHA256 from upstream's
+          # signed release manifest (actionlint_1.7.12_checksums.txt at
+          # https://github.com/rhysd/actionlint/releases/tag/v1.7.12).
+          # `sha256sum -c` aborts the job on mismatch — bytes-on-runner are
+          # exactly what was published at release time. Replaces the prior
+          # `curl|bash` of the unpinned download-actionlint.bash off `main`
+          # (#578): fetching+executing latest-of-main each run is a
+          # supply-chain gap and diverges from the pinned v1.7.12 the
+          # .pre-commit-config.yaml mirror already ships.
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          cd "$RUNNER_TEMP"
+          curl --fail --silent --show-error --location \
+            -o "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
+          actionlint -version
       - name: Run actionlint on workflows
         # shellcheck is preinstalled on ubuntu-latest, so actionlint's embedded
         # shellcheck integration runs (per the actionlint-needs-shellcheck
         # discipline) rather than silently skipping.
-        run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color
+        run: actionlint -color


### PR DESCRIPTION
## Summary
Pins the `actionlint` installer in `docs.yml`'s `Config — Workflow actionlint` job to **v1.7.12** with SHA256 verification, replacing the unpinned `bash <(curl ... download-actionlint.bash)` that tracked `main`. data-acquisition child slice of the org-wide rollout.

Refs noorinalabs-main#578 (rollout meta — stays open until all 7 children land).

## What changed
The single install+run step becomes two steps matching the parent-canonical `noorinalabs-main` `docs.yml@main` (PR #579):
1. **Download and verify actionlint** — fetches the tagged v1.7.12 `linux_amd64` tarball, runs `sha256sum -c` against the upstream-published checksum, `install`s to `/usr/local/bin`.
2. **Run actionlint on workflows** — `actionlint -color` (no `./` prefix; no `-ignore` flags — this repo had none).

## Why
- Closes the supply-chain gap of fetching + executing latest-of-`main` on every run.
- Aligns the CI installer with the pinned v1.7.12 the `.pre-commit-config.yaml` mirror already ships.
- `sha256sum -c` aborts the job on any byte mismatch, so the runner gets exactly what upstream published at release time.

## Verification
- **SHA256 independently re-verified** against `https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_checksums.txt`: `8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8` (linux_amd64) — matches the patch.
- `docs.yml` parses as YAML; `actionlint -color .github/workflows/docs.yml` exits 0 locally with shellcheck on PATH (embedded shellcheck integration runs).
- Confirmed against origin HEAD before editing: data-acquisition's actionlint job had `actions/checkout@v4` + plain `bash <(curl...)` + `./actionlint -color`, no `-ignore` flags — patch applies cleanly with nothing to preserve.

## Structured review fields
Requestor: Nikolaos Papadopoulos
Requestee: Kavitha Sundaramurthy
TechDebt: none
