### PR TITLE
da#82 (T0-A): collision-safe canonical source_id scheme

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -15,6 +15,12 @@ from typing import Any
 
 import pyarrow.parquet as pq
 
+from src.parse.identity import (
+    collection_node_id,
+    grading_node_id,
+    hadith_node_id,
+    narrator_node_id,
+)
 from src.utils.logging import get_logger
 from src.utils.neo4j_client import Neo4jClient
 
@@ -242,7 +248,7 @@ def _load_narrated(
 
     batch: list[dict[str, Any]] = []
     for hid, (_pos, nid) in first_narrators.items():
-        full_hid = f"hdt:{hid}" if not hid.startswith("hdt:") else hid
+        full_hid = hadith_node_id(hid)
         batch.append({"narrator_id": nid, "hadith_id": full_hid})
 
     if not batch:
@@ -334,12 +340,12 @@ def _load_appears_in(
             if not sid or not cname:
                 skipped += 1
                 continue
-            hid = f"hdt:{sid}" if not sid.startswith("hdt:") else sid
+            hid = hadith_node_id(sid)
             # Collection IDs in staging use "{corpus}:{name}" format (e.g. "lk:bukhari").
             # Build the same key so we match the Collection nodes that were loaded.
             corpus = row.get("source_corpus", "")
             raw_cid = f"{corpus}:{cname}" if corpus else cname
-            cid = f"col:{raw_cid}" if not raw_cid.startswith("col:") else raw_cid
+            cid = collection_node_id(raw_cid)
             batch.append(
                 {
                     "hadith_id": hid,
@@ -426,8 +432,8 @@ def _load_parallel_of(
             skipped += 1
             continue
         # Ensure lower ID -> higher ID for consistent directionality
-        full_a = f"hdt:{id_a}" if not id_a.startswith("hdt:") else id_a
-        full_b = f"hdt:{id_b}" if not id_b.startswith("hdt:") else id_b
+        full_a = hadith_node_id(id_a)
+        full_b = hadith_node_id(id_b)
         if full_a > full_b:
             full_a, full_b = full_b, full_a
         batch.append(
@@ -511,8 +517,8 @@ def _load_studied_under(
             skipped += 1
             continue
         # Ensure narrator prefix
-        full_from = f"nar:{from_id}" if not from_id.startswith("nar:") else from_id
-        full_to = f"nar:{to_id}" if not to_id.startswith("nar:") else to_id
+        full_from = narrator_node_id(from_id)
+        full_to = narrator_node_id(to_id)
         batch.append({"from_id": full_from, "to_id": full_to})
 
     if not batch:
@@ -588,8 +594,8 @@ def _load_graded_by(
             if not sid:
                 skipped += 1
                 continue
-            hid = f"hdt:{sid}" if not sid.startswith("hdt:") else sid
-            gid = f"grd:{sid}"
+            hid = hadith_node_id(sid)
+            gid = grading_node_id(sid)
             batch.append({"hadith_id": hid, "grading_id": gid})
 
     if not batch:

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -15,6 +15,12 @@ from typing import Any
 import pyarrow.parquet as pq
 import yaml
 
+from src.parse.identity import (
+    chain_node_id,
+    collection_node_id,
+    grading_node_id,
+    hadith_node_id,
+)
 from src.utils.logging import get_logger
 from src.utils.neo4j_client import Neo4jClient
 
@@ -192,7 +198,7 @@ def _load_hadiths(
                 all_errors.append(f"{fp.name} row {i}: invalid source_id={sid!r}")
                 total_skipped += 1
                 continue
-            hid = f"hdt:{sid}" if not sid.startswith("hdt:") else sid
+            hid = hadith_node_id(sid)
             batch.append(
                 {
                     "id": hid,
@@ -272,7 +278,7 @@ def _load_collections(
                 all_errors.append(f"{fp.name} row {i}: invalid collection_id={cid!r}")
                 total_skipped += 1
                 continue
-            full_id = f"col:{cid}" if not cid.startswith("col:") else cid
+            full_id = collection_node_id(cid)
             batch.append(
                 {
                     "id": full_id,
@@ -357,7 +363,7 @@ def _load_chains(
     skipped = 0
 
     for hid, mentions in seen_hadiths.items():
-        chn_id = f"chn:{hid}-0" if not hid.startswith("chn:") else hid
+        chn_id = chain_node_id(hid, 0)
         narrator_ids = []
         for m in sorted(mentions, key=lambda r: r.get("position_in_chain", 0)):
             nid = m.get("canonical_narrator_id")
@@ -366,7 +372,7 @@ def _load_chains(
         batch.append(
             {
                 "id": chn_id,
-                "hadith_id": f"hdt:{hid}" if not hid.startswith("hdt:") else hid,
+                "hadith_id": hadith_node_id(hid),
                 "chain_index": 0,
                 "full_chain_text_ar": None,
                 "full_chain_text_en": None,
@@ -435,11 +441,11 @@ def _load_gradings(
                 errors.append(f"{fp.name} row {i}: grade present but no source_id")
                 skipped += 1
                 continue
-            gid = f"grd:{sid}"
+            gid = grading_node_id(sid)
             batch.append(
                 {
                     "id": gid,
-                    "hadith_id": f"hdt:{sid}" if not sid.startswith("hdt:") else sid,
+                    "hadith_id": hadith_node_id(sid),
                     "scholar_name": _val(row, "collection_name", "unknown"),
                     "grade": grade,
                     "methodology_school": None,

--- a/src/parse/base.py
+++ b/src/parse/base.py
@@ -9,6 +9,7 @@ import pyarrow as pa
 import pyarrow.csv as pcsv
 import pyarrow.parquet as pq
 
+from src.parse.identity import ID_DELIMITER, SOURCE_CORPORA
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -63,12 +64,23 @@ def read_csv_robust(path: Path, encoding: str = "utf-8", **kwargs: Any) -> tuple
 
 
 def generate_source_id(corpus: str, collection: str, *parts: int | str) -> str:
-    """Generate deterministic source_id.
+    """Generate a deterministic, corpus-namespaced ``source_id``.
 
     Example: ``generate_source_id("lk", "bukhari", 1, 1)`` -> ``"lk:bukhari:1:1"``
+
+    *corpus* MUST be a known source corpus (:data:`identity.SOURCE_CORPORA`); an
+    unknown corpus is a collision hazard (ids only stay unique across sources
+    because the corpus namespaces them), so it fails fast. The canonical grammar
+    and the graph node-id rules live in :mod:`src.parse.identity`.
     """
+    if corpus not in SOURCE_CORPORA:
+        msg = (
+            f"unknown source corpus {corpus!r}; source_id must be namespaced by a "
+            f"known corpus (one of {sorted(SOURCE_CORPORA)}) to stay collision-safe"
+        )
+        raise ValueError(msg)
     segments = [corpus, collection, *[str(p) for p in parts]]
-    return ":".join(segments)
+    return ID_DELIMITER.join(segments)
 
 
 def safe_int(value: Any) -> int | None:

--- a/src/parse/identity.py
+++ b/src/parse/identity.py
@@ -1,0 +1,212 @@
+"""Canonical entity-identity contract for the ingest pipeline.
+
+This module is the **single source of truth** for how a ``source_id`` and every
+graph node id is constructed, across *all* ingest paths (the batch
+``src/graph`` loaders here, and the streaming/normalize path in
+``noorinalabs-isnad-ingest-platform``). It is the keystone for da#82 / epic
+da#81: every per-source light-up builds to the grammar defined here.
+
+Grammar
+-------
+``source_id`` (staging key, ``HADITH_SCHEMA.source_id``)::
+
+    <corpus>:<collection>[:<part>...]
+
+* ``<corpus>``     one of :data:`SOURCE_CORPORA` (the ``SourceCorpus`` enum) —
+  the namespace that makes ids collision-safe across sources.
+* ``<collection>`` per-corpus collection slug (e.g. ``"bukhari"``).
+* ``<part>...``    positional disambiguators (``book:chapter:ordinal``, or a
+  per-row index for dataset sources). The corpus appears **exactly once**, as
+  the leading segment.
+
+Graph node ids = ``<type-prefix><bare-id>``::
+
+    Hadith         hdt:<source_id>
+    Collection     col:<corpus>:<collection>
+    Narrator       nar:<canonical-id>
+    Chain          chn:<source_id>-<index>
+    Grading        grd:<source_id>
+
+Two historical identity hazards this module designs out
+-------------------------------------------------------
+1. **Double-prefix** (main#139): the streaming/normalize path prepended the
+   corpus a second time (``hdt:sunnah:sunnah:...``) while the batch loader did
+   not, so the *same* hadith became two graph nodes (toy ``h-1`` fixtures masked
+   it). :func:`hadith_node_id` is the ONE prefixing rule both paths call: it is
+   idempotent on the ``hdt:`` prefix **and** collapses an accidentally doubled
+   leading corpus, so both paths converge on exactly one id per hadith.
+2. **collection-ref vs in-book-ordinal** (da#77): ``source_id``'s positional
+   tail is a stable within-collection key. The *in-book ordinal* that flows to
+   ``APPEARS_IN.hadith_number_in_book`` is the staging ``hadith_number`` column —
+   **not** the collection-wide reference number (sunnah.com exposes both). See
+   ``HADITH_SCHEMA`` and ``src/graph/load_edges.py`` ``_APPEARS_IN_QUERY``.
+"""
+
+from __future__ import annotations
+
+from src.models.enums import SourceCorpus
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "SOURCE_CORPORA",
+    "HADITH_ID_PREFIX",
+    "COLLECTION_ID_PREFIX",
+    "NARRATOR_ID_PREFIX",
+    "CHAIN_ID_PREFIX",
+    "GRADING_ID_PREFIX",
+    "ID_DELIMITER",
+    "apply_prefix",
+    "bare_source_id",
+    "hadith_node_id",
+    "collection_node_id",
+    "narrator_node_id",
+    "chain_node_id",
+    "grading_node_id",
+    "is_double_prefixed",
+    "validate_source_id",
+]
+
+# The corpus namespace — derived from the enum so the two never drift. Note that
+# ``sunnah_scraped`` intentionally shares the ``sunnah`` corpus (the scraper and
+# the API describe the same collections, so a shared namespace lets the same
+# hadith dedup to one node).
+SOURCE_CORPORA: frozenset[str] = frozenset(c.value for c in SourceCorpus)
+
+ID_DELIMITER = ":"
+
+HADITH_ID_PREFIX = "hdt:"
+COLLECTION_ID_PREFIX = "col:"
+NARRATOR_ID_PREFIX = "nar:"
+CHAIN_ID_PREFIX = "chn:"
+GRADING_ID_PREFIX = "grd:"
+
+# Every graph type-prefix, longest-first so a stripping pass is unambiguous.
+_TYPE_PREFIXES = (
+    HADITH_ID_PREFIX,
+    COLLECTION_ID_PREFIX,
+    NARRATOR_ID_PREFIX,
+    CHAIN_ID_PREFIX,
+    GRADING_ID_PREFIX,
+)
+
+
+def apply_prefix(value: str, prefix: str) -> str:
+    """Idempotently prepend *prefix* to *value*.
+
+    Replaces the ``f"{p}{v}" if not v.startswith(p) else v`` idiom that was
+    duplicated across every loader. Idempotent: applying the same prefix twice
+    yields the same string.
+    """
+    return value if value.startswith(prefix) else f"{prefix}{value}"
+
+
+def _collapse_double_corpus(body: str) -> str:
+    """Collapse a doubled (or N-times repeated) leading corpus segment.
+
+    ``"sunnah:sunnah:bukhari:1"`` -> ``"sunnah:bukhari:1"``. Only collapses when
+    the repeated leading segment is a *known* corpus, so legitimate repeated
+    slugs deeper in an id (or a non-corpus first segment) are never touched.
+    Emits a warning when it collapses — a collapse means an upstream producer
+    bypassed the canonical builder (the main#139 streaming-path bug), which the
+    operator should still see.
+    """
+    segments = body.split(ID_DELIMITER)
+    collapsed = 0
+    while len(segments) >= 2 and segments[0] in SOURCE_CORPORA and segments[0] == segments[1]:
+        segments.pop(0)
+        collapsed += 1
+    if collapsed:
+        logger.warning(
+            "collapsed_double_corpus_prefix",
+            original=body,
+            canonical=ID_DELIMITER.join(segments),
+            collapsed_segments=collapsed,
+        )
+    return ID_DELIMITER.join(segments)
+
+
+def bare_source_id(value: str) -> str:
+    """Return the canonical *bare* ``source_id`` for *value*.
+
+    Strips a leading ``hdt:`` graph prefix if present, then collapses any
+    doubled leading corpus. This is the single canonicalization point shared by
+    :func:`hadith_node_id`, :func:`chain_node_id` and :func:`grading_node_id`,
+    so every hadith-derived id agrees on one identity for a given hadith.
+    """
+    body = value[len(HADITH_ID_PREFIX) :] if value.startswith(HADITH_ID_PREFIX) else value
+    return _collapse_double_corpus(body)
+
+
+def hadith_node_id(source_id: str) -> str:
+    """Canonical Hadith graph node id for a staging ``source_id``.
+
+    THE one prefixing rule for Hadith nodes — every ingest path (batch loaders,
+    streaming normalize) must route through this so the same hadith yields
+    exactly one node id. Idempotent, and collapses the main#139 double-prefix.
+    """
+    return f"{HADITH_ID_PREFIX}{bare_source_id(source_id)}"
+
+
+def collection_node_id(collection_id: str) -> str:
+    """Canonical Collection graph node id (``col:<corpus>:<collection>``)."""
+    return apply_prefix(collection_id, COLLECTION_ID_PREFIX)
+
+
+def narrator_node_id(canonical_id: str) -> str:
+    """Canonical Narrator graph node id (``nar:<canonical-id>``)."""
+    return apply_prefix(canonical_id, NARRATOR_ID_PREFIX)
+
+
+def chain_node_id(source_id: str, index: int = 0) -> str:
+    """Canonical Chain graph node id (``chn:<source_id>-<index>``)."""
+    if source_id.startswith(CHAIN_ID_PREFIX):
+        return source_id
+    return f"{CHAIN_ID_PREFIX}{bare_source_id(source_id)}-{index}"
+
+
+def grading_node_id(source_id: str) -> str:
+    """Canonical Grading graph node id (``grd:<source_id>``)."""
+    return f"{GRADING_ID_PREFIX}{bare_source_id(source_id)}"
+
+
+def is_double_prefixed(node_id: str) -> bool:
+    """True if *node_id* carries a doubled leading corpus (the main#139 bug).
+
+    Strict detector for tests / CI — unlike :func:`bare_source_id` it does not
+    repair, it only reports, so a guard can fail loudly on a producer that
+    emits doubled ids.
+    """
+    body = node_id
+    for prefix in _TYPE_PREFIXES:
+        if body.startswith(prefix):
+            body = body[len(prefix) :]
+            break
+    segments = body.split(ID_DELIMITER)
+    return len(segments) >= 2 and segments[0] in SOURCE_CORPORA and segments[0] == segments[1]
+
+
+def validate_source_id(source_id: str) -> list[str]:
+    """Return a list of contract violations for *source_id* (empty == valid).
+
+    Checks the grammar: a known leading corpus, at least a collection segment,
+    no empty segments, and no doubled leading corpus. Used by the builder and by
+    tests to assert collision-safety across all 8 sources.
+    """
+    problems: list[str] = []
+    if not source_id:
+        return ["source_id is empty"]
+    segments = source_id.split(ID_DELIMITER)
+    if segments[0] not in SOURCE_CORPORA:
+        problems.append(
+            f"leading segment {segments[0]!r} is not a known corpus "
+            f"(expected one of {sorted(SOURCE_CORPORA)})"
+        )
+    if len(segments) < 2:
+        problems.append("source_id has no collection segment")
+    if any(seg == "" for seg in segments):
+        problems.append("source_id has an empty segment")
+    if is_double_prefixed(source_id):
+        problems.append(f"source_id has a doubled leading corpus: {source_id!r}")
+    return problems

--- a/src/parse/schemas.py
+++ b/src/parse/schemas.py
@@ -17,6 +17,11 @@ __all__ = [
     "NETWORK_EDGE_SCHEMA",
 ]
 
+# ``source_id`` grammar and the graph node-id rules derived from it are the
+# canonical identity contract — see :mod:`src.parse.identity` (``<corpus>:
+# <collection>[:<part>...]``, corpus exactly once). ``hadith_number`` is the
+# IN-BOOK ordinal that flows to ``APPEARS_IN.hadith_number_in_book`` (da#77) —
+# NOT the collection-wide reference number.
 HADITH_SCHEMA = pa.schema(
     [
         pa.field("source_id", pa.string(), nullable=False),

--- a/tests/integration/test_source_id_collision.py
+++ b/tests/integration/test_source_id_collision.py
@@ -1,0 +1,129 @@
+"""Live-Neo4j collision-safety proof for the canonical source_id scheme (da#82).
+
+These exercise the REAL batch loaders against a live ``neo4j:5`` container and
+assert the two identity guarantees the keystone owes:
+
+1. **One node per hadith** — the same logical hadith arriving via the batch shape
+   (``sunnah:bukhari:...``) and the main#139 streaming-bug shape
+   (``sunnah:sunnah:bukhari:...``) collapses to exactly one Hadith node, not two.
+2. **In-book ordinal on the edge** — ``APPEARS_IN.hadith_number_in_book`` carries
+   the staging ``hadith_number`` (the in-book ordinal), per da#77.
+
+Requires Docker; the ``neo4j_client`` fixture ``pytest.skip``s when Docker is
+unreachable (see ``tests/integration/conftest.py``), so this degrades to a clean
+SKIP off-CI rather than a red ERROR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.graph.load_edges import load_all_edges
+from src.graph.load_nodes import load_all_nodes
+from src.parse.identity import hadith_node_id
+from tests.test_graph.conftest import write_collections, write_hadiths
+
+
+@pytest.fixture
+def staging(tmp_path: Path) -> Path:
+    d = tmp_path / "staging"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def curated(tmp_path: Path) -> Path:
+    d = tmp_path / "curated"
+    d.mkdir()
+    return d
+
+
+@pytest.mark.integration
+class TestSourceIdCollisionLive:
+    def test_double_prefix_collapses_to_one_node(
+        self, neo4j_client, staging: Path, curated: Path
+    ) -> None:
+        """Batch + streaming-bug shapes of the SAME hadith -> one Hadith node."""
+        coords = {
+            "collection_name": "bukhari",
+            "source_corpus": "sunnah",
+            "book_number": 1,
+            "chapter_number": 1,
+            "hadith_number": 1,
+            "matn_en": "the prophet said",
+        }
+        # Batch loader shape: corpus appears once.
+        write_hadiths(staging, [{"source_id": "sunnah:bukhari:1:1:1", **coords}], suffix="batch")
+        # Streaming/normalize bug shape: corpus doubled (main#139).
+        write_hadiths(
+            staging,
+            [{"source_id": "sunnah:sunnah:bukhari:1:1:1", **coords}],
+            suffix="streaming",
+        )
+
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+
+        rows = neo4j_client.execute_read("MATCH (h:Hadith) RETURN count(h) AS n")
+        assert rows[0]["n"] == 1, "double-prefix produced two nodes — collision NOT prevented"
+
+        id_rows = neo4j_client.execute_read("MATCH (h:Hadith) RETURN h.id AS id")
+        assert (
+            id_rows[0]["id"] == hadith_node_id("sunnah:bukhari:1:1:1") == "hdt:sunnah:bukhari:1:1:1"
+        )
+
+    def test_idempotent_reload(self, neo4j_client, staging: Path, curated: Path) -> None:
+        """Re-running the load does not create a second node (MERGE idempotency)."""
+        write_hadiths(
+            staging,
+            [{"source_id": "lk:bukhari:1:1", "collection_name": "bukhari", "source_corpus": "lk"}],
+            suffix="batch",
+        )
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+        rows = neo4j_client.execute_read("MATCH (h:Hadith) RETURN count(h) AS n")
+        assert rows[0]["n"] == 1
+
+    def test_in_book_ordinal_on_appears_in_edge(
+        self, neo4j_client, staging: Path, curated: Path
+    ) -> None:
+        """APPEARS_IN.hadith_number_in_book carries the in-book ordinal (da#77)."""
+        # in-book ordinal (7) is distinct from book_number (1) so a conflation is
+        # observable on the edge property.
+        write_hadiths(
+            staging,
+            [
+                {
+                    "source_id": "sunnah:bukhari:1:2:7",
+                    "collection_name": "bukhari",
+                    "source_corpus": "sunnah",
+                    "book_number": 1,
+                    "chapter_number": 2,
+                    "hadith_number": 7,
+                }
+            ],
+            suffix="batch",
+        )
+        write_collections(
+            staging,
+            [
+                {
+                    "collection_id": "sunnah:bukhari",
+                    "name_en": "Sahih al-Bukhari",
+                    "source_corpus": "sunnah",
+                }
+            ],
+            suffix="batch",
+        )
+
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+        load_all_edges(neo4j_client, staging, curated, strict=False)
+
+        rows = neo4j_client.execute_read(
+            "MATCH (:Hadith)-[r:APPEARS_IN]->(:Collection) "
+            "RETURN r.hadith_number_in_book AS ordinal, r.book_number AS book"
+        )
+        assert len(rows) == 1
+        assert rows[0]["ordinal"] == 7
+        assert rows[0]["book"] == 1

--- a/tests/test_parse/test_identity.py
+++ b/tests/test_parse/test_identity.py
@@ -1,0 +1,167 @@
+"""Tests for the canonical entity-identity contract (da#82).
+
+These lock the two historical identity hazards out:
+1. double-prefix (``hdt:sunnah:sunnah:...``) — both ingest paths must converge
+   on one id per hadith.
+2. cross-source collision-safety — ids are corpus-namespaced and unique across
+   all sources.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models.enums import SourceCorpus
+from src.parse.base import generate_source_id
+from src.parse.identity import (
+    SOURCE_CORPORA,
+    bare_source_id,
+    chain_node_id,
+    collection_node_id,
+    grading_node_id,
+    hadith_node_id,
+    is_double_prefixed,
+    narrator_node_id,
+    validate_source_id,
+)
+
+
+class TestSourceCorpora:
+    def test_corpora_derived_from_enum(self) -> None:
+        # Single source of truth — never drifts from the enum.
+        assert SOURCE_CORPORA == {c.value for c in SourceCorpus}
+
+    def test_known_corpora_present(self) -> None:
+        for corpus in ("lk", "sanadset", "thaqalayn", "sunnah", "fawaz"):
+            assert corpus in SOURCE_CORPORA
+
+
+class TestGenerateSourceId:
+    def test_basic_format(self) -> None:
+        assert generate_source_id("lk", "bukhari", 1, 1) == "lk:bukhari:1:1"
+
+    def test_collection_only(self) -> None:
+        assert generate_source_id("sunnah", "bukhari") == "sunnah:bukhari"
+
+    def test_unknown_corpus_raises(self) -> None:
+        # An unknown corpus is a collision hazard — fail fast.
+        with pytest.raises(ValueError, match="unknown source corpus"):
+            generate_source_id("notacorpus", "bukhari", 1)
+
+    def test_every_enum_corpus_accepted(self) -> None:
+        for corpus in SOURCE_CORPORA:
+            assert generate_source_id(corpus, "coll", 1).startswith(f"{corpus}:")
+
+
+class TestHadithNodeId:
+    def test_adds_single_prefix(self) -> None:
+        assert hadith_node_id("sunnah:bukhari:1:1:1") == "hdt:sunnah:bukhari:1:1:1"
+
+    def test_idempotent_on_hdt_prefix(self) -> None:
+        once = hadith_node_id("sunnah:bukhari:1:1:1")
+        assert hadith_node_id(once) == once
+
+    def test_collapses_doubled_corpus_bare(self) -> None:
+        # The main#139 streaming-path shape, pre-``hdt:``.
+        assert hadith_node_id("sunnah:sunnah:bukhari:1:1:1") == "hdt:sunnah:bukhari:1:1:1"
+
+    def test_collapses_doubled_corpus_with_prefix(self) -> None:
+        assert hadith_node_id("hdt:sunnah:sunnah:bukhari:1:1:1") == "hdt:sunnah:bukhari:1:1:1"
+
+    def test_collapses_triple_corpus(self) -> None:
+        assert hadith_node_id("sunnah:sunnah:sunnah:bukhari:1") == "hdt:sunnah:bukhari:1"
+
+    def test_does_not_collapse_legit_repeat_deeper(self) -> None:
+        # A repeated *non-leading* segment that is not a doubled corpus is kept.
+        assert hadith_node_id("lk:bukhari:1:1") == "hdt:lk:bukhari:1:1"
+
+    def test_does_not_collapse_non_corpus_lead(self) -> None:
+        # If the leading segment is not a known corpus, never collapse.
+        assert hadith_node_id("h-1:h-1:x") == "hdt:h-1:h-1:x"
+
+
+class TestBatchVsStreamingConverge:
+    """The keystone guarantee: the same hadith -> exactly one node id."""
+
+    def test_two_paths_same_id(self) -> None:
+        source_id = generate_source_id("sunnah", "bukhari", 1, 1, 1)
+        # Batch loader shape: hdt: + source_id (corpus once).
+        batch_id = hadith_node_id(source_id)
+        # Streaming/normalize bug shape: corpus re-injected before prefixing.
+        streaming_buggy = f"{SourceCorpus.SUNNAH.value}:{source_id}"
+        streaming_id = hadith_node_id(streaming_buggy)
+        assert batch_id == streaming_id
+
+    def test_naive_concat_would_diverge(self) -> None:
+        # Proves the helper is load-bearing: naive prefixing yields TWO ids.
+        source_id = "sunnah:bukhari:1:1:1"
+        naive_batch = f"hdt:{source_id}"
+        naive_streaming = f"hdt:{SourceCorpus.SUNNAH.value}:{source_id}"
+        assert naive_batch != naive_streaming
+        # ...but routed through the canonical helper they converge.
+        assert hadith_node_id(naive_batch) == hadith_node_id(naive_streaming)
+
+
+class TestOtherNodeIds:
+    def test_collection_node_id(self) -> None:
+        assert collection_node_id("sunnah:bukhari") == "col:sunnah:bukhari"
+        assert collection_node_id("col:sunnah:bukhari") == "col:sunnah:bukhari"
+
+    def test_narrator_node_id(self) -> None:
+        assert narrator_node_id("abu-hurayra-001") == "nar:abu-hurayra-001"
+        assert narrator_node_id("nar:abu-hurayra-001") == "nar:abu-hurayra-001"
+
+    def test_chain_node_id(self) -> None:
+        assert chain_node_id("sunnah:bukhari:1:1:1", 0) == "chn:sunnah:bukhari:1:1:1-0"
+        assert chain_node_id("hdt:sunnah:bukhari:1:1:1", 2) == "chn:sunnah:bukhari:1:1:1-2"
+        assert chain_node_id("chn:already-0") == "chn:already-0"
+
+    def test_grading_node_id(self) -> None:
+        assert grading_node_id("lk:bukhari:1:1") == "grd:lk:bukhari:1:1"
+        # Grading and Hadith id derive from the SAME bare source_id.
+        assert grading_node_id("hdt:lk:bukhari:1:1") == "grd:lk:bukhari:1:1"
+
+    def test_bare_source_id(self) -> None:
+        assert bare_source_id("hdt:sunnah:bukhari:1") == "sunnah:bukhari:1"
+        assert bare_source_id("sunnah:sunnah:bukhari:1") == "sunnah:bukhari:1"
+
+
+class TestCrossSourceCollisionSafety:
+    def test_same_coords_distinct_per_corpus(self) -> None:
+        # Same collection/book/chapter/num in every corpus -> distinct ids.
+        ids = {hadith_node_id(generate_source_id(c, "bukhari", 1, 1, 1)) for c in SOURCE_CORPORA}
+        assert len(ids) == len(SOURCE_CORPORA)
+
+
+class TestIsDoublePrefixed:
+    def test_detects_doubled(self) -> None:
+        assert is_double_prefixed("hdt:sunnah:sunnah:bukhari:1")
+        assert is_double_prefixed("sunnah:sunnah:bukhari:1")
+
+    def test_clean_is_not_flagged(self) -> None:
+        assert not is_double_prefixed("hdt:sunnah:bukhari:1")
+        assert not is_double_prefixed("hdt:lk:bukhari:1:1")
+
+
+class TestValidateSourceId:
+    def test_valid(self) -> None:
+        assert validate_source_id("sunnah:bukhari:1:1:1") == []
+
+    def test_empty(self) -> None:
+        assert validate_source_id("") == ["source_id is empty"]
+
+    def test_unknown_corpus(self) -> None:
+        problems = validate_source_id("xyz:bukhari:1")
+        assert any("not a known corpus" in p for p in problems)
+
+    def test_no_collection_segment(self) -> None:
+        problems = validate_source_id("sunnah")
+        assert any("no collection segment" in p for p in problems)
+
+    def test_doubled_corpus_flagged(self) -> None:
+        problems = validate_source_id("sunnah:sunnah:bukhari:1")
+        assert any("doubled leading corpus" in p for p in problems)
+
+    def test_empty_segment_flagged(self) -> None:
+        problems = validate_source_id("sunnah::1")
+        assert any("empty segment" in p for p in problems)


### PR DESCRIPTION
## da#82 (T0-A): collision-safe canonical `source_id` scheme

Keystone foundation for epic #81 — the single source of truth for `source_id` and graph node-id construction across all ingest paths. Per-source light-ups (#85, #89, #92) build to this contract (posted on #82).

### What
New `src/parse/identity.py` owns the identity grammar and prefixing rules:
- **source_id**: `<corpus>:<collection>[:<part>...]` — corpus exactly once, namespaced from the `SourceCorpus` enum (single source of truth, no drift). `generate_source_id()` now fails fast on an unknown corpus.
- **node ids**: one prefixing function per type (`hadith_node_id`, `collection_node_id`, `narrator_node_id`, `chain_node_id`, `grading_node_id`).

### Two known live identity hazards, designed out
1. **Double-prefix (main#139)** — `hadith_node_id()` is the ONE rule both the batch loaders and the streaming/normalize path call. Idempotent on `hdt:` and *collapses* a doubled leading corpus (`hdt:sunnah:sunnah:... → hdt:sunnah:...`), so the same hadith → exactly one node id regardless of producer. The scattered `f"hdt:{x}" if not x.startswith("hdt:")` idiom is refactored out of `load_nodes.py` and `load_edges.py` into these helpers.
2. **collection-ref vs in-book-ordinal (da#77)** — documents + asserts that staging `hadith_number` is the in-book ordinal that flows to `APPEARS_IN.hadith_number_in_book`, not the collection-wide reference.

### Collision-safety
`source_id` is corpus-namespaced; same `(collection, book, chapter, num)` across all corpora yields distinct ids (unit-tested). `sunnah_scraped` intentionally shares the `sunnah` corpus for dedup.

### Tests / acceptance (owner bar: LIVE local neo4j:5)
- `tests/integration/test_source_id_collision.py` — live `neo4j:5` container: same hadith via batch shape + doubled-corpus shape → **one Hadith node**; idempotent reload; in-book ordinal on `APPEARS_IN.hadith_number_in_book`. **3/3 green locally.**
- `tests/test_parse/test_identity.py` — grammar, idempotency, double-prefix collapse, batch-vs-streaming convergence, cross-source uniqueness, validators.
- Full suite: 566 unit tests pass; mypy + ruff clean.

Closes #82
Refs #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
