### PR TITLE
fix(graph-loader): align APPEARS_IN edge key to canonical hadith_number_in_book (#65)

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -279,7 +279,7 @@ MATCH (c:Collection {id: row.collection_id})
 MERGE (h)-[:APPEARS_IN {
     book_number: row.book_number,
     chapter_number: row.chapter_number,
-    hadith_number: row.hadith_number
+    hadith_number_in_book: row.hadith_number
 }]->(c)
 """
 

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from src.graph.load_edges import EdgeLoadResult, _build_chain_pairs, load_all_edges
+from src.graph.load_edges import (
+    _APPEARS_IN_QUERY,
+    EdgeLoadResult,
+    _build_chain_pairs,
+    load_all_edges,
+)
 from tests.test_graph.conftest import (
     MockNeo4jClient,
     write_hadiths,
@@ -197,6 +202,13 @@ class TestLoadAppearsIn:
         ai_result = results[2]
         assert ai_result.edge_type == "APPEARS_IN"
         assert ai_result.created == 1
+
+    def test_appears_in_edge_uses_canonical_property_key(self) -> None:
+        # The APPEARS_IN edge property MUST be the ig#935-canonical
+        # ``hadith_number_in_book`` (matches AppearsIn model + isnad-graph
+        # src/models/edges.py), NOT the legacy bare ``hadith_number`` (da#65).
+        assert "hadith_number_in_book: row.hadith_number" in _APPEARS_IN_QUERY
+        assert "hadith_number:" not in _APPEARS_IN_QUERY
 
     def test_missing_collection_name_skipped(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path


### PR DESCRIPTION
## Summary

Aligns the data-acquisition direct edge loader's APPEARS_IN edge property to the ig#935-ratified canonical name `hadith_number_in_book`, eliminating the cross-repo naming drift described in #65.

`src/graph/load_edges.py` `_APPEARS_IN_QUERY` was writing the edge property as the legacy bare `hadith_number`. The drift was loader-only:
- This repo's own `AppearsIn` Pydantic model (`src/models/edges.py`) already uses `hadith_number_in_book`.
- isnad-graph's canonical `src/models/edges.py` uses `hadith_number_in_book` (verified at origin HEAD — see below).
- The ingest-platform normalize path already emits `hadith_number_in_book`.

The direct loader was the lone divergent writer, so consumers reading the edge by the canonical name got nulls for edges produced via this path.

### Change scope (one Cypher property key)

```diff
 MERGE (h)-[:APPEARS_IN {
     book_number: row.book_number,
     chapter_number: row.chapter_number,
-    hadith_number: row.hadith_number
+    hadith_number_in_book: row.hadith_number
 }]->(c)
```

Only the Cypher **edge property key** changed. The bound value `row.hadith_number` is the staging-table (`hadiths_*.parquet`) column name and is intentionally unchanged — that's the source-data field, not the graph property.

## Canonical-name verification

`gh api repos/noorinalabs/noorinalabs-isnad-graph/contents/src/models/edges.py?ref=main` (decoded) →
```
hadith_number_in_book: int | None = None
```
Also confirmed in the org ontology (`ontology/domain.yaml` APPEARS_IN attributes: `[book_number, chapter_number, hadith_number_in_book]`).

## Data migration (runtime item — not in this PR)

Per #65, edges already loaded under the legacy `hadith_number` key in any live Neo4j environment will NOT be retroactively renamed by this code change. A one-time migration is needed where the old key already exists:

```cypher
MATCH ()-[r:APPEARS_IN]->()
WHERE r.hadith_number IS NOT NULL AND r.hadith_number_in_book IS NULL
SET r.hadith_number_in_book = r.hadith_number
REMOVE r.hadith_number
```

The issue does not ask this PR to write the migration, so it is flagged here as a post-merge runtime item for the environment owner. The loader is idempotent, so a fresh `make load` writes only the canonical key going forward.

## Test Plan

- New regression test `tests/test_graph/test_load_edges.py::TestLoadAppearsIn::test_appears_in_edge_uses_canonical_property_key` asserts `_APPEARS_IN_QUERY` uses `hadith_number_in_book: row.hadith_number` and not the legacy bare `hadith_number:` key.
- Local CI-equivalent (child repo config, line-length 100, ruff 0.15.11):
  - `ruff check src/ tests/` — passed
  - `ruff format --check src/ tests/` — 116 files already formatted
  - `mypy src/` — Success: no issues found in 62 source files
  - `pytest tests/ -m "not integration"` — 525 passed, 3 skipped, 13 deselected
- Integration tests (real Neo4j) run in CI's separate job.

Closes #65

Co-Authored-By: Kwesi Boateng <parametrization+Kwesi.Boateng@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
