### PR TITLE
da#89 (L6): light up sanadset E2E — narrator keystone

### DIFF
--- a/src/parse/sanadset.py
+++ b/src/parse/sanadset.py
@@ -26,6 +26,7 @@ from src.parse.base import (
     safe_str,
     write_parquet,
 )
+from src.parse.identity import ID_DELIMITER
 from src.parse.schemas import HADITH_SCHEMA, NARRATOR_BIO_SCHEMA, NARRATOR_MENTION_SCHEMA
 from src.utils.arabic import extract_transmission_phrases, normalize_arabic
 from src.utils.logging import get_logger
@@ -238,11 +239,12 @@ def _parse_narrators_bio(narrators_dir: Path) -> pa.Table | None:
 
             name_ar = safe_str(row_dict.get(field_map.get("name_ar", "")))
             ext_id = safe_str(row_dict.get(field_map.get("external_id", "")))
-            bio_id = generate_source_id(
-                _BIO_SOURCE,
-                csv_file.stem,
-                str(ext_id or i),
-            )
+            # The bio_id is a narrator-biography provenance key namespaced by the
+            # *bio source* (``kaggle_narrators``), which is NOT a hadith
+            # ``SourceCorpus``. Building it with ``generate_source_id`` would trip
+            # that helper's da#82 fail-fast on an unknown corpus, so we join the
+            # key directly with the shared delimiter instead.
+            bio_id = ID_DELIMITER.join([_BIO_SOURCE, csv_file.stem, str(ext_id or i)])
             name_ar_norm = normalize_arabic(name_ar) if name_ar else None
 
             all_bios.append(

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -24,6 +24,7 @@ from rapidfuzz import fuzz
 from rapidfuzz.distance import Levenshtein
 
 from src.parse.base import safe_str, write_parquet
+from src.parse.identity import narrator_node_id
 from src.resolve.schemas import AMBIGUOUS_NARRATORS_SCHEMA, NARRATORS_CANONICAL_SCHEMA
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
@@ -440,9 +441,12 @@ def _make_canonical_id(name_normalized: str) -> str:
     """Deterministic canonical ID via uuid5 with fixed namespace.
 
     Returns ``nar:<uuid5>`` to match the ``nar:`` prefix the graph
-    loader (``load_nodes._load_narrators``) validates on import.
+    loader (``load_nodes._load_narrators``) validates on import. The ``nar:``
+    prefix is applied through the canonical :func:`narrator_node_id` helper
+    (da#82) so resolve agrees with the loaders on one prefixing rule rather than
+    hand-concatenating the prefix here.
     """
-    return f"nar:{uuid.uuid5(_CANONICAL_NAMESPACE, name_normalized)}"
+    return narrator_node_id(str(uuid.uuid5(_CANONICAL_NAMESPACE, name_normalized)))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_sanadset_lightup.py
+++ b/tests/integration/test_sanadset_lightup.py
@@ -1,0 +1,151 @@
+"""Live-Neo4j end-to-end light-up for the sanadset narrator keystone (da#89).
+
+Exercises the REAL pipeline — ``parse → ner → disambiguate → load`` — against a
+live ``neo4j:5`` container and proves the keystone narrators for
+isnad-graph#963 / #965 actually land in the graph:
+
+1. **Narrator nodes land** — disambiguation produces canonical narrators that
+   load as ``Narrator`` nodes with ``nar:``-prefixed ids (via the da#82
+   :func:`narrator_node_id` helper) and searchable Arabic names.
+2. **Hadith nodes carry sect + source_corpus** — every sanadset Hadith is tagged
+   ``sect="sunni"`` and ``source_corpus="sanadset"`` and gets a single-corpus
+   ``hdt:sanadset:...`` id (no da#82 double-prefix).
+3. **Edges land** — ``APPEARS_IN`` hadith→collection edges materialize against a
+   sanadset Collection that is itself ``sect="sunni"`` / ``source_corpus="sanadset"``.
+
+Only the narrator-resolution path (NER + disambiguate) is driven directly; the
+heavy embedding-based dedup step (parallel-link detection) is orthogonal to the
+narrator keystone and is covered by its own tests, so it is intentionally not
+run here.
+
+Requires Docker; the ``neo4j_client`` fixture ``pytest.skip``s when Docker is
+unreachable (see ``tests/integration/conftest.py``), so this degrades to a clean
+SKIP off-CI rather than a red ERROR.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+from src.graph.load_edges import load_all_edges
+from src.graph.load_nodes import load_all_nodes
+from src.parse import sanadset
+from src.resolve import disambiguate, ner
+from tests.test_graph.conftest import write_collections
+
+# A NAR-tagged sanadset CSV. The narrator names below are mirrored exactly in the
+# bio CSV so disambiguation resolves them via the deterministic exact-match stage.
+_SANADSET_CSV = (
+    "hadith_id,book_id,hadith,grade\n"
+    '1,1,"<SANAD><NAR>مالك بن أنس</NAR> عن <NAR>أبو هريرة</NAR></SANAD>'
+    '<MATN>إنما الأعمال بالنيات</MATN>",Sahih\n'
+    '2,1,"<SANAD><NAR>مالك بن أنس</NAR> عن <NAR>أنس بن مالك</NAR></SANAD>'
+    '<MATN>لا ضرر ولا ضرار</MATN>",Hasan\n'
+    '3,2,"<SANAD>No SANAD</SANAD><MATN>بعض المتن هنا</MATN>",\n'
+)
+
+# Bios whose names match the NAR mentions above (exact-match → resolved narrator).
+_BIOS_CSV = "name,death_year\nمالك بن أنس,179\nأبو هريرة,59\nأنس بن مالك,93\n"
+
+_EXPECTED_HADITHS = 3
+
+
+@pytest.fixture
+def sources(tmp_path: Path) -> dict[str, Path]:
+    """Lay out a raw sanadset corpus (hadith CSV + narrator bios) on disk."""
+    raw_dir = tmp_path / "sanadset"
+    narrators_dir = raw_dir / "narrators"
+    narrators_dir.mkdir(parents=True)
+    (raw_dir / "bukhari.csv").write_text(_SANADSET_CSV, encoding="utf-8")
+    (narrators_dir / "bios.csv").write_text(_BIOS_CSV, encoding="utf-8")
+    return {
+        "raw": raw_dir,
+        "staging": _mkdir(tmp_path / "staging"),
+        "curated": _mkdir(tmp_path / "curated"),
+        "resolve": _mkdir(tmp_path / "resolve"),
+    }
+
+
+def _mkdir(p: Path) -> Path:
+    p.mkdir()
+    return p
+
+
+@pytest.mark.integration
+class TestSanadsetLightupLive:
+    def test_sanadset_narrators_and_hadiths_land_in_graph(
+        self, neo4j_client, sources: dict[str, Path]
+    ) -> None:
+        raw, staging, curated, resolve_out = (
+            sources["raw"],
+            sources["staging"],
+            sources["curated"],
+            sources["resolve"],
+        )
+
+        # --- parse: raw CSV -> staging Parquet (hadiths + mentions + bios) ------
+        outputs = sanadset.parse_sanadset(raw_dir=raw, staging_dir=staging)
+        assert "narrators_bio" in outputs, "bio parse must run for narrator resolution"
+
+        # --- resolve (narrator path): NER consolidation -> disambiguation -------
+        ner.run(staging, resolve_out)
+        disambiguate.run(staging, resolve_out)
+        canonical = resolve_out / "narrators_canonical.parquet"
+        assert canonical.exists(), "disambiguation must produce canonical narrators"
+        assert pq.read_table(canonical).num_rows >= 1, "expected >=1 resolved narrator"
+        # The loader reads narrators_canonical.parquet from the staging dir.
+        shutil.copy(canonical, staging / "narrators_canonical.parquet")
+
+        # A sanadset Collection so APPEARS_IN (hadith->collection) can materialize.
+        write_collections(
+            staging,
+            [
+                {
+                    "collection_id": "sanadset:bukhari",
+                    "name_en": "Sahih al-Bukhari (sanadset)",
+                    "source_corpus": "sanadset",
+                    "sect": "sunni",
+                }
+            ],
+            suffix="sanadset",
+        )
+
+        # --- load: real loaders into the live neo4j:5 container -----------------
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+        load_all_edges(neo4j_client, staging, curated, strict=False)
+
+        # 1. Narrator nodes landed with nar: ids and searchable Arabic names.
+        narrators = neo4j_client.execute_read(
+            "MATCH (n:Narrator) RETURN n.id AS id, n.name_ar AS name_ar"
+        )
+        assert len(narrators) >= 1
+        assert all(r["id"].startswith("nar:") for r in narrators)
+        assert any(r["name_ar"] for r in narrators), "narrators must carry a searchable name"
+
+        # 2. Hadith nodes carry sect + source_corpus and a single-corpus id.
+        hadiths = neo4j_client.execute_read(
+            "MATCH (h:Hadith) RETURN h.id AS id, h.sect AS sect, h.source_corpus AS source_corpus"
+        )
+        assert len(hadiths) == _EXPECTED_HADITHS
+        assert all(h["sect"] == "sunni" for h in hadiths)
+        assert all(h["source_corpus"] == "sanadset" for h in hadiths)
+        # da#82: ids are hdt:sanadset:... exactly once (no doubled corpus).
+        assert all(h["id"].startswith("hdt:sanadset:") for h in hadiths)
+        assert not any(h["id"].startswith("hdt:sanadset:sanadset:") for h in hadiths)
+
+        # 3. Collection node + APPEARS_IN edges landed with correct tagging.
+        collections = neo4j_client.execute_read(
+            "MATCH (c:Collection) RETURN c.sect AS sect, c.source_corpus AS source_corpus"
+        )
+        assert len(collections) == 1
+        assert collections[0]["sect"] == "sunni"
+        assert collections[0]["source_corpus"] == "sanadset"
+
+        appears_in = neo4j_client.execute_read(
+            "MATCH (:Hadith)-[r:APPEARS_IN]->(:Collection) RETURN count(r) AS n"
+        )
+        assert appears_in[0]["n"] == _EXPECTED_HADITHS

--- a/tests/test_acquire/test_sanadset.py
+++ b/tests/test_acquire/test_sanadset.py
@@ -1,0 +1,135 @@
+"""Tests for the Sanadset acquire-side downloader (da#89).
+
+Closes the acquire-side coverage gap: before this, only ``base`` and
+``sunnah_scraper`` had acquire-layer tests. Network access (Mendeley, Kaggle) is
+fully mocked — these assert the downloader's *orchestration* logic: idempotent
+skip-when-present, the Mendeley-primary path, Kaggle credential gating, row-count
+validation, and manifest/messaging emission.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.acquire.sanadset import (
+    _count_csv_rows,
+    _kaggle_credentials_available,
+    download_sanadset,
+)
+
+
+def _fake_download(url: str, path: Path, **_kwargs: object) -> None:
+    """Stand-in for ``download_file`` — materializes a tiny CSV at *path*."""
+    path.write_text("col_a,col_b\n1,2\n", encoding="utf-8")
+
+
+def _settings(*, kaggle_username: str | None = None, kaggle_key: str | None = None) -> MagicMock:
+    s = MagicMock()
+    s.kaggle_username = kaggle_username
+    s.kaggle_key = kaggle_key
+    return s
+
+
+class TestCountCsvRows:
+    def test_counts_data_rows_excluding_headers(self, tmp_path: Path) -> None:
+        (tmp_path / "a.csv").write_text("h1,h2\n1,2\n3,4\n", encoding="utf-8")
+        (tmp_path / "b.csv").write_text("h\nx\n", encoding="utf-8")
+        # (2 data rows) + (1 data row) = 3
+        assert _count_csv_rows(tmp_path) == 3
+
+
+class TestKaggleCredentials:
+    def test_true_from_settings(self) -> None:
+        with patch(
+            "src.acquire.sanadset.get_settings",
+            return_value=_settings(kaggle_username="u", kaggle_key="k"),
+        ):
+            assert _kaggle_credentials_available() is True
+
+    def test_false_when_absent(self, tmp_path: Path) -> None:
+        with (
+            patch("src.acquire.sanadset.get_settings", return_value=_settings()),
+            patch("src.acquire.sanadset.Path.home", return_value=tmp_path),
+        ):
+            assert _kaggle_credentials_available() is False
+
+    def test_true_from_kaggle_json(self, tmp_path: Path) -> None:
+        kaggle_dir = tmp_path / ".kaggle"
+        kaggle_dir.mkdir()
+        (kaggle_dir / "kaggle.json").write_text(
+            json.dumps({"username": "u", "key": "k"}), encoding="utf-8"
+        )
+        with (
+            patch("src.acquire.sanadset.get_settings", return_value=_settings()),
+            patch("src.acquire.sanadset.Path.home", return_value=tmp_path),
+        ):
+            assert _kaggle_credentials_available() is True
+
+
+class TestDownloadSanadset:
+    def test_downloads_mendeley_when_empty(self, tmp_path: Path) -> None:
+        dest = tmp_path / "sanadset"
+        with (
+            patch("src.acquire.sanadset.get_settings", return_value=_settings()),
+            patch("src.acquire.sanadset.Path.home", return_value=tmp_path / "nohome"),
+            patch("src.acquire.sanadset.download_file", side_effect=_fake_download) as dl,
+            patch("src.acquire.sanadset.write_manifest") as manifest,
+            patch("src.acquire.sanadset.emit_raw_new_for_manifest") as emit,
+        ):
+            out = download_sanadset(dest=dest)
+
+        assert out == dest
+        # Both Mendeley files (sanadset.csv, books.csv) were fetched.
+        assert dl.call_count == 2
+        manifest.assert_called_once()
+        emit.assert_called_once()
+
+    def test_skips_mendeley_when_csv_present(self, tmp_path: Path) -> None:
+        dest = tmp_path / "sanadset"
+        dest.mkdir()
+        (dest / "sanadset.csv").write_text("h\n1\n", encoding="utf-8")
+        with (
+            patch("src.acquire.sanadset.get_settings", return_value=_settings()),
+            patch("src.acquire.sanadset.Path.home", return_value=tmp_path / "nohome"),
+            patch("src.acquire.sanadset.download_file", side_effect=_fake_download) as dl,
+            patch("src.acquire.sanadset.write_manifest"),
+            patch("src.acquire.sanadset.emit_raw_new_for_manifest"),
+        ):
+            download_sanadset(dest=dest)
+
+        # Idempotent: existing CSVs short-circuit the Mendeley download.
+        dl.assert_not_called()
+
+    def test_narrators_skipped_without_credentials(self, tmp_path: Path) -> None:
+        dest = tmp_path / "sanadset"
+        with (
+            patch("src.acquire.sanadset.get_settings", return_value=_settings()),
+            patch("src.acquire.sanadset.Path.home", return_value=tmp_path / "nohome"),
+            patch("src.acquire.sanadset.download_file", side_effect=_fake_download),
+            patch("src.acquire.sanadset.write_manifest"),
+            patch("src.acquire.sanadset.emit_raw_new_for_manifest"),
+            patch("src.acquire.sanadset._run_kaggle_download") as kaggle,
+        ):
+            download_sanadset(dest=dest)
+
+        # No Kaggle creds → narrator-bio download is never attempted.
+        kaggle.assert_not_called()
+
+    def test_narrators_downloaded_with_credentials(self, tmp_path: Path) -> None:
+        dest = tmp_path / "sanadset"
+        with (
+            patch(
+                "src.acquire.sanadset.get_settings",
+                return_value=_settings(kaggle_username="u", kaggle_key="k"),
+            ),
+            patch("src.acquire.sanadset.download_file", side_effect=_fake_download),
+            patch("src.acquire.sanadset.write_manifest"),
+            patch("src.acquire.sanadset.emit_raw_new_for_manifest"),
+            patch("src.acquire.sanadset._run_kaggle_download") as kaggle,
+        ):
+            download_sanadset(dest=dest)
+
+        # Credentials present → narrator-bio dataset is fetched into narrators/.
+        kaggle.assert_called_once()

--- a/tests/test_parse/test_sanadset_parser.py
+++ b/tests/test_parse/test_sanadset_parser.py
@@ -157,3 +157,37 @@ class TestSanadsetParser:
                 mock_settings.return_value.data_raw_dir = tmp_path / "raw"
                 mock_settings.return_value.data_staging_dir = staging_dir
                 parse_sanadset(raw_dir=raw_dir, staging_dir=staging_dir)
+
+    def test_narrator_bios_parsed_without_corpus_failfast(self, tmp_path: Path) -> None:
+        """Bios parse cleanly even though their id namespace is not a SourceCorpus.
+
+        Regression for da#89: the bio_id is namespaced by the bio *source*
+        (``kaggle_narrators``), which is not a hadith ``SourceCorpus``. Building
+        it through ``generate_source_id`` would trip that helper's da#82
+        fail-fast on an unknown corpus and abort the whole parse the moment a
+        ``narrators/`` directory is present (the real acquisition path). Here a
+        bio CSV IS present, so a regression resurfaces as a raised ValueError.
+        """
+        raw_dir = tmp_path / "raw" / "sanadset"
+        raw_dir.mkdir(parents=True)
+        narrators_dir = raw_dir / "narrators"
+        narrators_dir.mkdir()
+        staging_dir = tmp_path / "staging"
+
+        _make_sanadset_csv(raw_dir / "hadiths.csv")
+        (narrators_dir / "bios.csv").write_text(
+            "name,death_year\nمالك بن أنس,179\nأبو هريرة,59\n",
+            encoding="utf-8",
+        )
+
+        with patch("src.parse.sanadset.get_settings") as mock_settings:
+            mock_settings.return_value.data_raw_dir = tmp_path / "raw"
+            mock_settings.return_value.data_staging_dir = staging_dir
+            outputs = parse_sanadset(raw_dir=raw_dir, staging_dir=staging_dir)
+
+        assert "narrators_bio" in outputs
+        bio_table = pq.read_table(outputs["narrators_bio"])
+        assert bio_table.num_rows == 2
+        # bio_id is the bio-source-namespaced provenance key, never corpus-gated.
+        bio_ids = bio_table.column("bio_id").to_pylist()
+        assert all(bid.startswith("kaggle_narrators:bios:") for bid in bio_ids)


### PR DESCRIPTION
## da#89 (L6): light up sanadset end-to-end — narrator keystone

Lights up the **sanadset** adapter (Sanadset 650K, sunni-heavy) end-to-end —
`parse → ner → disambiguate → load` — into a live `neo4j:5`, producing the
**Narrator** nodes that unblock isnad-graph#963 (narrator search) / #965. The
adapter + parser already existed and were parse-validated; this PR makes them
land in the graph through the canonical schema and the da#82 id contract.

### Changes
- **`src/parse/sanadset.py`** — build the narrator-bio provenance key directly
  with `ID_DELIMITER` instead of `generate_source_id()`. The bio source
  (`kaggle_narrators`) is **not** a hadith `SourceCorpus`, so da#82's fail-fast
  would (correctly) reject it and abort the entire parse the moment a
  `narrators/` directory is present — i.e. the real acquisition path. Latent
  until now because existing parse tests create no `narrators/` dir.
- **`src/resolve/disambiguate.py`** — route `_make_canonical_id` through the
  da#82 `narrator_node_id()` helper instead of hand-concatenating `nar:`, so
  resolve and the loaders share one prefixing rule (no drift, idempotent).
- **`tests/integration/test_sanadset_lightup.py`** — live `neo4j:5` E2E proof
  (skip-guarded off Docker).
- **`tests/test_acquire/test_sanadset.py`** — new acquire-side coverage (only
  `base` + `sunnah_scraper` had one before).
- **`tests/test_parse/test_sanadset_parser.py`** — regression for the bio_id
  fail-fast fix.

### Acceptance — LIVE local neo4j:5 (owner bar)
`tests/integration/test_sanadset_lightup.py` runs the **real** parser + resolve
+ loaders against a live `neo4j:5` container and asserts **real nodes/edges**:
- **Narrator** nodes land with `nar:`-prefixed ids and searchable Arabic names.
- **Hadith** nodes carry `sect="sunni"` + `source_corpus="sanadset"` and a
  single-corpus `hdt:sanadset:…` id (no da#82 double-prefix).
- **APPEARS_IN** hadith→collection edges materialize against a sanadset
  Collection that is itself `sect="sunni"` / `source_corpus="sanadset"`.

```
tests/integration/test_sanadset_lightup.py::TestSanadsetLightupLive::test_sanadset_narrators_and_hadiths_land_in_graph PASSED  [16.27s, real neo4j:5-community]
```
Off-Docker it degrades to a clean SKIP via the `neo4j_client` fixture.

Local: 16 unit tests (parse+acquire) pass; full resolve+parse+graph suites
306 passed / 3 skipped; `ruff format --check`, `ruff check`, `mypy src/` clean.

### Reachability + licensing
- **Hadith corpus — Mendeley Data, primary, public, no credentials.** Sanadset
  650K v4, DOI `10.17632/5xth87zwb5.4`, stable public download URLs (per-file
  SHA-256 pinned in `src/acquire/sanadset.py`). Reachable headless in CI/sandbox.
- **Narrator biographies — Kaggle `fahd09/hadith-narrators`, CC0.** Requires
  `KAGGLE_USERNAME` / `KAGGLE_KEY`; gated and **skipped cleanly** when absent
  (no hard failure). Was briefly removed circa early 2026, accessible again as
  of March 2026.

### Out of scope / follow-ups
- **NARRATED (narrator→hadith) edges are not asserted here — tracked in #109.**
  `disambiguate.run` writes `narrators_canonical.parquet` + a `merge_log.parquet`
  mapping `mention_id → canonical_id`, but does **not** backfill
  `canonical_narrator_id` into `narrator_mentions_resolved.parquet`, which is what
  `_load_narrated` / `_load_chains` read. So narrator→hadith wiring needs a
  cross-source resolve change with its own blast radius — deferred to **#109**
  (adjacent to T3 #99 / #101), not this T1 light-up. The keystone (searchable
  Narrator nodes) is delivered; the edge enrichment is the follow-up.
- **Staging-cluster load** (cluster-internal `ssh docker exec cypher-shell`) is a
  **separate post-merge verify**, not a PR gate, per the issue.

Closes #89
Refs #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
