### PR TITLE
da#83 (T0-B): provenance conformance gate (non-empty + in-domain sect/source_corpus/source)

### DIFF
--- a/src/parse/base.py
+++ b/src/parse/base.py
@@ -6,9 +6,11 @@ from pathlib import Path
 from typing import Any
 
 import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.csv as pcsv
 import pyarrow.parquet as pq
 
+from src.models.enums import Sect, SourceCorpus
 from src.parse.identity import ID_DELIMITER, SOURCE_CORPORA
 from src.utils.logging import get_logger
 
@@ -21,17 +23,74 @@ __all__ = [
     "safe_int",
     "safe_str",
     "validate_enum_fields",
+    "provenance_violations",
 ]
+
+# Provenance columns every staging schema is expected to populate, mapped to the
+# closed value-domain each must stay within. ``sect`` / ``source_corpus`` are the
+# enum-namespaced provenance on the hadith/collection/mention schemas; ``source``
+# is the free-text provenance label on the narrator-bio / network-edge schemas
+# (no enum domain, but it must still be non-empty). A table carrying none of
+# these columns (a non-canonical intermediate) is simply not provenance-checked.
+_PROVENANCE_DOMAINS: dict[str, frozenset[str] | None] = {
+    "sect": frozenset(s.value for s in Sect),
+    "source_corpus": frozenset(s.value for s in SourceCorpus),
+    "source": None,
+}
+
+
+def provenance_violations(table: pa.Table) -> list[str]:
+    """Return provenance-tagging violations for *table* (empty list == clean).
+
+    The conformance gate for da#83: a non-nullable schema column already rejects
+    a *null* ``sect``/``source_corpus`` at construction, but an **empty string**
+    slips through a non-nullable column, and a **wrong-domain** value
+    (``source_corpus="sunna"`` typo, a ``sect`` outside the enum) is never caught
+    anywhere. This checks both, for whichever provenance columns the table
+    carries, so every parser's output is tagged consistently and in-domain.
+    """
+    problems: list[str] = []
+    columns = set(table.column_names)
+    for column, domain in _PROVENANCE_DOMAINS.items():
+        if column not in columns:
+            continue
+        values = table.column(column)
+        if values.null_count:
+            problems.append(f"{column}: {values.null_count} null value(s)")
+        non_null = values.drop_null()
+        if not len(non_null):
+            continue
+        empty = pc.sum(pc.equal(pc.utf8_trim_whitespace(non_null), "")).as_py() or 0
+        if empty:
+            problems.append(f"{column}: {empty} empty/whitespace value(s)")
+        if domain is not None:
+            out_of_domain = sorted(
+                {
+                    v
+                    for v in pc.unique(non_null).to_pylist()
+                    if v is not None and v.strip() != "" and v not in domain
+                }
+            )
+            if out_of_domain:
+                problems.append(f"{column}: value(s) outside {sorted(domain)}: {out_of_domain}")
+    return problems
 
 
 def write_parquet(table: pa.Table, path: Path, schema: pa.Schema | None = None) -> Path:
     """Write PyArrow Table to Parquet with Snappy compression.
 
-    Validate against schema if provided. Create parent dirs. Log stats.
+    Validate against schema if provided, then enforce the provenance-tagging
+    contract (:func:`provenance_violations`) as a fail-fast invariant so no
+    parser can ship staging data with an empty or out-of-domain ``sect`` /
+    ``source_corpus`` / ``source``. Create parent dirs. Log stats.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     if schema is not None:
         table = table.cast(schema)
+    violations = provenance_violations(table)
+    if violations:
+        msg = f"provenance conformance failed for {path.name}: " + "; ".join(violations)
+        raise ValueError(msg)
     pq.write_table(table, path, compression="snappy")
     size_mb = path.stat().st_size / (1024 * 1024)
     logger.info("wrote_parquet", path=str(path), rows=table.num_rows, size_mb=round(size_mb, 2))

--- a/tests/test_parse/test_provenance_conformance.py
+++ b/tests/test_parse/test_provenance_conformance.py
@@ -1,0 +1,198 @@
+"""Provenance-tagging conformance gate (da#83, T0-B).
+
+Every parser must emit ``sect`` / ``source_corpus`` / ``source`` provenance that
+is non-empty and in the enum value-domain. A non-nullable schema column already
+rejects a *null* value at construction — the gap this gate closes is the
+**empty string** (which passes a non-nullable column) and the **wrong-domain**
+value (a ``source_corpus`` typo, a ``sect`` outside the enum) that nothing else
+catches. The invariant is enforced fail-fast in
+:func:`src.parse.base.write_parquet`, so it holds for every parser and every
+future parser, and these tests assert that contract directly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import src.parse as parse_pkg
+from src.models.enums import Sect, SourceCorpus
+from src.parse.base import provenance_violations, write_parquet
+from src.parse.schemas import (
+    COLLECTION_SCHEMA,
+    HADITH_SCHEMA,
+    NARRATOR_BIO_SCHEMA,
+    NARRATOR_MENTION_SCHEMA,
+    NETWORK_EDGE_SCHEMA,
+)
+
+# A canonical schema is "provenance-bearing" iff it carries one of these columns.
+_PROVENANCE_COLUMNS = frozenset({"sect", "source_corpus", "source"})
+_ALL_SCHEMA_NAMES = frozenset(
+    {
+        "HADITH_SCHEMA",
+        "NARRATOR_MENTION_SCHEMA",
+        "NARRATOR_BIO_SCHEMA",
+        "COLLECTION_SCHEMA",
+        "NETWORK_EDGE_SCHEMA",
+    }
+)
+
+# Parse modules that are framework, not per-source parsers — excluded from the
+# "every parser emits a provenance-bearing schema" coverage assertion.
+_NON_PARSER_MODULES = frozenset(
+    {"__init__", "base", "schemas", "validate", "narrator_extraction", "identity"}
+)
+
+
+def _valid_hadith_table(**overrides: object) -> pa.Table:
+    """A 1-row HADITH_SCHEMA table with valid provenance, castable to schema."""
+    row: dict[str, object] = {field.name: None for field in HADITH_SCHEMA}
+    row.update(
+        source_id="sunnah:bukhari:1:1:1",
+        source_corpus="sunnah",
+        collection_name="bukhari",
+        sect="sunni",
+    )
+    row.update(overrides)
+    return pa.table({k: [v] for k, v in row.items()}).cast(HADITH_SCHEMA)
+
+
+class TestProvenanceValidatorClean:
+    """Valid provenance produces no violations."""
+
+    def test_valid_hadith_provenance(self) -> None:
+        table = pa.table({"sect": ["sunni", "shia"], "source_corpus": ["sunnah", "thaqalayn"]})
+        assert provenance_violations(table) == []
+
+    def test_valid_bio_source(self) -> None:
+        table = pa.table({"source": ["muhaddithat", "kaggle_narrators"]})
+        assert provenance_violations(table) == []
+
+    def test_table_without_provenance_columns_is_clean(self) -> None:
+        # A non-canonical intermediate (no provenance columns) is not checked.
+        table = pa.table({"some_metric": [1, 2, 3]})
+        assert provenance_violations(table) == []
+
+    def test_every_enum_value_accepted(self) -> None:
+        table = pa.table(
+            {
+                "sect": [s.value for s in Sect],
+                "source_corpus": [s.value for s in list(SourceCorpus)[: len(list(Sect))]],
+            }
+        )
+        assert provenance_violations(table) == []
+
+
+class TestProvenanceValidatorCatchesGaps:
+    """The empty-string / wrong-domain gaps a non-nullable schema misses."""
+
+    def test_empty_string_sect_flagged(self) -> None:
+        table = pa.table({"sect": ["sunni", ""], "source_corpus": ["sunnah", "sunnah"]})
+        problems = provenance_violations(table)
+        assert any("sect" in p and "empty" in p for p in problems)
+
+    def test_whitespace_only_sect_flagged(self) -> None:
+        table = pa.table({"sect": ["   "], "source_corpus": ["sunnah"]})
+        problems = provenance_violations(table)
+        assert any("sect" in p and "empty" in p for p in problems)
+
+    def test_wrong_domain_sect_flagged(self) -> None:
+        # Right idea, wrong casing/domain — a non-nullable column would accept it.
+        table = pa.table({"sect": ["Sunni"], "source_corpus": ["sunnah"]})
+        problems = provenance_violations(table)
+        assert any("sect" in p and "outside" in p for p in problems)
+
+    def test_wrong_domain_source_corpus_flagged(self) -> None:
+        table = pa.table({"sect": ["sunni"], "source_corpus": ["sunna"]})
+        problems = provenance_violations(table)
+        assert any("source_corpus" in p and "outside" in p for p in problems)
+
+    def test_empty_source_flagged(self) -> None:
+        table = pa.table({"source": ["muhaddithat", ""]})
+        problems = provenance_violations(table)
+        assert any("source" in p and "empty" in p for p in problems)
+
+    def test_null_provenance_flagged(self) -> None:
+        table = pa.table({"sect": ["sunni", None], "source_corpus": ["sunnah", "sunnah"]})
+        problems = provenance_violations(table)
+        assert any("sect" in p and "null" in p for p in problems)
+
+
+class TestWriteParquetEnforces:
+    """write_parquet is the fail-fast chokepoint for the provenance contract."""
+
+    def test_valid_table_writes(self, tmp_path: Path) -> None:
+        out = write_parquet(_valid_hadith_table(), tmp_path / "hadiths_x.parquet")
+        assert out.exists()
+        assert pq.read_table(out).num_rows == 1
+
+    def test_empty_sect_is_rejected(self, tmp_path: Path) -> None:
+        bad = _valid_hadith_table(sect="")
+        with pytest.raises(ValueError, match="provenance conformance failed"):
+            write_parquet(bad, tmp_path / "hadiths_bad.parquet")
+
+    def test_wrong_domain_corpus_is_rejected(self, tmp_path: Path) -> None:
+        bad = _valid_hadith_table(source_corpus="sunna")
+        with pytest.raises(ValueError, match="source_corpus"):
+            write_parquet(bad, tmp_path / "hadiths_bad.parquet")
+
+    def test_rejected_table_is_not_written(self, tmp_path: Path) -> None:
+        dest = tmp_path / "hadiths_bad.parquet"
+        with pytest.raises(ValueError):
+            write_parquet(_valid_hadith_table(sect=""), dest)
+        assert not dest.exists()
+
+
+class TestEverySchemaIsProvenanceBearing:
+    """Each canonical staging schema carries a provenance column."""
+
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            HADITH_SCHEMA,
+            NARRATOR_MENTION_SCHEMA,
+            NARRATOR_BIO_SCHEMA,
+            COLLECTION_SCHEMA,
+            NETWORK_EDGE_SCHEMA,
+        ],
+    )
+    def test_schema_has_provenance_column(self, schema: pa.Schema) -> None:
+        assert _PROVENANCE_COLUMNS & {f.name for f in schema}, (
+            f"schema {schema} carries no provenance column ({sorted(_PROVENANCE_COLUMNS)})"
+        )
+
+
+class TestEveryParserEmitsProvenanceSchema:
+    """A per-source parser must emit at least one provenance-bearing schema.
+
+    Guards against a future parser that writes raw, untagged staging data: every
+    module under ``src/parse`` that is a per-source parser must reference one of
+    the canonical schemas (all of which are provenance-bearing).
+    """
+
+    def _parser_modules(self) -> list[str]:
+        names = [
+            m.name
+            for m in pkgutil.iter_modules(parse_pkg.__path__)
+            if not m.ispkg and m.name not in _NON_PARSER_MODULES
+        ]
+        assert names, "no per-source parser modules discovered under src/parse"
+        return names
+
+    def test_parser_modules_reference_a_canonical_schema(self) -> None:
+        offenders: list[str] = []
+        for name in self._parser_modules():
+            module = importlib.import_module(f"src.parse.{name}")
+            source = inspect.getsource(module)
+            if not any(schema_name in source for schema_name in _ALL_SCHEMA_NAMES):
+                offenders.append(name)
+        assert not offenders, (
+            f"parser modules emit no provenance-bearing canonical schema: {offenders}"
+        )


