### PR TITLE
docs+ci(#520): recover ADR-001 citation fix + auto-close workflow (da#53/#54)

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,0 +1,35 @@
+name: Auto-close issues
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Close referenced issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const matches = body.matchAll(/[Cc]loses?\s+#(\d+)/g);
+            for (const match of matches) {
+              const issue_number = parseInt(match[1]);
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                state: 'closed',
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body: `Closed by PR #${context.payload.pull_request.number} merged into \`${context.payload.pull_request.base.ref}\`.`,
+              });
+            }

--- a/docs/adr/001-local-hook-policy-dispatcher-style.md
+++ b/docs/adr/001-local-hook-policy-dispatcher-style.md
@@ -11,14 +11,17 @@ Claude Code automation hooks are delegated to the parent canonical at
 
 The org-level charter recognizes a *dispatcher-style* exemption category for children in
 this topology — see `charter/hooks.md § Hook Authorship Requirements § 5 Parser-Fixture
-Coverage Requirements — dispatcher-children sub-clause` (pending
-noorinalabs/noorinalabs-main#311, charter PR #334). The classification command used in
-"Verification at HEAD" below is the one being added to `charter/hooks.md § Hook Audit
-Protocol` (pending noorinalabs/noorinalabs-main#313, also bundled in PR #334). The W7
-audit (parent#300) and Aino's W8 charter edits (parent#311 + #313) name
-data-acquisition as one of the canonical dispatcher-style exemplars. This ADR ratifies
-the local effect of those charter rules for `noorinalabs-data-acquisition`; it does not
-redefine them.
+Coverage Requirements`, dispatcher-children sub-clause: "Children that delegate all hook
+execution to the parent canonical via `settings.json` are exempt from per-child fixture
+requirements. Coverage obligations are fulfilled by the parent's test suite." The
+classification command used in "Verification at HEAD" below is codified in
+`charter/hooks.md § Hook Audit Protocol`. Both edits landed in
+noorinalabs/noorinalabs-main PR #334 (merge_sha `c7fd964c24a197317a700c90cdb5a0140a6050be`,
+2026-05-09), which bundled #311 (dispatcher-children sub-clause) and #313 (Hook Audit
+Protocol). The W7 audit (parent#300) and Aino's W8 charter edits (parent#311 + #313)
+name data-acquisition as one of the canonical dispatcher-style exemplars. This ADR
+ratifies the local effect of those charter rules for `noorinalabs-data-acquisition`; it
+does not redefine them.
 
 Issue #44 was filed in P3W7 originally framed as "remove dead-code child hook copies",
 then re-scoped during the W7 audit when committed-tree inspection confirmed there was
@@ -28,9 +31,9 @@ onboarding pattern?
 
 ### Verification at HEAD
 
-Applying the charter's dispatcher-style classification check (defined under `§ Hook Audit
-Protocol`, pending parent#313) to this repo at the wave-8 base SHA
-`f43b84d19d1e38f4b964c6ed313ce5cc58584914`:
+Applying the charter's dispatcher-style classification check (defined under
+`charter/hooks.md § Hook Audit Protocol`, merged via parent#334) to this repo at the
+wave-8 base SHA `f43b84d19d1e38f4b964c6ed313ce5cc58584914`:
 
 ```bash
 gh api repos/noorinalabs/noorinalabs-data-acquisition/git/trees/f43b84d19d1e38f4b964c6ed313ce5cc58584914?recursive=1 \
@@ -56,8 +59,7 @@ execution is delegated to the parent canonical at `noorinalabs-main/.claude/hook
 local hook files are committed to this repository. Coverage obligations under
 `charter/hooks.md § Hook Authorship Requirements § 5 Parser-Fixture Coverage
 Requirements` are fulfilled by the parent's test suite per the dispatcher-children
-sub-clause (pending parent#311 — citation will resolve to merged charter language once
-PR #334 lands).
+sub-clause (merged via parent#334 on 2026-05-09).
 
 The door is explicitly left open to revisit this decision if a concrete domain-specific
 hook need emerges that the parent does not naturally cover.


### PR DESCRIPTION
## Summary

Recovers two changes stranded on the abandoned `deployments/phase-3/wave-10` branch.

**1. `docs/adr/001-local-hook-policy-dispatcher-style.md`** (from da#53, commit `e14109d`)
Replaces 6 `pending parent#311` / `pending parent#313` / `pending PR #334 lands` placeholder citation strings with the resolved merged-charter language and the concrete parent merge SHA (`c7fd964c24a197317a700c90cdb5a0140a6050be`, 2026-05-09, bundling #311 dispatcher-children sub-clause + #313 Hook Audit Protocol). Prose-cleanup only — Decision / Rationale / Consequences unchanged.

main's ADR was byte-identical to `e14109d`'s parent (`git diff` empty; no later wave touched it — last commit `9f9324b`), so the recovered post-state applies clean with no merge reconciliation.

**2. `.github/workflows/auto-close-issues.yml`** (from da#54, commit `ad49005`)
Auto-closes referenced issues on PR merge. Owner-approved org-wide propagation from isnad-graph per main#402. File was absent on main (clean add).

## Check results

- `actionlint .github/workflows/auto-close-issues.yml` → exit 0
- `actionlint` (all workflows, mirrors docs.yml gate) → exit 0
- `markdownlint-cli2` (repo `.markdownlint-cli2.jsonc`) → 0 errors, exit 0
- `cspell --config .cspell.json` on the ADR → 0 issues, exit 0
- lychee: binary not on local PATH; not run locally. The ADR's only links are relative anchors to charter sections (no new external URLs introduced), and `.lychee.toml` runs offline/internal-only in CI — docs.yml will cover it.

ruff / mypy / pytest are not applicable (docs + workflow file only; no `src/` change).

Refs noorinalabs-main#520
Recovers da#53/#54 (stranded on wave-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
