### PR TITLE
test(da#85): light up thaqalayn (Shia) end-to-end into Neo4j

### DIFF
--- a/tests/integration/test_thaqalayn_lightup.py
+++ b/tests/integration/test_thaqalayn_lightup.py
@@ -1,0 +1,240 @@
+"""Thaqalayn (Shia) end-to-end light-up against a real Neo4j container (da#85).
+
+The ``thaqalayn`` adapter + parser already existed and were parse-validated, but
+the corpus had **never been loaded into the graph**. This is the first Shia
+corpus to land — the keystone for cross-sect parallels (isnad-graph#964, whose
+Browse-Parallels view needs real ``sect=shia`` hadith in the graph).
+
+These tests exercise the real ``parse -> load_nodes -> load_edges`` path against
+a live ``neo4j:5-community`` container (via the shared ``neo4j_client`` fixture in
+``conftest.py``). They ``pytest.skip`` cleanly when Docker is unavailable, so a
+no-Docker environment yields a SKIP rather than a red ERROR (#69). The parser's
+own conformance is covered by ``tests/test_parse/test_thaqalayn_parser.py``; what
+is asserted *here* and nowhere else is that real Shia nodes/edges actually
+**persist in Neo4j** with the correct ``sect`` + ``source_corpus`` and
+collision-safe, single-prefixed ids (the da#82 / main#139 identity contract).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+from src.graph.load_edges import load_all_edges
+from src.graph.load_nodes import load_all_nodes
+from src.parse import thaqalayn
+from src.parse.identity import is_double_prefixed, validate_source_id
+from src.utils.neo4j_client import Neo4jClient
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Sample Thaqalayn data — API-format JSON, two of the Four Books (Shia).
+# Mirrors the real ThaqalaynAPI shape: a top-level ``data`` list of hadith
+# objects under a ``bookName``. Arabic + English matn, grades, chapters.
+# ---------------------------------------------------------------------------
+
+_AL_KAFI = {
+    "bookName": "Al-Kafi",
+    "bookNameAr": "الكافي",
+    "author": "al-Kulayni",
+    "data": [
+        {
+            "hadithNumber": 1,
+            "textAr": "إنما الأعمال بالنيات ولكل امرئ ما نوى",
+            "textEn": "Actions are but by intentions; everyone shall have what they intended.",
+            "grade": "Sahih",
+            "chapterEn": "The Book of Intellect and Ignorance",
+            "chapterNumber": 1,
+        },
+        {
+            "hadithNumber": 2,
+            "textAr": "العلم نور يقذفه الله في قلب من يشاء",
+            "textEn": "Knowledge is a light that Allah casts into the heart of whom He wills.",
+            "grade": "Hasan",
+            "chapterEn": "The Book of the Excellence of Knowledge",
+            "chapterNumber": 2,
+        },
+        {
+            "hadithNumber": 3,
+            "textAr": "من سلك طريقا يطلب فيه علما سلك الله به طريقا إلى الجنة",
+            "textEn": "Whoever travels a path seeking knowledge, Allah sets them toward Paradise.",
+            "grade": "Sahih",
+            "chapterEn": "The Book of the Excellence of Knowledge",
+            "chapterNumber": 2,
+        },
+    ],
+}
+
+_MAN_LA_YAHDURUHU = {
+    "bookName": "Man La Yahduruhu al-Faqih",
+    "bookNameAr": "من لا يحضره الفقيه",
+    "author": "al-Shaykh al-Saduq",
+    "data": [
+        {
+            "hadithNumber": 1,
+            "textAr": "الطهور نصف الإيمان",
+            "textEn": "Purification is half of faith.",
+            "grade": "Sahih",
+            "chapterEn": "The Book of Purification",
+            "chapterNumber": 1,
+        },
+        {
+            "hadithNumber": 2,
+            "textAr": "الصلاة عمود الدين",
+            "textEn": "Prayer is the pillar of the religion.",
+            "grade": "Sahih",
+            "chapterEn": "The Book of Prayer",
+            "chapterNumber": 2,
+        },
+    ],
+}
+
+# Total hadith / collection counts the fixture is expected to produce.
+_EXPECTED_HADITHS = len(_AL_KAFI["data"]) + len(_MAN_LA_YAHDURUHU["data"])  # 5
+_EXPECTED_COLLECTIONS = 2
+
+
+def _write_thaqalayn_raw(raw_dir: Path) -> None:
+    """Write the two-book Thaqalayn API-format fixture under raw/thaqalayn/."""
+    thaq_dir = raw_dir / "thaqalayn"
+    thaq_dir.mkdir(parents=True)
+    (thaq_dir / "book_1.json").write_text(
+        json.dumps(_AL_KAFI, ensure_ascii=False), encoding="utf-8"
+    )
+    (thaq_dir / "book_2.json").write_text(
+        json.dumps(_MAN_LA_YAHDURUHU, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def _parse_to_staging(tmp_path: Path) -> Path:
+    """Run the real thaqalayn parser; return the staging dir with parquet output."""
+    raw_dir = tmp_path / "raw"
+    staging_dir = tmp_path / "staging"
+    staging_dir.mkdir(parents=True)
+    _write_thaqalayn_raw(raw_dir)
+
+    hadiths_path, collections_path = thaqalayn.run(raw_dir, staging_dir)
+    assert hadiths_path.exists()
+    assert collections_path.exists()
+    return staging_dir
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestThaqalaynLightup:
+    """parse -> load -> read-back the first Shia corpus into a live graph."""
+
+    def test_source_ids_are_canonical(self, tmp_path: Path) -> None:
+        """Every staged source_id is corpus-namespaced + collision-safe (da#82).
+
+        Pure parser/identity check (no Neo4j) — guards that the parser builds ids
+        through ``generate_source_id`` so they satisfy the canonical grammar and
+        never re-prepend the corpus (the main#139 double-prefix hazard).
+        """
+        staging_dir = _parse_to_staging(tmp_path)
+        rows = pq.read_table(staging_dir / "hadiths_thaqalayn.parquet").to_pylist()
+
+        assert len(rows) == _EXPECTED_HADITHS
+        for row in rows:
+            sid = row["source_id"]
+            assert validate_source_id(sid) == [], f"non-canonical source_id: {sid!r}"
+            assert sid.startswith("thaqalayn:"), sid
+            assert not is_double_prefixed(sid), f"double-prefixed source_id: {sid!r}"
+
+    def test_nodes_land_with_shia_tagging(self, neo4j_client: Neo4jClient, tmp_path: Path) -> None:
+        """Real Hadith/Collection nodes persist, tagged sect=shia + corpus=thaqalayn."""
+        staging_dir = _parse_to_staging(tmp_path)
+        curated_dir = tmp_path / "curated"
+        curated_dir.mkdir()
+
+        results = load_all_nodes(neo4j_client, staging_dir, curated_dir, strict=False)
+
+        hadith_result = next(r for r in results if r.node_type == "Hadith")
+        assert hadith_result.created == _EXPECTED_HADITHS
+        collection_result = next(r for r in results if r.node_type == "Collection")
+        assert collection_result.created == _EXPECTED_COLLECTIONS
+
+        # Read the nodes back from the live graph and assert the Shia tagging that
+        # isnad-graph#964 keys on — not just that *some* nodes exist.
+        hadith_rows = neo4j_client.execute_read(
+            "MATCH (h:Hadith) RETURN count(h) AS cnt, "
+            "collect(DISTINCT h.sect) AS sects, "
+            "collect(DISTINCT h.source_corpus) AS corpora"
+        )
+        assert hadith_rows[0]["cnt"] == _EXPECTED_HADITHS
+        assert hadith_rows[0]["sects"] == ["shia"]
+        assert hadith_rows[0]["corpora"] == ["thaqalayn"]
+
+        coll_rows = neo4j_client.execute_read(
+            "MATCH (c:Collection) RETURN collect(DISTINCT c.sect) AS sects, "
+            "collect(DISTINCT c.source_corpus) AS corpora"
+        )
+        assert coll_rows[0]["sects"] == ["shia"]
+        assert coll_rows[0]["corpora"] == ["thaqalayn"]
+
+    def test_node_ids_single_prefixed_in_graph(
+        self, neo4j_client: Neo4jClient, tmp_path: Path
+    ) -> None:
+        """Persisted Hadith node ids carry exactly one ``hdt:thaqalayn:`` prefix.
+
+        The same hadith must not double-prefix to two nodes (main#139). Asserts on
+        the ids *as stored in Neo4j*, the layer the mock-client unit suite cannot
+        reach.
+        """
+        staging_dir = _parse_to_staging(tmp_path)
+        curated_dir = tmp_path / "curated"
+        curated_dir.mkdir()
+        load_all_nodes(neo4j_client, staging_dir, curated_dir, strict=False)
+
+        rows = neo4j_client.execute_read("MATCH (h:Hadith) RETURN h.id AS id")
+        ids = [r["id"] for r in rows]
+        assert len(ids) == _EXPECTED_HADITHS
+        for hid in ids:
+            assert hid.startswith("hdt:thaqalayn:"), hid
+            assert not is_double_prefixed(hid), f"double-prefixed node id: {hid!r}"
+        # Ids are unique — no hadith collapsed/duplicated across the two books.
+        assert len(set(ids)) == _EXPECTED_HADITHS
+
+    def test_appears_in_edges_link_hadith_to_collection(
+        self, neo4j_client: Neo4jClient, tmp_path: Path
+    ) -> None:
+        """Each Shia hadith gets an APPEARS_IN edge to its (Shia) collection."""
+        staging_dir = _parse_to_staging(tmp_path)
+        curated_dir = tmp_path / "curated"
+        curated_dir.mkdir()
+        load_all_nodes(neo4j_client, staging_dir, curated_dir, strict=False)
+
+        edge_results = load_all_edges(neo4j_client, staging_dir, curated_dir, strict=False)
+        appears_in = next(r for r in edge_results if r.edge_type == "APPEARS_IN")
+        assert appears_in.created == _EXPECTED_HADITHS
+        assert appears_in.missing_endpoints == 0
+
+        # Read the edges back: every Shia hadith resolves to a Shia collection.
+        rows = neo4j_client.execute_read(
+            "MATCH (h:Hadith)-[r:APPEARS_IN]->(c:Collection) "
+            "RETURN count(r) AS cnt, collect(DISTINCT c.sect) AS coll_sects"
+        )
+        assert rows[0]["cnt"] == _EXPECTED_HADITHS
+        assert rows[0]["coll_sects"] == ["shia"]
+
+    def test_shia_corpus_is_queryable(self, neo4j_client: Neo4jClient, tmp_path: Path) -> None:
+        """The Browse-Parallels Shia slice (isnad-graph#964) is now answerable.
+
+        A ``sect=shia`` lookup against the live graph returns the loaded Thaqalayn
+        hadith — the concrete capability this keystone unblocks.
+        """
+        staging_dir = _parse_to_staging(tmp_path)
+        curated_dir = tmp_path / "curated"
+        curated_dir.mkdir()
+        load_all_nodes(neo4j_client, staging_dir, curated_dir, strict=False)
+
+        rows = neo4j_client.execute_read("MATCH (h:Hadith {sect: 'shia'}) RETURN count(h) AS cnt")
+        assert rows[0]["cnt"] == _EXPECTED_HADITHS

--- a/tests/test_acquire/test_thaqalayn.py
+++ b/tests/test_acquire/test_thaqalayn.py
@@ -1,0 +1,86 @@
+"""Tests for the Thaqalayn (Shia) acquire adapter.
+
+da#85 — closing the acquire-side test gap (only ``base`` and ``sunnah_scraper``
+had one before). The network/clone is mocked: ``clone_repo`` is patched to
+materialise fake book JSONs so the GitHub-clone, idempotent-skip, and
+under-minimum branches of ``run`` are exercised without touching the network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.acquire.thaqalayn import MIN_EXPECTED_BOOKS, run
+
+
+def _fake_clone(_url: str, dest: Path, **_kwargs: object) -> Path:
+    """Stand-in for ``clone_repo``: materialise MIN_EXPECTED_BOOKS JSON files."""
+    dest.mkdir(parents=True, exist_ok=True)
+    for i in range(MIN_EXPECTED_BOOKS):
+        (dest / f"book_{i}.json").write_text(
+            json.dumps({"bookName": f"Book {i}", "data": []}), encoding="utf-8"
+        )
+    return dest
+
+
+class TestThaqalaynAcquire:
+    @patch("src.acquire.thaqalayn.emit_raw_new_for_manifest")
+    @patch("src.acquire.thaqalayn.clone_repo", side_effect=_fake_clone)
+    def test_clones_and_writes_manifest(
+        self, mock_clone: object, mock_emit: object, tmp_path: Path
+    ) -> None:
+        """Happy path: clone the repo, then write a manifest + emit the event."""
+        raw_dir = tmp_path / "raw"
+
+        dest = run(raw_dir)
+
+        assert dest == raw_dir / "thaqalayn"
+        assert (dest / "manifest.json").exists()
+        mock_clone.assert_called_once()  # type: ignore[attr-defined]
+        mock_emit.assert_called_once()  # type: ignore[attr-defined]
+
+        # Manifest lists the cloned JSONs.
+        manifest = json.loads((dest / "manifest.json").read_text())
+        assert len(manifest) >= MIN_EXPECTED_BOOKS
+
+    @patch("src.acquire.thaqalayn.emit_raw_new_for_manifest")
+    @patch("src.acquire.thaqalayn.clone_repo", side_effect=_fake_clone)
+    def test_idempotent_skips_when_already_acquired(
+        self, mock_clone: object, mock_emit: object, tmp_path: Path
+    ) -> None:
+        """Pre-existing ``book_*.json`` short-circuits the clone (no network)."""
+        dest = tmp_path / "raw" / "thaqalayn"
+        dest.mkdir(parents=True)
+        for i in range(MIN_EXPECTED_BOOKS):
+            (dest / f"book_{i}.json").write_text("{}", encoding="utf-8")
+
+        result = run(tmp_path / "raw")
+
+        assert result == dest
+        mock_clone.assert_not_called()  # type: ignore[attr-defined]
+        # The skip path still publishes a manifest + raw-new event.
+        assert (dest / "manifest.json").exists()
+        mock_emit.assert_called_once()  # type: ignore[attr-defined]
+
+    @patch("src.acquire.thaqalayn.emit_raw_new_for_manifest")
+    @patch("src.acquire.thaqalayn.clone_repo")
+    def test_raises_when_too_few_books(
+        self, mock_clone: object, mock_emit: object, tmp_path: Path
+    ) -> None:
+        """A clone yielding fewer than MIN_EXPECTED_BOOKS JSONs fails loudly."""
+
+        def _sparse_clone(_url: str, clone_dest: Path, **_kwargs: object) -> Path:
+            clone_dest.mkdir(parents=True, exist_ok=True)
+            (clone_dest / "book_0.json").write_text("{}", encoding="utf-8")
+            return clone_dest
+
+        mock_clone.side_effect = _sparse_clone  # type: ignore[attr-defined]
+
+        with pytest.raises(AssertionError, match="JSON files"):
+            run(tmp_path / "raw")
+
+        mock_emit.assert_not_called()  # type: ignore[attr-defined]


### PR DESCRIPTION
## da#85 — light up the Thaqalayn adapter end-to-end (SHIA keystone)

The `thaqalayn` adapter (`src/acquire/thaqalayn.py`) + parser (`src/parse/thaqalayn.py`) already existed and were parse-validated, but the corpus had **never been loaded into the graph**. This is the first **Shia** corpus to land end-to-end — the keystone that unblocks cross-sect Browse Parallels (isnad-graph#964, whose view needs real `sect=shia` hadith in the graph).

No production code changed — the wiring was already correct (parser builds ids via `generate_source_id`, loaders glob `hadiths_*`/`collections_*`). What was missing was **proof it actually loads**. This PR adds that proof.

### What's here
- **`tests/integration/test_thaqalayn_lightup.py`** — live `parse -> load_nodes -> load_edges` against a real `neo4j:5-community` container (skip-guarded via the shared `neo4j_client` fixture when Docker is down, #69). Asserts, reading back from the live graph:
  - real Hadith + Collection nodes persist tagged `sect=shia` + `source_corpus=thaqalayn` (not just parse/conformance);
  - node ids are single-prefixed `hdt:thaqalayn:…` and not double-prefixed (the da#82 / main#139 identity contract), via `is_double_prefixed` + `validate_source_id`;
  - every Shia hadith gets an `APPEARS_IN` edge to its Shia collection (0 missing endpoints);
  - a `sect=shia` lookup is answerable — the concrete capability isnad-graph#964 keys on.
- **`tests/test_acquire/test_thaqalayn.py`** — closes the acquire-side test gap (only `base` + `sunnah_scraper` had one): clone happy path, idempotent skip, under-minimum guard, with the network mocked.

### Live load counts (real neo4j:5-community, this PR)
```
5 hadiths  (Al-Kafi ×3 + Man La Yahduruhu al-Faqih ×2)
2 collections
5 APPEARS_IN edges, 0 missing endpoints
sect=shia, source_corpus=thaqalayn on every node
```
`5 passed in 16.45s` against the real container; full new-file suite (acquire + parser + integration) green; ruff (v0.15.11) format+lint and mypy strict clean.

### Reachability + licensing
- **Reachability:** acquisition is via `git clone` of the public `MohammedArab1/ThaqalaynAPI` GitHub repo. The upstream REST API v2 was removed ~early 2026 (site rebuilt on Next.js), so the GitHub repo is the primary source — already reflected in the adapter docstring. The clone path is exercised here only with a mocked `clone_repo` (no network in CI).
- **Licensing:** the fixtures in these tests are **hand-authored** (well-known, public-domain hadith text) — **no scraped upstream content is committed**. Upstream ThaqalaynAPI repo licensing should be confirmed before any **bulk redistribution** of acquired data (flagged as post-merge, not a blocker for this test-only PR).

### Out of scope (post-merge verify, not a PR gate)
Per the issue + `feedback_wsl2_no_local_docker`: a staging-cluster load (cluster-internal, `ssh … docker exec cypher-shell`) is tracked as a **separate post-merge verification**, not a gate on this PR.

Refs da#81. Closes #85
