### PR TITLE
fix(graph/load_edges): null-safe APPEARS_IN MERGE + coalesce-preserve (#77)

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -272,15 +272,22 @@ def _load_narrated(
 # 3. APPEARS_IN — hadith -> collection
 # ---------------------------------------------------------------------------
 
+# Identity of an APPEARS_IN edge is the (hadith, collection) PAIR — a hadith
+# appears in a given collection at exactly one position, so the positional
+# values (book / chapter / hadith number) are *attributes* of that single edge,
+# not part of its key. They are therefore SET after the MERGE, never inside the
+# MERGE pattern (da#77): Neo4j refuses to MERGE a relationship with a null
+# property value, and the scraper leaves ``hadith_number`` null until da#72, so a
+# keyed-on-properties MERGE aborts the whole load on real scraped data. SET is
+# null-safe and keeps dedup correct (one APPEARS_IN per hadith->collection).
 _APPEARS_IN_QUERY = """\
 UNWIND $batch AS row
 MATCH (h:Hadith {id: row.hadith_id})
 MATCH (c:Collection {id: row.collection_id})
-MERGE (h)-[:APPEARS_IN {
-    book_number: row.book_number,
-    chapter_number: row.chapter_number,
-    hadith_number_in_book: row.hadith_number
-}]->(c)
+MERGE (h)-[r:APPEARS_IN]->(c)
+SET r.book_number = row.book_number,
+    r.chapter_number = row.chapter_number,
+    r.hadith_number_in_book = row.hadith_number
 """
 
 _APPEARS_IN_CHECK = """\

--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -278,16 +278,22 @@ def _load_narrated(
 # not part of its key. They are therefore SET after the MERGE, never inside the
 # MERGE pattern (da#77): Neo4j refuses to MERGE a relationship with a null
 # property value, and the scraper leaves ``hadith_number`` null until da#72, so a
-# keyed-on-properties MERGE aborts the whole load on real scraped data. SET is
-# null-safe and keeps dedup correct (one APPEARS_IN per hadith->collection).
+# keyed-on-properties MERGE aborts the whole load on real scraped data.
+#
+# The SET uses the streaming ingest path's coalesce-preserve contract
+# (ingest-platform ``workers/ingest/processor.py _build_edge_cypher``:
+# ``r.<f> = coalesce(row.<f>, r.<f>)``) so the two ingest paths converge byte-for-
+# byte on idempotency: a row with an explicit-null positional value preserves any
+# value already on the edge rather than clearing it. This keeps dedup correct
+# (one APPEARS_IN per hadith->collection) and is null-safe.
 _APPEARS_IN_QUERY = """\
 UNWIND $batch AS row
 MATCH (h:Hadith {id: row.hadith_id})
 MATCH (c:Collection {id: row.collection_id})
 MERGE (h)-[r:APPEARS_IN]->(c)
-SET r.book_number = row.book_number,
-    r.chapter_number = row.chapter_number,
-    r.hadith_number_in_book = row.hadith_number
+SET r.book_number = coalesce(row.book_number, r.book_number),
+    r.chapter_number = coalesce(row.chapter_number, r.chapter_number),
+    r.hadith_number_in_book = coalesce(row.hadith_number, r.hadith_number_in_book)
 """
 
 _APPEARS_IN_CHECK = """\

--- a/tests/integration/test_graph_loading.py
+++ b/tests/integration/test_graph_loading.py
@@ -453,6 +453,57 @@ class TestEdgeLoading:
             # ... and the pre-#68 ``hadith_number`` key MUST NOT linger.
             assert "hadith_number" not in row["keys"]
 
+    def test_appears_in_edges_load_with_null_hadith_number(
+        self, neo4j_client: Neo4jClient, tmp_path: Path
+    ) -> None:
+        """da#77 regression: a null ``hadith_number`` must NOT abort the load.
+
+        Scraped hadiths carry null ``hadith_number`` until da#72. The previous
+        ``MERGE (h)-[:APPEARS_IN {hadith_number_in_book: row.hadith_number}]->(c)``
+        aborted the whole edge stage with a Neo4j null-property error. The fix
+        SETs the positional props after the MERGE, so the edge is created with a
+        null ``hadith_number_in_book`` instead of erroring. Runs against a real
+        Neo4j — the mock load suite cannot enforce the MERGE-null rule.
+        """
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        curated = tmp_path / "curated"
+        curated.mkdir()
+
+        null_hadith = dict(SAMPLE_HADITHS[0])
+        null_hadith["source_id"] = "bukhari:nullnum"
+        null_hadith["hadith_number"] = None  # the da#77 trigger
+        _write_hadiths_parquet(staging, [null_hadith])
+        # Self-contained collection: the edge loader derives the target id as
+        # ``col:{source_corpus}:{collection_name}`` = ``col:sunnah:bukhari``, so
+        # the Collection node id must be the corpus-qualified ``sunnah:bukhari``
+        # for the endpoints to match (independent of the shared fixture).
+        null_collection = {
+            "collection_id": "sunnah:bukhari",
+            "name_en": "Sahih al-Bukhari",
+            "sect": "sunni",
+            "source_corpus": "sunnah",
+        }
+        _write_collections_parquet(staging, [null_collection])
+
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+        edge_results = load_all_edges(neo4j_client, staging, curated, strict=False)
+
+        appears_in = next(r for r in edge_results if r.edge_type == "APPEARS_IN")
+        # The edge is created (no abort) ...
+        assert appears_in.created == 1
+        rows = neo4j_client.execute_read(
+            "MATCH ()-[r:APPEARS_IN]->() RETURN r.hadith_number_in_book AS num, keys(r) AS keys"
+        )
+        assert len(rows) == 1
+        # ... and reads back with a null hadith_number_in_book instead of failing
+        # the MERGE. Neo4j does not persist a property SET to null, so the key is
+        # simply absent from keys(r) — the point is the load SUCCEEDED.
+        assert rows[0]["num"] is None
+        assert "hadith_number_in_book" not in rows[0]["keys"]
+        # The non-null positional props are still stored.
+        assert "book_number" in rows[0]["keys"]
+
     def test_graded_by_edges(self, neo4j_client: Neo4jClient, tmp_path: Path) -> None:
         staging, curated = _write_staging_data(tmp_path)
         load_all_nodes(neo4j_client, staging, curated, strict=False)

--- a/tests/integration/test_graph_loading.py
+++ b/tests/integration/test_graph_loading.py
@@ -101,6 +101,14 @@ SAMPLE_NARRATORS = [
     },
 ]
 
+# NOTE (da#77): every hadith here carries a NON-null hadith_number on purpose.
+# The APPEARS_IN loader SETs hadith_number_in_book = coalesce(row.hadith_number,
+# …), and Neo4j drops a property SET to null — so an edge built from a null
+# hadith_number has NO hadith_number_in_book key (absent, not present-null). If a
+# null-hadith_number row is ever added here, any per-edge
+# ``"hadith_number_in_book" in keys(r)`` assertion (e.g. #74's read-back) will
+# fail for that row. The null path is covered separately by
+# ``test_appears_in_edges_load_with_null_hadith_number``.
 SAMPLE_HADITHS = [
     {
         "source_id": "bukhari:1",

--- a/tests/integration/test_graph_loading.py
+++ b/tests/integration/test_graph_loading.py
@@ -101,14 +101,6 @@ SAMPLE_NARRATORS = [
     },
 ]
 
-# NOTE (da#77): every hadith here carries a NON-null hadith_number on purpose.
-# The APPEARS_IN loader SETs hadith_number_in_book = coalesce(row.hadith_number,
-# …), and Neo4j drops a property SET to null — so an edge built from a null
-# hadith_number has NO hadith_number_in_book key (absent, not present-null). If a
-# null-hadith_number row is ever added here, any per-edge
-# ``"hadith_number_in_book" in keys(r)`` assertion (e.g. #74's read-back) will
-# fail for that row. The null path is covered separately by
-# ``test_appears_in_edges_load_with_null_hadith_number``.
 SAMPLE_HADITHS = [
     {
         "source_id": "bukhari:1",

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -207,9 +207,12 @@ class TestLoadAppearsIn:
         # The APPEARS_IN edge property MUST be the ig#935-canonical
         # ``hadith_number_in_book`` mapped from ``row.hadith_number`` (matches
         # AppearsIn model + isnad-graph src/models/edges.py), NOT the legacy bare
-        # ``hadith_number`` (da#65). Post-da#77 it is SET after the MERGE, not a
-        # MERGE-key property, so assert the SET form.
-        assert "r.hadith_number_in_book = row.hadith_number" in _APPEARS_IN_QUERY
+        # ``hadith_number`` (da#65). Post-da#77 it is SET after the MERGE with the
+        # streaming path's coalesce-preserve contract, so assert that SET form.
+        assert (
+            "r.hadith_number_in_book = coalesce(row.hadith_number, r.hadith_number_in_book)"
+            in _APPEARS_IN_QUERY
+        )
         # The legacy bare ``hadith_number`` edge key must never appear.
         assert "hadith_number:" not in _APPEARS_IN_QUERY
 

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -205,10 +205,22 @@ class TestLoadAppearsIn:
 
     def test_appears_in_edge_uses_canonical_property_key(self) -> None:
         # The APPEARS_IN edge property MUST be the ig#935-canonical
-        # ``hadith_number_in_book`` (matches AppearsIn model + isnad-graph
-        # src/models/edges.py), NOT the legacy bare ``hadith_number`` (da#65).
-        assert "hadith_number_in_book: row.hadith_number" in _APPEARS_IN_QUERY
+        # ``hadith_number_in_book`` mapped from ``row.hadith_number`` (matches
+        # AppearsIn model + isnad-graph src/models/edges.py), NOT the legacy bare
+        # ``hadith_number`` (da#65). Post-da#77 it is SET after the MERGE, not a
+        # MERGE-key property, so assert the SET form.
+        assert "r.hadith_number_in_book = row.hadith_number" in _APPEARS_IN_QUERY
+        # The legacy bare ``hadith_number`` edge key must never appear.
         assert "hadith_number:" not in _APPEARS_IN_QUERY
+
+    def test_appears_in_merge_has_no_property_key_null_unsafe(self) -> None:
+        # da#77: positional props MUST be SET after the MERGE, never inside the
+        # MERGE relationship pattern — Neo4j aborts a MERGE on a null property,
+        # and scraped hadiths carry null ``hadith_number`` until da#72. Guard the
+        # MERGE line so the null-unsafe keyed form can't be reintroduced.
+        merge_line = next(line for line in _APPEARS_IN_QUERY.splitlines() if "MERGE (" in line)
+        assert merge_line.strip() == "MERGE (h)-[r:APPEARS_IN]->(c)"
+        assert "{" not in merge_line  # no inline property map on the MERGE pattern
 
     def test_missing_collection_name_skipped(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path


### PR DESCRIPTION
## Summary

The APPEARS_IN edge loader MERGEd the relationship with its positional properties **inside the MERGE pattern**, so Neo4j aborted the entire edge stage with a null-property error whenever `hadith_number` was null. The scraper leaves `hadith_number` null until da#72, so the real `isnad-ingest load` failed on all scraped data (surfaced by da#73's live staging load).

```text
neo4j.exceptions.ClientError: Cannot merge the following relationship because of
null property value for 'hadith_number_in_book': (h)-[:APPEARS_IN {…: null}]->(c)
```

## The fix

```cypher
MERGE (h)-[r:APPEARS_IN]->(c)
SET r.book_number          = coalesce(row.book_number, r.book_number),
    r.chapter_number       = coalesce(row.chapter_number, r.chapter_number),
    r.hadith_number_in_book = coalesce(row.hadith_number, r.hadith_number_in_book)
```

An APPEARS_IN edge's identity is the **(hadith, collection) pair** — a hadith appears in a collection at exactly one position — so the positional values are *attributes* of that single edge, not part of its key. `SET` after the MERGE is null-safe and keeps dedup correct (one APPEARS_IN per hadith→collection).

The `SET` uses the **streaming ingest path's coalesce-preserve contract** (`ingest-platform workers/ingest/processor.py _build_edge_cypher`: `r.<f> = coalesce(row.<f>, r.<f>)`), so the batch and streaming Parquet→Neo4j paths converge byte-for-byte on idempotency and null-handling — an explicit-null preserves any value already on the edge rather than clearing it.

## Contract-change note (for the two affected contracts)

- **Edge property NAME (`hadith_number_in_book`) and value source (`row.hadith_number`) are UNCHANGED.** Only the mechanism changes: MERGE-key → `SET` (coalesce-preserve). The `AppearsIn` model (`src/models/edges.py`) is untouched.
- **#74 (Oyunbileg)**: the unit string-contract test in `tests/test_graph/test_load_edges.py` moves to the SET form (`r.hadith_number_in_book = coalesce(row.hadith_number, r.hadith_number_in_book)`); the legacy bare `hadith_number:` guard stays. The #74 read-back integration test (key present + non-null on a non-null sample) re-runs **green unchanged** against a real Neo4j.
- **ig#62 / main#139 (Nikolaos)**: the batch path now produces the same APPEARS_IN edge contract the streaming path already asserts — no harness change needed for this PR.

## Out of scope — folded decision, deferred to da#78

The semantic question Oyunbileg raised (the staging `hadith_number` will hold the **collection-wide reference** number, e.g. 680, not the in-book ordinal) is decided here: `hadith_number_in_book` must carry the genuine **in-book ordinal**; the collection-wide ref stays in `source_id` only. This PR ships correct **structure** — the prop maps from `row.hadith_number` and is simply null until the scraper provides the in-book ordinal (null-safe handles it; a correct-null beats a wrong-value). The scraper/schema half is **da#78** (parser lane), a fast-follow — not folded here.

## Test plan

- [x] New real-Neo4j regression test: a null `hadith_number` now **creates** the APPEARS_IN edge (was aborting) instead of failing the MERGE.
- [x] Unit guard that the MERGE line carries no inline property map (the null-unsafe form can't be reintroduced).
- [x] Live Neo4j: coalesce-preserve verified — set `hadith_number_in_book=5`, re-load the same edge with null → value preserved (5), single edge.
- [x] `TestEdgeLoading` (3) + `test_load_edges.py` (19) pass against a real Neo4j; full non-integration suite 525 passed; ruff + `mypy src/` clean; sync-drift gate OK.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