### PR DESCRIPTION
## da#83 (T0-B): provenance conformance gate

Parser-level gate ensuring every parser emits `sect` / `source_corpus` / `source` provenance that is **non-empty and in the enum value-domain**. Foundation for epic #81; complements #82.

### The real gap (re-scoped after investigation)
The original premise was "muhaddithat dropped sect/source_corpus tagging." Investigation (posted on #83) showed otherwise: muhaddithat emits the narrator-bio / network-edge schemas, which carry a free-text `source` (correctly set to `"muhaddithat"`), not `sect`/`source_corpus` — so there's no parse-time sect bug, and stamping a binary `sect` onto narrator rows would be semantically wrong (narrator sect = resolution-time `SectAffiliation`).

The genuine gap: `sect`/`source_corpus` are non-nullable, so a *null* is already impossible — **but an empty string passes a non-nullable column**, and a **wrong-domain** value (`source_corpus="sunna"` typo, a `sect` outside the enum) was never caught anywhere.

### What
- `provenance_violations(table)` in `src/parse/base.py` — checks non-null + non-empty + in-domain (`sect ∈ Sect`, `source_corpus ∈ SourceCorpus`; `source` non-empty) for whichever provenance columns a table carries.
- Enforced **fail-fast in `write_parquet()`** — the single chokepoint every parser writes through — so the invariant holds for every current and future parser, not just a test that can be forgotten.
- `tests/test_parse/test_provenance_conformance.py` — validator (empty / whitespace / null / wrong-domain), the `write_parquet` invariant (rejects + does not write), every canonical schema is provenance-bearing, and every per-source parser emits a provenance-bearing schema.

### Scope note
Node-level `sect_affiliation` + `source_corpus` on Narrator/edge nodes in Neo4j (a resolve→canonical-schema→loader change, overlapping #82/#99) is split out to **#103** — that's where the live-Neo4j node-tagging proof lives. This PR is parser-level, no DB needed (acceptance updated on #83).

### Test plan
- Full unit suite green; the new `write_parquet` enforcement breaks **no** existing parser fixtures (235 parse+graph tests pass post-rebase onto #102).
- `ruff check` + `ruff format --check` clean; `mypy src/` clean (63 files).

Closes #83
Refs #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
