### PR TITLE
fix(sunnah_scraper): extract hadith_number from current sunnah.com markup (#72)

### DIFF
--- a/src/acquire/sunnah_scraper.py
+++ b/src/acquire/sunnah_scraper.py
@@ -35,14 +35,26 @@ USER_AGENT = "isnad-graph/1.0 (hadith-research)"
 # If sunnah.com redesigns, add new selectors at the front of each list.
 #
 # Hadith number: sunnah.com's current layout no longer exposes a bare
-# ``.hadith_num`` span.  The collection-wide reference number now lives in the
-# ``.hadith_reference_sticky`` label (e.g. "Riyad as-Salihin 680") and in the
-# reference link inside ``table.hadith_reference`` (``href="/<coll>:680"``).
-# We prefer the sticky label, fall back to the reference-link href, then to the
-# legacy span selectors for any collection still on the old markup.
+# ``.hadith_num`` span.  Both numbers we care about live in the
+# ``table.hadith_reference`` block at the bottom of each container, e.g.
+#     Reference         : Riyad as-Salihin 680   (collection-wide)
+#     In-book reference : Book 1, Hadith 1        (book + in-book ordinal)
+# We want the IN-BOOK ordinal (1) for ``hadith_number`` because the downstream
+# APPEARS_IN edge maps it into ``hadith_number_in_book`` (documented as "Hadith
+# number within the book" — da#77).  The in-book ordinal is unique within a
+# book, so ``source_id = sunnah:<coll>:<book>:<chapter>:<ordinal>`` stays
+# collision-free.  If the "In-book reference" row is absent we fall back to the
+# collection-wide reference (sticky label / link href) so source_id keying still
+# gets a non-null, per-collection-unique value, then to the legacy span.
+HADITH_REFERENCE_SELECTORS = ["table.hadith_reference"]
 HADITH_NUMBER_STICKY_SELECTORS = [".hadith_reference_sticky"]
 HADITH_NUMBER_LINK_SELECTORS = ["table.hadith_reference tr td a[href]"]
 HADITH_NUMBER_SELECTORS = [".hadith_reference .hadith_num", ".hadithNar498"]
+
+# In-book reference row: "In-book reference : Book 1, Hadith 1".
+_IN_BOOK_REF_RE = re.compile(
+    r"In-book reference\s*:?\s*Book\s+(\d+)\s*,\s*Hadith\s+(\d+)", re.IGNORECASE
+)
 ARABIC_TEXT_SELECTORS = [".arabic_hadith_full", ".text_details .arabic_text_details"]
 ENGLISH_TEXT_SELECTORS = [".english_hadith_full", ".text_details .english_hadith_full"]
 GRADE_SELECTORS = [".hadith_grade", ".hadith-grade"]
@@ -95,13 +107,27 @@ def _fetch_page(client: httpx.Client, url: str) -> BeautifulSoup | None:
         return None
 
 
-def _extract_hadith_number(row: Tag) -> int | None:
-    """Extract the collection-wide hadith reference number from a container.
+def _extract_in_book_ref(row: Tag) -> tuple[int | None, int | None]:
+    """Extract ``(book_number, in_book_ordinal)`` from the reference table.
 
-    The reference number (e.g. 680 for "Riyad as-Salihin 680") is unique across
-    the whole collection, so it is the strongest disambiguator for the downstream
-    ``source_id`` — it keeps records distinct even when book/chapter parsing is
-    imperfect.  Tried in order of robustness against the current sunnah.com markup:
+    Reads the "In-book reference : Book N, Hadith M" row of
+    ``table.hadith_reference``.  Returns ``(None, None)`` when that row is
+    absent (e.g. a collection whose pages omit it).
+    """
+    ref_tag = select_first(row, HADITH_REFERENCE_SELECTORS)
+    if ref_tag is None:
+        return None, None
+    match = _IN_BOOK_REF_RE.search(ref_tag.get_text(" ", strip=True))
+    if not match:
+        return None, None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _extract_collection_ref_number(row: Tag) -> int | None:
+    """Extract the collection-wide reference number (e.g. 680).
+
+    Fallback for ``hadith_number`` when the in-book ordinal is unavailable: it
+    is unique per collection, so source_id keying still gets a non-null value.
 
     1. ``.hadith_reference_sticky`` label — trailing number ("... 680").
     2. ``table.hadith_reference`` reference link — ``href="/<coll>:680"``.
@@ -137,8 +163,13 @@ def _extract_hadith_number(row: Tag) -> int | None:
 
 def _extract_hadith_from_row(row: Tag) -> dict[str, Any] | None:
     """Extract a single hadith record from a hadith container element."""
-    # Hadith number
-    hadith_number = _extract_hadith_number(row)
+    # Hadith number: prefer the IN-BOOK ordinal (what hadith_number_in_book
+    # promises downstream); fall back to the collection-wide reference so
+    # source_id keying still gets a non-null, per-collection-unique value.
+    book_number, in_book_ordinal = _extract_in_book_ref(row)
+    hadith_number = (
+        in_book_ordinal if in_book_ordinal is not None else _extract_collection_ref_number(row)
+    )
 
     # Arabic text
     ar_tag = select_first(row, ARABIC_TEXT_SELECTORS)
@@ -157,6 +188,9 @@ def _extract_hadith_from_row(row: Tag) -> dict[str, Any] | None:
 
     return {
         "hadith_number": hadith_number,
+        # Book number parsed from the in-book reference ("Book N, ..."); the
+        # caller falls back to the page URL's book number when this is None.
+        "book_number": book_number,
         "text_ar": text_ar,
         "text_en": text_en,
         "grade": grade,
@@ -216,7 +250,10 @@ def _scrape_book_page(
 
         record = _extract_hadith_from_row(row)
         if record is not None:
-            record["book_number"] = book_number
+            # Prefer the book number parsed from the in-book reference; fall
+            # back to the page URL's book number when the row was absent.
+            if record.get("book_number") is None:
+                record["book_number"] = book_number
             record["chapter_number"] = current_chapter_number
             record["chapter_name_ar"] = chapter_name_ar
             record["chapter_name_en"] = chapter_name_en

--- a/src/acquire/sunnah_scraper.py
+++ b/src/acquire/sunnah_scraper.py
@@ -11,6 +11,7 @@ Output directory: ``data/raw/sunnah_scraped/``
 from __future__ import annotations
 
 import json
+import re
 import time
 from pathlib import Path
 from typing import Any
@@ -32,6 +33,15 @@ USER_AGENT = "isnad-graph/1.0 (hadith-research)"
 
 # CSS selectors with fallbacks, ordered by preference.
 # If sunnah.com redesigns, add new selectors at the front of each list.
+#
+# Hadith number: sunnah.com's current layout no longer exposes a bare
+# ``.hadith_num`` span.  The collection-wide reference number now lives in the
+# ``.hadith_reference_sticky`` label (e.g. "Riyad as-Salihin 680") and in the
+# reference link inside ``table.hadith_reference`` (``href="/<coll>:680"``).
+# We prefer the sticky label, fall back to the reference-link href, then to the
+# legacy span selectors for any collection still on the old markup.
+HADITH_NUMBER_STICKY_SELECTORS = [".hadith_reference_sticky"]
+HADITH_NUMBER_LINK_SELECTORS = ["table.hadith_reference tr td a[href]"]
 HADITH_NUMBER_SELECTORS = [".hadith_reference .hadith_num", ".hadithNar498"]
 ARABIC_TEXT_SELECTORS = [".arabic_hadith_full", ".text_details .arabic_text_details"]
 ENGLISH_TEXT_SELECTORS = [".english_hadith_full", ".text_details .english_hadith_full"]
@@ -85,17 +95,50 @@ def _fetch_page(client: httpx.Client, url: str) -> BeautifulSoup | None:
         return None
 
 
-def _extract_hadith_from_row(row: Tag) -> dict[str, Any] | None:
-    """Extract a single hadith record from a hadith container element."""
-    # Hadith number
+def _extract_hadith_number(row: Tag) -> int | None:
+    """Extract the collection-wide hadith reference number from a container.
+
+    The reference number (e.g. 680 for "Riyad as-Salihin 680") is unique across
+    the whole collection, so it is the strongest disambiguator for the downstream
+    ``source_id`` — it keeps records distinct even when book/chapter parsing is
+    imperfect.  Tried in order of robustness against the current sunnah.com markup:
+
+    1. ``.hadith_reference_sticky`` label — trailing number ("... 680").
+    2. ``table.hadith_reference`` reference link — ``href="/<coll>:680"``.
+    3. Legacy ``.hadith_num`` / ``.hadithNar498`` span (pre-redesign markup).
+    """
+    # 1. Sticky reference label: "<Collection Name> <number>".
+    sticky_tag = select_first(row, HADITH_NUMBER_STICKY_SELECTORS)
+    if sticky_tag:
+        match = re.search(r"(\d+)\s*$", sticky_tag.get_text(strip=True))
+        if match:
+            return int(match.group(1))
+
+    # 2. Reference link href: "/<collection>:<number>" (or "...#<number>").
+    link_tag = select_first(row, HADITH_NUMBER_LINK_SELECTORS)
+    if link_tag:
+        href = link_tag.get("href", "")
+        if isinstance(href, str):
+            match = re.search(r"[:#](\d+)\s*$", href)
+            if match:
+                return int(match.group(1))
+
+    # 3. Legacy bare-number span.
     num_tag = select_first(row, HADITH_NUMBER_SELECTORS)
-    hadith_number: int | None = None
     if num_tag:
         text = num_tag.get_text(strip=True).replace(":", "").strip()
         try:
-            hadith_number = int(text)
+            return int(text)
         except ValueError:
             pass
+
+    return None
+
+
+def _extract_hadith_from_row(row: Tag) -> dict[str, Any] | None:
+    """Extract a single hadith record from a hadith container element."""
+    # Hadith number
+    hadith_number = _extract_hadith_number(row)
 
     # Arabic text
     ar_tag = select_first(row, ARABIC_TEXT_SELECTORS)

--- a/tests/test_acquire/fixtures/riyadussalihin_book1_sample.html
+++ b/tests/test_acquire/fixtures/riyadussalihin_book1_sample.html
@@ -1,0 +1,38 @@
+<html><body>
+<div class="book_page_english_name">
+				The Book of Good Manners			</div>
+<div class="book_page_arabic_name arabic">كتاب الأدب</div>
+<div class="actualHadithContainer hadith_container_riyadussalihin" id="h1706760">
+<!-- Begin hadith -->
+<a name="1"></a>
+<div class="hadith_reference_sticky">Riyad as-Salihin 680</div><div class="hadithTextContainers" id="htc1706760"><div class="englishcontainer" id="t1706760"><div class="english_hadith_full"><div class="hadith_narrated">Ibn 'Umar (May Allah be pleased with them) reported:</div><div class="text_details">Messenger of Allah (ﷺ) passed by a man of the Ansar who was admonishing his brother regarding shyness. Messenger of Allah (ﷺ) said, "Leave him alone, for modesty is a part of Iman."<br/><p>
+<p><br/><p>
+<b>[Al-Bukhari and Muslim]</b>.</p></p></p></div>
+<div class="clear"></div></div></div><div class="arabic_hadith_full arabic"><span class="arabic_sanad arabic">وعن ابن عمر رضي الله عنهما أن رسول الله صلى الله عليه وسلم مر على رجل من الأنصار وهو يعظ أخاه في الحياء، فقال رسول الله صلى الله عليه وسلم‏:‏</span>
+<span class="arabic_text_details arabic">"دعه فإن الحياء من الإيمان"</span><span class="arabic_sanad arabic"> ‏(‏‏(‏متفق عليه‏)‏‏)‏ ‏.‏</span></div>
+</div>
+<!-- End hadith -->
+<div class="clear"></div><div class="bottomItems">
+<table cellpadding="0" cellspacing="0" class="hadith_reference"><tr><td><b>Reference</b></td><td> : <a href="/riyadussalihin:680">Riyad as-Salihin 680</a></td></tr><tr><td>In-book reference</td><td> : Book 1, Hadith 1</td></tr></table><div class="hadith_permalink"><span class="reportlink" data-cf-modified-332ebd8ffa6d2bef2418afc7-="" href="javascript: void(0);" onclick="if (!window.__cfRLUnblockHandlers) return false; reportHadith(1606725, 'h1706760')">Report Error</span> | <span class="sharelink" data-cf-modified-332ebd8ffa6d2bef2418afc7-="" onclick="if (!window.__cfRLUnblockHandlers) return false; share(this, '/riyadussalihin:680')">Share</span> | <span class="copylink" title="Copy hadith to clipboard">Copy</span> <span class="copycbcaret" title="Change copy options">▼</span></div></div><div class="clear"></div></div>
+<div class="actualHadithContainer hadith_container_riyadussalihin" id="h1706770">
+<!-- Begin hadith -->
+<a name="2"></a>
+<div class="hadith_reference_sticky">Riyad as-Salihin 681</div><div class="hadithTextContainers" id="htc1706770"><div class="englishcontainer" id="t1706770"><div class="english_hadith_full"><div class="hadith_narrated">'Imran bin Husain (May Allah be pleased with them) reported:</div><div class="text_details">Messenger of Allah (ﷺ) said, "Shyness does not bring anything except good."<br/><br/><b>[Al-Bukhari and Muslim]</b>.<br/><br/>In a narration of Muslim: Messenger of Allah (ﷺ) said, "All of shyness is good."<br/><br/></div>
+<div class="clear"></div></div></div><div class="arabic_hadith_full arabic"><span class="arabic_sanad arabic">وعن عمران بن حصين، رضي الله عنهما، قال‏:‏ قال رسول الله صلى الله عليه وسلم‏:‏ “ الحياء لا يأتى إلا بخير” ‏(‏‏(‏متفق عليه‏)‏‏)‏ ‏.‏ <br/><p>
+وفي رواية لمسلم” ‏</p></span>
+<span class="arabic_text_details arabic">"‏الحياءه خير كله”أوقال‏:‏ “الحياء كله خير‏"</span><span class="arabic_sanad arabic">‏‏.‏</span></div>
+</div>
+<!-- End hadith -->
+<div class="clear"></div><div class="bottomItems">
+<table cellpadding="0" cellspacing="0" class="hadith_reference"><tr><td><b>Reference</b></td><td> : <a href="/riyadussalihin:681">Riyad as-Salihin 681</a></td></tr><tr><td>In-book reference</td><td> : Book 1, Hadith 2</td></tr></table><div class="hadith_permalink"><span class="reportlink" data-cf-modified-332ebd8ffa6d2bef2418afc7-="" href="javascript: void(0);" onclick="if (!window.__cfRLUnblockHandlers) return false; reportHadith(1606730, 'h1706770')">Report Error</span> | <span class="sharelink" data-cf-modified-332ebd8ffa6d2bef2418afc7-="" onclick="if (!window.__cfRLUnblockHandlers) return false; share(this, '/riyadussalihin:681')">Share</span> | <span class="copylink" title="Copy hadith to clipboard">Copy</span> <span class="copycbcaret" title="Change copy options">▼</span></div></div><div class="clear"></div></div>
+<div class="actualHadithContainer hadith_container_riyadussalihin" id="h1706780">
+<!-- Begin hadith -->
+<a name="3"></a>
+<div class="hadith_reference_sticky">Riyad as-Salihin 682</div><div class="hadithTextContainers" id="htc1706780"><div class="englishcontainer" id="t1706780"><div class="english_hadith_full"><div class="hadith_narrated">Abu Hurairah (May Allah be pleased with him) reported:</div><div class="text_details">Messenger of Allah (ﷺ) said, "Iman has sixty odd or seventy odd branches. The uppermost of all these is the Testimony of Faith: 'La ilaha illallah' (there is no true god except Allah) while the least of them is the removal of harmful object from the road. And shyness is a branch of Iman."<br/><br/><b>[Al-Bukhari and Muslim]</b>.<br/><br/></div>
+<div class="clear"></div></div></div><div class="arabic_hadith_full arabic"><span class="arabic_sanad arabic"></span>
+<span class="arabic_text_details arabic">-وعن أبى هريرة رضي الله عنه، أن رسول الله صلى الله عليه وسلم قال‏:‏ “الإيمان بضع وسبعون، أو بضع وستون شعبة، فأفضلها قول لا إله إلا الله، وأدناها إماطة الأذى عن الطريق، والحياء شعبة من الإيمان” ‏(‏‏(‏متفق عليه‏)‏‏)‏ ‏.‏</span><span class="arabic_sanad arabic"></span></div>
+</div>
+<!-- End hadith -->
+<div class="clear"></div><div class="bottomItems">
+<table cellpadding="0" cellspacing="0" class="hadith_reference"><tr><td><b>Reference</b></td><td> : <a href="/riyadussalihin:682">Riyad as-Salihin 682</a></td></tr><tr><td>In-book reference</td><td> : Book 1, Hadith 3</td></tr></table><div class="hadith_permalink"><span class="reportlink" data-cf-modified-332ebd8ffa6d2bef2418afc7-="" href="javascript: void(0);" onclick="if (!window.__cfRLUnblockHandlers) return false; reportHadith(1606740, 'h1706780')">Report Error</span> | <span class="sharelink" data-cf-modified-332ebd8ffa6d2bef2418afc7-="" onclick="if (!window.__cfRLUnblockHandlers) return false; share(this, '/riyadussalihin:682')">Share</span> | <span class="copylink" title="Copy hadith to clipboard">Copy</span> <span class="copycbcaret" title="Change copy options">▼</span></div></div><div class="clear"></div></div>
+</body></html>

--- a/tests/test_acquire/test_sunnah_scraper.py
+++ b/tests/test_acquire/test_sunnah_scraper.py
@@ -11,10 +11,13 @@ import httpx
 from src.acquire.sunnah_scraper import (
     SCRAPE_COLLECTIONS,
     _extract_hadith_from_row,
+    _extract_hadith_number,
     _get_book_numbers,
     _scrape_book_page,
     run,
 )
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 SAMPLE_COLLECTION_HTML = """
 <html><body>
@@ -184,3 +187,112 @@ class TestRun:
         assert len(SCRAPE_COLLECTIONS) == 8
         assert "musnad-ahmad" in SCRAPE_COLLECTIONS
         assert "riyadussalihin" in SCRAPE_COLLECTIONS
+
+
+# Container markup matching sunnah.com's CURRENT layout (no bare `.hadith_num`
+# span). Regression guard for da#72: the reference number now lives in the
+# `.hadith_reference_sticky` label and the `table.hadith_reference` link href.
+CURRENT_MARKUP_HADITH_HTML = """
+<div class="actualHadithContainer">
+  <div class="hadith_reference_sticky">Riyad as-Salihin 680</div>
+  <div class="english_hadith_full">English text</div>
+  <div class="arabic_hadith_full arabic">عربي</div>
+  <div class="bottomItems">
+    <table class="hadith_reference"><tr>
+      <td><b>Reference</b></td>
+      <td>: <a href="/riyadussalihin:680">Riyad as-Salihin 680</a></td>
+    </tr></table>
+  </div>
+</div>
+"""
+
+
+class TestExtractHadithNumber:
+    """Regression coverage for da#72 — number extraction on current markup."""
+
+    def test_extracts_from_sticky_reference_label(self) -> None:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(CURRENT_MARKUP_HADITH_HTML, "html.parser")
+        row = soup.select_one(".actualHadithContainer")
+        assert row is not None
+        # Primary path: the sticky "Riyad as-Salihin 680" label.
+        assert _extract_hadith_number(row) == 680
+
+    def test_extracts_from_reference_link_href(self) -> None:
+        from bs4 import BeautifulSoup
+
+        # No sticky label — must fall back to the reference-link href.
+        html = """
+        <div class="actualHadithContainer">
+          <div class="english_hadith_full">English text</div>
+          <table class="hadith_reference"><tr>
+            <td><b>Reference</b></td>
+            <td>: <a href="/riyadussalihin:681">Riyad as-Salihin 681</a></td>
+          </tr></table>
+        </div>
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        row = soup.select_one(".actualHadithContainer")
+        assert row is not None
+        assert _extract_hadith_number(row) == 681
+
+    def test_legacy_span_still_supported(self) -> None:
+        from bs4 import BeautifulSoup
+
+        # Pre-redesign markup must keep working for collections still on it.
+        html = """
+        <div class="actualHadithContainer">
+          <div class="hadith_reference"><span class="hadith_num">42</span></div>
+          <div class="english_hadith_full">English text</div>
+        </div>
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        row = soup.select_one(".actualHadithContainer")
+        assert row is not None
+        assert _extract_hadith_number(row) == 42
+
+    def test_full_record_has_non_null_number_on_current_markup(self) -> None:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(CURRENT_MARKUP_HADITH_HTML, "html.parser")
+        row = soup.select_one(".actualHadithContainer")
+        assert row is not None
+        record = _extract_hadith_from_row(row)
+        assert record is not None
+        # The pre-fix bug: this was None for every row on the live site.
+        assert record["hadith_number"] == 680
+
+
+class TestRiyadussalihinFixture:
+    """End-to-end selector guard over a saved current-markup fixture page."""
+
+    def test_numbers_parsed_and_source_ids_unique(self) -> None:
+        from bs4 import BeautifulSoup
+
+        from src.parse.base import generate_source_id
+
+        html = (FIXTURES_DIR / "riyadussalihin_book1_sample.html").read_text(encoding="utf-8")
+        soup = BeautifulSoup(html, "html.parser")
+        rows = soup.select(".actualHadithContainer")
+        assert rows, "fixture must contain hadith containers"
+
+        records = [rec for r in rows if (rec := _extract_hadith_from_row(r)) is not None]
+        assert records, "fixture must yield parseable hadith records"
+
+        # Acceptance: a non-null number for every sampled hadith.
+        assert all(r["hadith_number"] is not None for r in records)
+
+        # Acceptance: source_id uniqueness holds. The collection-wide reference
+        # number alone keeps every record distinct, so dedup never merges them.
+        source_ids = {
+            generate_source_id(
+                "sunnah",
+                "riyadussalihin",
+                1,
+                1,
+                r["hadith_number"] or 0,
+            )
+            for r in records
+        }
+        assert len(source_ids) == len(records)

--- a/tests/test_acquire/test_sunnah_scraper.py
+++ b/tests/test_acquire/test_sunnah_scraper.py
@@ -10,8 +10,9 @@ import httpx
 
 from src.acquire.sunnah_scraper import (
     SCRAPE_COLLECTIONS,
+    _extract_collection_ref_number,
     _extract_hadith_from_row,
-    _extract_hadith_number,
+    _extract_in_book_ref,
     _get_book_numbers,
     _scrape_book_page,
     run,
@@ -190,25 +191,59 @@ class TestRun:
 
 
 # Container markup matching sunnah.com's CURRENT layout (no bare `.hadith_num`
-# span). Regression guard for da#72: the reference number now lives in the
-# `.hadith_reference_sticky` label and the `table.hadith_reference` link href.
+# span). The reference table carries BOTH numbers: the collection-wide ref in
+# the first row / sticky label, and the in-book ordinal in the "In-book
+# reference" row. da#72 extracts the IN-BOOK ordinal into `hadith_number` so the
+# downstream APPEARS_IN `hadith_number_in_book` edge prop is semantically honest
+# (da#77); the collection-wide ref is a non-null fallback for source_id keying.
 CURRENT_MARKUP_HADITH_HTML = """
 <div class="actualHadithContainer">
   <div class="hadith_reference_sticky">Riyad as-Salihin 680</div>
   <div class="english_hadith_full">English text</div>
   <div class="arabic_hadith_full arabic">عربي</div>
   <div class="bottomItems">
-    <table class="hadith_reference"><tr>
-      <td><b>Reference</b></td>
-      <td>: <a href="/riyadussalihin:680">Riyad as-Salihin 680</a></td>
-    </tr></table>
+    <table class="hadith_reference">
+      <tr><td><b>Reference</b></td>
+        <td>: <a href="/riyadussalihin:680">Riyad as-Salihin 680</a></td></tr>
+      <tr><td>In-book reference</td><td>: Book 1, Hadith 5</td></tr>
+    </table>
   </div>
 </div>
 """
 
 
-class TestExtractHadithNumber:
-    """Regression coverage for da#72 — number extraction on current markup."""
+class TestExtractInBookRef:
+    """Regression coverage for da#72/da#77 — in-book ordinal on current markup."""
+
+    def test_extracts_book_and_in_book_ordinal(self) -> None:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(CURRENT_MARKUP_HADITH_HTML, "html.parser")
+        row = soup.select_one(".actualHadithContainer")
+        assert row is not None
+        # "In-book reference : Book 1, Hadith 5" -> (book=1, ordinal=5).
+        assert _extract_in_book_ref(row) == (1, 5)
+
+    def test_returns_none_pair_when_in_book_row_absent(self) -> None:
+        from bs4 import BeautifulSoup
+
+        html = """
+        <div class="actualHadithContainer">
+          <div class="english_hadith_full">English text</div>
+          <table class="hadith_reference"><tr>
+            <td><b>Reference</b></td>
+            <td>: <a href="/riyadussalihin:681">Riyad as-Salihin 681</a></td>
+          </tr></table>
+        </div>
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        row = soup.select_one(".actualHadithContainer")
+        assert row is not None
+        assert _extract_in_book_ref(row) == (None, None)
+
+
+class TestExtractCollectionRefNumber:
+    """The collection-wide ref is the source_id-keying fallback when no ordinal."""
 
     def test_extracts_from_sticky_reference_label(self) -> None:
         from bs4 import BeautifulSoup
@@ -216,8 +251,7 @@ class TestExtractHadithNumber:
         soup = BeautifulSoup(CURRENT_MARKUP_HADITH_HTML, "html.parser")
         row = soup.select_one(".actualHadithContainer")
         assert row is not None
-        # Primary path: the sticky "Riyad as-Salihin 680" label.
-        assert _extract_hadith_number(row) == 680
+        assert _extract_collection_ref_number(row) == 680
 
     def test_extracts_from_reference_link_href(self) -> None:
         from bs4 import BeautifulSoup
@@ -235,7 +269,7 @@ class TestExtractHadithNumber:
         soup = BeautifulSoup(html, "html.parser")
         row = soup.select_one(".actualHadithContainer")
         assert row is not None
-        assert _extract_hadith_number(row) == 681
+        assert _extract_collection_ref_number(row) == 681
 
     def test_legacy_span_still_supported(self) -> None:
         from bs4 import BeautifulSoup
@@ -250,9 +284,13 @@ class TestExtractHadithNumber:
         soup = BeautifulSoup(html, "html.parser")
         row = soup.select_one(".actualHadithContainer")
         assert row is not None
-        assert _extract_hadith_number(row) == 42
+        assert _extract_collection_ref_number(row) == 42
 
-    def test_full_record_has_non_null_number_on_current_markup(self) -> None:
+
+class TestExtractHadithFromRowCurrentMarkup:
+    """`hadith_number` carries the in-book ordinal; book parsed from the ref."""
+
+    def test_record_uses_in_book_ordinal(self) -> None:
         from bs4 import BeautifulSoup
 
         soup = BeautifulSoup(CURRENT_MARKUP_HADITH_HTML, "html.parser")
@@ -260,14 +298,35 @@ class TestExtractHadithNumber:
         assert row is not None
         record = _extract_hadith_from_row(row)
         assert record is not None
-        # The pre-fix bug: this was None for every row on the live site.
-        assert record["hadith_number"] == 680
+        # The pre-fix bug: hadith_number was None for every row on the live site.
+        # Now it is the IN-BOOK ordinal (5), not the collection-wide ref (680).
+        assert record["hadith_number"] == 5
+        assert record["book_number"] == 1
+
+    def test_falls_back_to_collection_ref_when_no_in_book_row(self) -> None:
+        from bs4 import BeautifulSoup
+
+        # No "In-book reference" row: hadith_number must still be non-null,
+        # using the collection-wide ref so source_id keying never collapses.
+        html = """
+        <div class="actualHadithContainer">
+          <div class="hadith_reference_sticky">Riyad as-Salihin 681</div>
+          <div class="english_hadith_full">English text</div>
+        </div>
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        row = soup.select_one(".actualHadithContainer")
+        assert row is not None
+        record = _extract_hadith_from_row(row)
+        assert record is not None
+        assert record["hadith_number"] == 681
+        assert record["book_number"] is None
 
 
 class TestRiyadussalihinFixture:
     """End-to-end selector guard over a saved current-markup fixture page."""
 
-    def test_numbers_parsed_and_source_ids_unique(self) -> None:
+    def test_in_book_ordinals_parsed_and_source_ids_unique(self) -> None:
         from bs4 import BeautifulSoup
 
         from src.parse.base import generate_source_id
@@ -280,16 +339,20 @@ class TestRiyadussalihinFixture:
         records = [rec for r in rows if (rec := _extract_hadith_from_row(r)) is not None]
         assert records, "fixture must yield parseable hadith records"
 
-        # Acceptance: a non-null number for every sampled hadith.
+        # Acceptance: a non-null number for every sampled hadith ...
         assert all(r["hadith_number"] is not None for r in records)
+        # ... and it is the in-book ordinal (1, 2, 3, ...), not the
+        # collection-wide ref (680, 681, ...).
+        assert [r["hadith_number"] for r in records] == list(range(1, len(records) + 1))
 
-        # Acceptance: source_id uniqueness holds. The collection-wide reference
-        # number alone keeps every record distinct, so dedup never merges them.
+        # Acceptance: source_id uniqueness holds. The in-book ordinal is unique
+        # within a book, so book+chapter+ordinal keeps every record distinct and
+        # dedup never merges them — even with chapter held constant here.
         source_ids = {
             generate_source_id(
                 "sunnah",
                 "riyadussalihin",
-                1,
+                r["book_number"] or 0,
                 1,
                 r["hadith_number"] or 0,
             )


### PR DESCRIPTION
## Summary

Fixes `sunnah_scraper` failing to extract `hadith_number` against sunnah.com's current layout (da#72), and routes the **in-book ordinal** into staging `hadith_number` so the downstream APPEARS_IN `hadith_number_in_book` edge prop is semantically correct (coordinated with da#77; folds in da#78, closed superseded).

### Background
Live riyadussalihin book 1 parsed **0/47** numbers (all `None`) because `_extract_hadith_from_row` used `.hadith_reference .hadith_num`, a selector the site no longer emits. With a missing number, `parse.sunnah_scraped` keys `source_id = sunnah:<coll>:<book>:<chapter>:<hadith_no|0>` on `:0`, collapsing uniqueness onto `chapter_number` — a chapter-grouped book then merges distinct hadiths at dedup.

### Semantic contract (da#77 / Oyunbileg's da#74-review catch)
`src/models/edges.py` documents `hadith_number_in_book` as "Hadith number within the book" (the IN-BOOK ordinal), and `load_edges.py` maps it straight from staging `hadith_number`. So `hadith_number` must carry the in-book ordinal (1, 2, …), not the collection-wide reference (680).

## Fix
The `table.hadith_reference` block carries both numbers:
```
Reference         : Riyad as-Salihin 680   (collection-wide)
In-book reference : Book 1, Hadith 1        (book + in-book ordinal)
```
- `_extract_in_book_ref` parses the in-book ordinal + book number from the "In-book reference" row → ordinal into `hadith_number`, book into `book_number`.
- `_extract_collection_ref_number` is the non-null fallback (sticky label / reference-link href / legacy `.hadith_num` span) used only when the in-book row is absent, so source_id keying always gets a per-collection-unique value.
- `_scrape_book_page` prefers the parsed book number, falling back to the page URL's book number.

The in-book ordinal is unique within a book, so `source_id = sunnah:<coll>:<book>:<chapter>:<ordinal>` stays collision-free.

## Tests
- `TestExtractInBookRef`, `TestExtractCollectionRefNumber`, `TestExtractHadithFromRowCurrentMarkup` — ordinal extraction, collection-ref fallback, and the full-record path on current markup.
- `TestRiyadussalihinFixture` — saved current-markup fixture (`tests/test_acquire/fixtures/riyadussalihin_book1_sample.html`) asserts the in-book ordinals (1, 2, 3, …) are parsed and that `source_id`s are unique.

17/17 scraper tests pass; 156/156 acquire+parse; ruff (pinned 0.15.11) format+lint and `mypy --strict` clean over `src/` and the test file. CI all 5 green on head `52ec39a`.

## Acceptance criteria
- [x] non-null `hadith_number` for the riyadussalihin sample (now the in-book ordinal)
- [x] no `source_id` collisions for a chapter-grouped sample (verified live, 47/47 unique)
- [x] regression test covering the selector against a saved fixture page

## Coordination
Changes the riyadussalihin sample's `source_id`s to `...:<in_book_ordinal>`. Kwesi (da#73) re-runs his loaded sample against this head at the wrapup rebase. da#77 (loader) needs no extra mapping once `hadith_number` holds the ordinal.

Closes #72

## TechDebt
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
