### PR TITLE
da#84 (L1): extend sunnah_scraper light-up beyond riyadussalihin (adab + live multi-collection neo4j:5)

### DIFF
--- a/scripts/first_light/sample/sunnah_scraped/adab.json
+++ b/scripts/first_light/sample/sunnah_scraped/adab.json
@@ -1,0 +1,462 @@
+[
+  {
+    "hadith_number": 1,
+    "book_number": 1,
+    "text_ar": "أَخْبَرَنَا أَبُو نَصْرٍ أَحْمَدُ بْن مُحَمَّدِ بْنِ الْحَسَنِ بْنِ حَامِدِ بْنِ هَارُونَ بْنِ عَبْدِ الجْبَّارِ البُخَارِيُّ المَعْرُوفُ بِابْنِ النَّيَازِكِيِّ قِرَاءَةً عَلَيْهِ فَأَقْرَّ بِهِ قَدِمَ عَلَيْنَا حَاجًا فِي صَفَرَ سَنَةَ سَبْعِينَ وَثَلاثِمِئَةٍ، قَالَ‏:‏ أَخْبَرَناَ أَبُو الْخَيْرِ أَحْمَدُ بْنُ مُحَمِّدِ بْنِ الجَلِيلِ بْنِ خَالِدِ بْنِ حُرَيْثٍ البُخَارِيُّ الْكِرْمَانِيُّ الْعَبْقَسِيُّ البَزَّارُ سَنَة اثْنَتَيْنِ وَعِشْرِينَ وَثَلاَثِمِئَةٍ، قَالَ‏:‏ حَدَّثَنَا أَبُو عَبْدِ اللهِ مُحَمَّدُ بْنُ إِسْمَاعِيلَ بْنِ إِبْرَاهِيمَ بْنِ المُغَيرَةِ بْنِ الأَحْنَفِ الْجُعْفِيُّ البُخَاِرُّي قال‏:‏ حَدَّثَنَا أَبُو الْوَلِيدِ، قَالَ‏:‏ حَدَّثَنَا شُعْبَةُ قَالَ‏:‏ الْوَلِيدُ بْنُ الْعَيْزَارِ أَخْبَرَنِي قَالَ‏:‏ سَمِعْتُ أَبَا عَمْرٍو الشَّيْبَانِيَّ يَقُولُ‏:‏ حَدَّثَنَا صَاحِبُ هَذِهِ الدَّارِ، وَأَوْمَأَ بِيَدِهِ إِلَى دَارِ عَبْدِ اللهِ قَالَ‏:‏ سَأَلْتُ النَّبِيَّ صلى الله عليه وسلم‏:‏ أَيُّ الْعَمَلِ أَحَبُّ إِلَى اللهِ عَزَّ وَجَلَّ‏؟‏ قَالَ‏:‏ الصَّلاَةُ عَلَى وَقْتِهَا، قُلْتُ‏:‏ ثُمَّ أَيٌّ‏؟‏ قَالَ‏:‏ ثُمَّ بِرُّ الْوَالِدَيْنِ، قُلْتُ‏:‏ ثُمَّ أَيٌّ‏؟‏ قَالَ‏:‏ ثُمَّ الْجِهَادُ فِي سَبِيلِ اللهِ قَالَ‏:‏ حَدَّثَنِي بِهِنَّ، وَلَوِ اسْتَزَدْتُهُ لَزَادَنِي‏.‏",
+    "text_en": "Abu 'Amr ash-Shaybani said, \"The owner of this house (and he pointed at\nthe house of 'Abdullah ibn Mas'ud) said, \"I asked the Prophet, may Allah\nbless him and grant him peace, which action Allah loves best. He replied,\n'Prayer at its proper time.' 'Then what?' I asked. He said, 'Then kindness\nto parents.\" I asked, 'Then what?' He replied, 'Then jihad in the Way of\nAllah.'\" He added, \"He told me about these things. If I had asked him to\ntell me more, he would have told me more.\"",
+    "grade": null,
+    "chapter_number": 101,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 2,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا آدَمُ، قَالَ‏:‏ حَدَّثَنَا شُعْبَةُ، قَالَ‏:‏ حَدَّثَنَا يَعْلَى بْنُ عَطَاءٍ، عَنْ أَبِيهِ، عَنْ عَبْدِ اللهِ بْنِ عُمَرَ قَالَ‏:‏ رِضَا الرَّبِّ فِي رِضَا الْوَالِدِ، وَسَخَطُ الرَّبِّ فِي سَخَطِ الْوَالِدِ‏.‏",
+    "text_en": "'Abdullah ibn 'Umar said, \"The pleasure of the Lord lies in the pleasure\nof the parent. The anger of the Lord lies in the anger of the parent.\"",
+    "grade": null,
+    "chapter_number": 102,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 3,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا أَبُو عَاصِمٍ، عَنْ بَهْزِ بْنِ حَكِيمٍ، عَنْ أَبِيهِ، عَنْ جَدِّهِ، قُلْتُ‏:‏ يَا رَسُولَ اللهِ، مَنْ أَبَرُّ‏؟‏ قَالَ‏:‏ أُمَّكَ، قُلْتُ‏:‏ مَنْ أَبَرُّ‏؟‏ قَالَ‏:‏ أُمَّكَ، قُلْتُ‏:‏ مَنْ أَبَرُّ‏؟‏ قَالَ‏:‏ أُمَّكَ، قُلْتُ‏:‏ مَنْ أَبَرُّ‏؟‏ قَالَ‏:‏ أَبَاكَ، ثُمَّ الأَقْرَبَ فَالأَقْرَبَ‏.‏",
+    "text_en": "Bahz ibn Hakim's grandfather said, \"I asked, 'Messenger of Allah, to whom\nshould I be dutiful?' 'Your mother,' he replied. I asked, 'Then whom?' 'Your\nmother,' he replied. I asked, 'Then whom?' 'Your mother,' he replied. I asked, 'Then to whom should I be\ndutiful?' 'Your father,' he replied, 'and then the next closest relative\nand then the next.'\"",
+    "grade": null,
+    "chapter_number": 103,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 4,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا سَعِيدُ بْنُ أَبِي مَرْيَمَ، قَالَ‏:‏ أَخْبَرَنَا مُحَمَّدُ بْنُ جَعْفَرِ بْنِ أَبِي كَثِيرٍ قَالَ‏:‏ أَخْبَرَنِي زَيْدُ بْنُ أَسْلَمَ، عَنْ عَطَاءِ بْنِ يَسَارٍ، عَنِ ابْنِ عَبَّاسٍ، أَنَّهُ أَتَاهُ رَجُلٌ فَقَالَ‏:‏ إِنِّي خَطَبْتُ امْرَأَةً، فَأَبَتْ أَنْ تَنْكِحَنِي، وَخَطَبَهَا غَيْرِي، فَأَحَبَّتْ أَنْ تَنْكِحَهُ، فَغِرْتُ عَلَيْهَا فَقَتَلْتُهَا، فَهَلْ لِي مِنْ تَوْبَةٍ‏؟‏ قَالَ‏:‏ أُمُّكَ حَيَّةٌ‏؟‏ قَالَ‏:‏ لاَ، قَالَ‏:‏ تُبْ إِلَى اللهِ عَزَّ وَجَلَّ، وَتَقَرَّبْ إِلَيْهِ مَا اسْتَطَعْتَ‏.‏ فَذَهَبْتُ فَسَأَلْتُ ابْنَ عَبَّاسٍ‏:‏ لِمَ سَأَلْتَهُ عَنْ حَيَاةِ أُمِّهِ‏؟‏ فَقَالَ‏:‏ إِنِّي لاَ أَعْلَمُ عَمَلاً أَقْرَبَ إِلَى اللهِ عَزَّ وَجَلَّ مِنْ بِرِّ الْوَالِدَةِ‏.‏",
+    "text_en": "'Ata' ibn Yasar said that a man came to Ibn 'Abbas and said, \"I asked\na woman to marry me and she refused to marry me. Another man asked her and\nshe agreed to marry him. I became jealous and killed her. Is there any way\nfor me to repent?\" He asked, \"Is your mother alive?\" \"No,\" he replied. He\nsaid, \"repent to Allah Almighty and try to draw near Him as much as you can.\"So I went and asked Ibn `Abbas why he inquired about the man's mother. He replied:\"I don't know of a deed closer to Allah, Exalted and Majestic, other than dutifulness to the mother.\"",
+    "grade": null,
+    "chapter_number": 104,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 5,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا سُلَيْمَانُ بْنُ حَرْبٍ، قَالَ‏:‏ حَدَّثَنَا وُهَيْبُ بْنُ خَالِدٍ، عَنِ ابْنِ شُبْرُمَةَ قَالَ‏:‏ سَمِعْتُ أَبَا زُرْعَةَ، عَنْ أَبِي هُرَيْرَةَ قَالَ‏:‏ قِيلَ‏:‏ يَا رَسُولَ اللهِ صلى الله عليه وسلم، مَنْ أَبَرُّ‏؟‏ قَالَ‏:‏ أُمَّكَ، قَالَ‏:‏ ثُمَّ مَنْ‏؟‏ قَالَ‏:‏ أُمَّكَ، قَالَ‏:‏ ثُمَّ مَنْ‏؟‏ قَالَ‏:‏ أُمَّكَ، قَالَ‏:‏ ثُمَّ مَنْ‏؟‏ قَالَ‏:‏ أَبَاكَ‏.‏",
+    "text_en": "Abu Hurayra said, \"The Prophet was asked, 'Messenger of Allah, to whom\nshould I be dutiful?' 'Your mother,' he replied. He was asked, 'Then whom?'\n'Your mother,' he replied. He was asked, 'Then whom?' 'Your mother,' he replied.\nHe was asked, 'Then\nwhom?' He replied, 'Your father.'\"",
+    "grade": null,
+    "chapter_number": 105,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 6,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا بِشْرُ بْنُ مُحَمَّدٍ، قَالَ‏:‏ أَخْبَرَنَا عَبْدُ اللهِ، قَالَ‏:‏ أَخْبَرَنَا يَحْيَى بْنُ أَيُّوبَ، قَالَ‏:‏ حَدَّثَنَا أَبُو زُرْعَةَ، عَنْ أَبِي هُرَيْرَةَ، أَتَى رَجُلٌ نَبِيَّ اللهِ صلى الله عليه وسلم فَقَالَ‏:‏ مَا تَأْمُرُنِي‏؟‏ فَقَالَ‏:‏ بِرَّ أُمَّكَ، ثُمَّ عَادَ، فَقَالَ‏:‏ بِرَّ أُمَّكَ، ثُمَّ عَادَ، فَقَالَ‏:‏ بِرَّ أُمَّكَ، ثُمَّ عَادَ الرَّابِعَةَ، فَقَالَ‏:‏ بِرَّ أَبَاكَ‏.‏",
+    "text_en": "Abu Hurayra reported:\"A man came to the Prophet of Allah, may Allah bless\nhim and grant him peace, and asked, 'What do you command me to do?' He replied,\n'Be dutiful towards your mother.' Then he asked him the same question again\nand he replied, 'Be dutiful towards your mother.' He repeated it yet again\nand the Prophet replied, 'Be dutiful towards your mother.' Then he put the question a fourth time and the Prophet said, 'Be dutiful towards\nyour father.'\"",
+    "grade": null,
+    "chapter_number": 106,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 7,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا حَجَّاجٌ، قَالَ‏:‏ حَدَّثَنَا حَمَّادٌ هُوَ ابْنُ سَلَمَةَ، عَنْ سُلَيْمَانَ التَّيْمِيِّ، عَنْ سَعِيدٍ الْقَيْسِيِّ، عَنِ ابْنِ عَبَّاسٍ قَالَ‏:‏ مَا مِنْ مُسْلِمٍ لَهُ وَالِدَانِ مُسْلِمَانِ يُصْبِحُ إِلَيْهِمَا مُحْتَسِبًا، إِلاَّ فَتْحَ لَهُ اللَّهُ بَابَيْنِ يَعْنِي‏:‏ مِنَ الْجَنَّةِ وَإِنْ كَانَ وَاحِدًا فَوَاحِدٌ، وَإِنْ أَغْضَبَ أَحَدَهُمَا لَمْ يَرْضَ اللَّهُ عَنْهُ حَتَّى يَرْضَى عَنْهُ، قِيلَ‏:‏ وَإِنْ ظَلَمَاهُ‏؟‏ قَالَ‏:‏ وَإِنْ ظَلَمَاهُ‏.‏",
+    "text_en": "Ibn 'Abbas said, \"If any Muslim obeys Allah regarding his parents, Allah\nwill open two gates of the Garden for him. If there is only one parent, then\none gate will be opened. If one of them is angry, then Allah will not be\npleased with him until that parent is pleased with him.\" He was asked, \"Even\nif they wrong him?\" \"Even if they wrong him\" he replied.",
+    "grade": null,
+    "chapter_number": 107,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 8,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُسَدَّدٌ، قَالَ‏:‏ حَدَّثَنَا إِسْمَاعِيلُ بْنُ إِبْرَاهِيمَ، قَالَ‏:‏ حَدَّثَنَا زِيَادُ بْنُ مِخْرَاقٍ قَالَ‏:‏ حَدَّثَنِي طَيْسَلَةُ بْنُ مَيَّاسٍ قَالَ‏:‏ كُنْتُ مَعَ النَّجَدَاتِ، فَأَصَبْتُ ذُنُوبًا لاَ أَرَاهَا إِلاَّ مِنَ الْكَبَائِرِ، فَذَكَرْتُ ذَلِكَ لِابْنِ عُمَرَ قَالَ‏:‏ مَا هِيَ‏؟‏ قُلْتُ‏:‏ كَذَا وَكَذَا، قَالَ‏:‏ لَيْسَتْ هَذِهِ مِنَ الْكَبَائِرِ، هُنَّ تِسْعٌ‏:‏ الإِشْرَاكُ بِاللَّهِ، وَقَتْلُ نَسَمَةٍ، وَالْفِرَارُ مِنَ الزَّحْفِ، وَقَذْفُ الْمُحْصَنَةِ، وَأَكْلُ الرِّبَا، وَأَكْلُ مَالِ الْيَتِيمِ، وَإِلْحَادٌ فِي الْمَسْجِدِ، وَالَّذِي يَسْتَسْخِرُ، وَبُكَاءُ الْوَالِدَيْنِ مِنَ الْعُقُوقِ‏.‏ قَالَ لِي ابْنُ عُمَرَ‏:‏ أَتَفْرَقُ النَّارَ، وَتُحِبُّ أَنْ تَدْخُلَ الْجَنَّةَ‏؟‏ قُلْتُ‏:‏ إِي وَاللَّهِ، قَالَ‏:‏ أَحَيٌّ وَالِدُكَ‏؟‏ قُلْتُ‏:‏ عِنْدِي أُمِّي، قَالَ‏:‏ فَوَاللَّهِ لَوْ أَلَنْتَ لَهَا الْكَلاَمَ، وَأَطْعَمْتَهَا الطَّعَامَ، لَتَدْخُلَنَّ الْجَنَّةَ مَا اجْتَنَبْتَ الْكَبَائِرَ‏.‏",
+    "text_en": "Taysala ibn Mayyas said, \"I was with the Najadites [Kharijites] when I\ncommitted wrong actions which I supposed were major wrong actions. I mentioned\nthat to Ibn 'Umar. He inquired, 'What are they?\" I replied, 'Such-and-such.'\nHe stated, 'These are not major wrong actions. There are nine major wrong\nactions. They are:associating others with Allah, killing someone, desertion\nfrom the army when it is advancing, slandering a chaste woman, usury, consuming\nan orphan's property, heresy in the mosque, scoffing, and causing one's parents\nto weep through disobedience.' Ibn 'Umar then said to me, 'Do you wish to\nseparate yourself from the Fire? Would you like to enter Paradise?' 'By Allah,\nyes!' I replied. He asked, 'Are your parents still alive?' I replied, 'My\nmother is.' He said, 'By Allah, if you speak gently to her and feed her,\nthen you will enter the Garden as long as you avoid the major wrong actions.'\"",
+    "grade": null,
+    "chapter_number": 108,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 9,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا أَبُو نُعَيْمٍ، قَالَ‏:‏ حَدَّثَنَا سُفْيَانُ، عَنْ هِشَامِ بْنِ عُرْوَةَ، عَنْ أَبِيهِ قَالَ‏:‏ ‏{‏وَاخْفِضْ لَهُمَا جَنَاحَ الذُّلِّ مِنَ الرَّحْمَةِ‏}‏، قَالَ‏:‏ لاَ تَمْتَنِعْ مِنْ شَيْءٍ أَحَبَّاهُ‏.‏",
+    "text_en": "Hisham ibn 'Urwa related this ayat from his father, \"Take them\nunder your wing, out of mercy, with due humility.\" (17:24)",
+    "grade": null,
+    "chapter_number": 109,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 10,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا قَبِيصَةُ، قَالَ‏:‏ حَدَّثَنَا سُفْيَانُ، عَنْ سُهَيْلِ بْنِ أَبِي صَالِحٍ، عَنْ أَبِيهِ، عَنْ أَبِي هُرَيْرَةَ، عَنِ النَّبِيِّ صلى الله عليه وسلم قَالَ‏:‏ لاَ يَجْزِي وَلَدٌ وَالِدَهُ، إِلاَّ أَنْ يَجِدَهُ مَمْلُوكًا فَيَشْتَرِيَهُ فَيُعْتِقَهُ‏.‏",
+    "text_en": "Abu Hurayra reported that the Prophet, may Allah bless him and grant\nhim peace, said, \"A child cannot repay his father unless he finds him as\na slave and the buys him and sets him free.\"",
+    "grade": null,
+    "chapter_number": 110,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 11,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا آدَمُ، قَالَ‏:‏ حَدَّثَنَا شُعْبَةُ، قَالَ‏:‏ حَدَّثَنَا سَعِيدُ بْنُ أَبِي بُرْدَةَ قَالَ‏:‏ سَمِعْتُ أَبِي يُحَدِّثُ، أَنَّهُ شَهِدَ ابْنَ عُمَرَ وَرَجُلٌ يَمَانِيٌّ يَطُوفُ بِالْبَيْتِ، حَمَلَ أُمَّهُ وَرَاءَ ظَهْرِهِ، يَقُولُ‏:‏\nإِنِّي لَهَا بَعِيرُهَا الْمُذَلَّلُ إِنْ أُذْعِرَتْ رِكَابُهَا لَمْ أُذْعَرِثُمَّ قَالَ‏:‏ يَا ابْنَ عُمَرَ أَتُرَانِي جَزَيْتُهَا‏؟‏ قَالَ‏:‏ لاَ، وَلاَ بِزَفْرَةٍ وَاحِدَةٍ، ثُمَّ طَافَ ابْنُ عُمَرَ، فَأَتَى الْمَقَامَ فَصَلَّى رَكْعَتَيْنِ، ثُمَّ قَالَ‏:‏ يَا ابْنَ أَبِي مُوسَى، إِنَّ كُلَّ رَكْعَتَيْنِ تُكَفِّرَانِ مَا أَمَامَهُمَا‏.‏",
+    "text_en": "Sa'id ibn Abi Burda said, \"I heard my father say that Ibn 'Umar saw a\nYamani man going around the House while carrying his mother on his back,\nsaying, 'I am your humble camel. If her mount is frightened, I am not\nfrightened.' Then he asked, 'Ibn 'Umar? Do you think that I have repaid her?'\nHe replied, 'No, not even for a single groan.'",
+    "grade": null,
+    "chapter_number": 111,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 12,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا عَبْدُ اللهِ بْنُ صَالِحٍ قَالَ‏:‏ حَدَّثَنِي اللَّيْثُ قَالَ‏:‏ حَدَّثَنِي خَالِدُ بْنُ يَزِيدَ، عَنْ سَعِيدِ بْنِ أَبِي هِلاَلٍ، عَنْ أَبِي حَازِمٍ، عَنْ أَبِي مُرَّةَ مَوْلَى عَقِيلٍ، أَنَّ أَبَا هُرَيْرَةَ كَانَ يَسْتَخْلِفُهُ مَرْوَانُ، وَكَانَ يَكُونُ بِذِي الْحُلَيْفَةِ، فَكَانَتْ أُمُّهُ فِي بَيْتٍ وَهُوَ فِي آخَرَ‏.‏ قَالَ‏:‏ فَإِذَا أَرَادَ أَنْ يَخْرُجَ وَقَفَ عَلَى بَابِهَا فَقَالَ‏:‏ السَّلاَمُ عَلَيْكِ يَا أُمَّتَاهُ وَرَحْمَةُ اللهِ وَبَرَكَاتُهُ، فَتَقُولُ‏:‏ وَعَلَيْكَ السَّلاَمُ يَا بُنَيَّ وَرَحْمَةُ اللهِ وَبَرَكَاتُهُ، فَيَقُولُ‏:‏ رَحِمَكِ اللَّهُ كَمَا رَبَّيْتِنِي صَغِيرًا، فَتَقُولُ‏:‏ رَحِمَكَ اللَّهُ كَمَا بَرَرْتَنِي كَبِيرًا، ثُمَّ إِذَا أَرَادَ أَنْ يَدْخُلَ صَنَعَ مِثْلَهُ‏.‏",
+    "text_en": "Marwan used to make Abu Hurayra his agent and he used to be located in\nDhu'l-Hulayfa. His mother was in one house and he was in another. When he\nwanted to go out, he would stop at her door and say, \"Peace be upon you,\nmother, and the mercy of Allah and His blessing.\" She would reply, \"And peace\nbe upon you, my son, and the mercy of Allah and His blessing.\" Then he said,\n\"May Allah have mercy on you as you raised me when I was a child.\" She answered,\n\"May Allah have mercy on you as you were dutiful to me when I was old.\" Whenever\nhe wanted to go inside, he would do something similar.",
+    "grade": null,
+    "chapter_number": 112,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 13,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا أَبُو نُعَيْمٍ، قَالَ‏:‏ حَدَّثَنَا سُفْيَانُ، عَنْ عَطَاءِ بْنِ السَّائِبِ، عَنْ أَبِيهِ، عَنْ عَبْدِ اللهِ بْنِ عَمْرٍو قَالَ‏:‏ جَاءَ رَجُلٌ إِلَى النَّبِيِّ صلى الله عليه وسلم يُبَايِعُهُ عَلَى الْهِجْرَةِ، وَتَرَكَ أَبَوَيْهِ يَبْكِيَانِ، فَقَالَ‏:‏ ارْجِعْ إِلَيْهِمَا، وَأَضْحِكْهُمَا كَمَا أَبْكَيْتَهُمَا‏.‏",
+    "text_en": "'Abdullah ibn 'Amr said, \"A man came to the Prophet, may Allah bless\nhim and grant him peace, and made a pledge to him that he would do hijra.\nHe left his parents who were in tears. The Prophet said, 'Go back to them\nand make them laugh as you made them weep.'\"",
+    "grade": null,
+    "chapter_number": 113,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 14,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا عَبْدُ الرَّحْمَنِ بْنُ شَيْبَةَ قَالَ‏:‏ أَخْبَرَنِي ابْنُ أَبِي الْفُدَيْكِ قَالَ‏:‏ حَدَّثَنِي مُوسَى، عَنْ أَبِي حَازِمٍ، أَنَّ أَبَا مُرَّةَ، مَوْلَى أُمِّ هَانِئِ ابْنَةِ أَبِي طَالِبٍ أَخْبَرَهُ، أَنَّهُ رَكِبَ مَعَ أَبِي هُرَيْرَةَ إِلَى أَرْضِهِ بِالْعَقِيقِ فَإِذَا دَخَلَ أَرْضَهُ صَاحَ بِأَعْلَى صَوْتِهِ‏:‏ عَلَيْكِ السَّلاَمُ وَرَحْمَةُ اللهِ وَبَرَكَاتُهُ يَا أُمَّتَاهُ، تَقُولُ‏:‏ وَعَلَيْكَ السَّلاَمُ وَرَحْمَةُ اللهِ وَبَرَكَاتُهُ، يَقُولُ‏:‏ رَحِمَكِ اللَّهُ رَبَّيْتِنِي صَغِيرًا، فَتَقُولُ‏:‏ يَا بُنَيَّ، وَأَنْتَ فَجَزَاكَ اللَّهُ خَيْرًا وَرَضِيَ عَنْكَ كَمَا بَرَرْتَنِي كَبِيرًا قَالَ مُوسَى‏:‏ كَانَ اسْمُ أَبِي هُرَيْرَةَ‏:‏ عَبْدَ اللهِ بْنَ عَمْرٍو‏.‏",
+    "text_en": "Abu Hazim reported that Abu Murra, the mawla of Umm Hani' bint Abi Talib\nhad told him that he rode with Abu Hurayra to his land in al-'Aqiq. When\nhe entered his land, he shouted out in his loudest voice, \"Peace be upon\nyou, mother, and the mercy of Allah and His blessing!\" She replied, \"And\npeace be upon you and the mercy of Allah and His blessing.\" He said, \"May\nAllah have mercy on you as you raised me when I was a child.\" She replied,\n\"My son, may Allah repay you well and be pleased with you as you were dutiful\ntowards me when I was old.\"",
+    "grade": null,
+    "chapter_number": 114,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 15,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُسَدَّدٌ، قَالَ‏:‏ حَدَّثَنَا بِشْرُ بْنُ الْفَضْلِ، قَالَ‏:‏ حَدَّثَنَا الْجُرَيْرِيُّ، عَنْ عَبْدِ الرَّحْمَنِ بْنِ أَبِي بَكْرَةَ، عَنْ أَبِيهِ قَالَ‏:‏ قَالَ رَسُولُ اللهِ صلى الله عليه وسلم‏:‏ أَلاَ أُنَبِّئُكُمْ بِأَكْبَرِ الْكَبَائِرِ‏؟‏ ثَلاَثًا، قَالُوا‏:‏ بَلَى يَا رَسُولَ اللهِ، قَالَ‏:‏ الإِشْرَاكُ بِاللَّهِ، وَعُقُوقُ الْوَالِدَيْنِ وَجَلَسَ وَكَانَ مُتَّكِئًا أَلاَ وَقَوْلُ الزُّورِ، مَا زَالَ يُكَرِّرُهَا حَتَّى قُلْتُ‏:‏ لَيْتَهُ سَكَتَ‏.‏",
+    "text_en": "Abu Bakra reported that the Messenger of Allah, may Allah bless him and\ngrant him peace, said, \"Shall I tell you which is the worst of the major\nwrong actions?\" \"Yes, Messenger of Allah,\" they replied. He said, \"Associating\nsomething else with Allah and disobeying parents.\" He had been reclining\nbut then he sat up and said, \"and false witness.\" Abu Bakra said, \"He continued\nto repeat it until I said, 'Is he never going to stop?'\"",
+    "grade": null,
+    "chapter_number": 115,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 16,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُحَمَّدُ بْنُ سَلاَمٍ، قَالَ‏:‏ أَخْبَرَنَا جَرِيرٌ، عَنْ عَبْدِ الْمَلِكِ بْنِ عُمَيْرٍ، عَنْ وَرَّادٍ، كَاتِبِ الْمُغِيرَةِ بْنِ شُعْبَةَ، قَالَ‏:‏ كَتَبَ مُعَاوِيَةُ إِلَى الْمُغِيرَةِ‏:‏ اكْتُبْ إِلَيَّ بِمَا سَمِعْتَ مِنْ رَسُولِ اللهِ صلى الله عليه وسلم‏.‏ قَالَ وَرَّادٌ‏:‏ فَأَمْلَى عَلَيَّ وَكَتَبْتُ بِيَدَيَّ‏:‏ إِنِّي سَمِعْتُهُ يَنْهَى عَنْ كَثْرَةِ السُّؤَالِ، وَإِضَاعَةِ الْمَالِ، وَعَنْ قِيلَ وَقَالَ‏.‏",
+    "text_en": "Warrad, the scribe of al-Mughira ibn Shu'ba, said, \"Mu'awiya wrote to\nal-Mughira, saying, 'Write down for me what you heard the Messenger of Allah,\nmay Allah bless him and grant him peace, say.'\" Warrad said, \"He dictated\nto me and I wrote out, 'I heard him forbid asking too many questions, wasting\nmoney and chit-chat.'\"",
+    "grade": null,
+    "chapter_number": 116,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 17,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا عَمْرُو بْنُ مَرْزُوقٍ، قَالَ‏:‏ أَخْبَرَنَا شُعْبَةُ، عَنِ الْقَاسِمِ بْنِ أَبِي بَزَّةَ، عَنْ أَبِي الطُّفَيْلِ قَالَ‏:‏ سُئِلَ عَلِيٌّ‏:‏ هَلْ خَصَّكُمُ النَّبِيُّ صلى الله عليه وسلم بِشَيْءٍ لَمْ يَخُصَّ بِهِ النَّاسَ كَافَّةً‏؟‏ قَالَ‏:‏ مَا خَصَّنَا رَسُولُ اللهِ صلى الله عليه وسلم بِشَيْءٍ لَمْ يَخُصَّ بِهِ النَّاسَ، إِلاَّ مَا فِي قِرَابِ سَيْفِي، ثُمَّ أَخْرَجَ صَحِيفَةً، فَإِذَا فِيهَا مَكْتُوبٌ‏:‏ لَعَنَ اللَّهُ مَنْ ذَبَحَ لِغَيْرِ اللهِ، لَعَنَ اللَّهُ مَنْ سَرَقَ مَنَارَ الأَرْضِ، لَعَنَ اللَّهُ مَنْ لَعَنَ وَالِدَيْهِ، لَعَنَ اللَّهُ مَنْ آوَى مُحْدِثًا‏.‏",
+    "text_en": "Abu't-Tufayl said, \"'Ali was asked, 'Did the Prophet, may Allah bless\nhim and grant him peace, give you something special which he did not give\nto anyone else?' He replied, 'The Messenger of Allah, may Allah bless him\nand grant him peace, did not give me anything special which he did not give\nto everyone else except for what I have in my sword scabbard.' He brought\nout a piece of paper. Written on that paper was:'Allah curses anyone who\nsacrifices an animal to something other than Allah. Allah curses anyone who\nsteals a milestone. Allah curses anyone who curses his parents. Allah curses\nanyone who gives shelter to an innovator.'\"",
+    "grade": null,
+    "chapter_number": 117,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 18,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُحَمَّدُ بْنُ عَبْدِ الْعَزِيزِ، قَالَ‏:‏ حَدَّثَنَا عَبْدُ الْمَلِكِ بْنُ الْخَطَّابِ بْنِ عُبَيْدِ اللهِ بْنِ أَبِي بَكْرَةَ الْبَصْرِيُّ لَقِيتُهُ بِالرَّمْلَةِ قَالَ‏:‏ حَدَّثَنِي رَاشِدٌ أَبُو مُحَمَّدٍ، عَنْ شَهْرِ بْنِ حَوْشَبٍ، عَنْ أُمِّ الدَّرْدَاءِ، عَنْ أَبِي الدَّرْدَاءِ قَالَ‏:‏ أَوْصَانِي رَسُولُ اللهِ صلى الله عليه وسلم بِتِسْعٍ‏:‏ لاَ تُشْرِكْ بِاللَّهِ شَيْئًا ؛ وَإِنْ قُطِّعْتَ أَوْ حُرِّقْتَ، وَلاَ تَتْرُكَنَّ الصَّلاَةَ الْمَكْتُوبَةَ مُتَعَمِّدًا، وَمَنْ تَرَكَهَا مُتَعَمِّدًا بَرِئَتْ مِنْهُ الذِّمَّةُ، وَلاَ تَشْرَبَنَّ الْخَمْرَ، فَإِنَّهَا مِفْتَاحُ كُلِّ شَرٍّ، وَأَطِعْ وَالِدَيْكَ، وَإِنْ أَمَرَاكَ أَنْ تَخْرُجَ مِنْ دُنْيَاكَ فَاخْرُجْ لَهُمَا، وَلاَ تُنَازِعَنَّ وُلاَةَ الأَمْرِ وَإِنْ رَأَيْتَ أَنَّكَ أَنْتَ، وَلاَ تَفْرُرْ مِنَ الزَّحْفِ، وَإِنْ هَلَكْتَ وَفَرَّ أَصْحَابُكَ، وَأَنْفِقْ مِنْ طَوْلِكَ عَلَى أَهْلِكَ، وَلاَ تَرْفَعْ عَصَاكَ عَنْ أَهْلِكَ، وَأَخِفْهُمْ فِي اللهِ عَزَّ وَجَلَّ‏.‏",
+    "text_en": "Abu'd-Darda' said, \"The Messenger of Allah, may Allah bless him and grant\nhim peace, recommended nine things to me:'Do not associate anything with\nAllah, even if you are cut to pieces or burned. Do not abandon a prescribed\nprayer deliberately. Anyone who abandons it will forfeit Allah's protection.\nDo not drink wine - it is the key to every evil. Obey your parents. If they\ncommand you to abandon your worldly possessions, then leave them for them.\nDo not contend with those in power, even if you think that you are in the\nright. Do not run away from the army when it advances, even if you are\nkilled while your companions run away. Spend on your wife out of your means.\nDo not raise a stick against your wife. Cause your family to fear Allah,\nthe Almighty and Exalted.'\"",
+    "grade": null,
+    "chapter_number": 118,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 19,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُحَمَّدُ بْنُ كَثِيرٍ، قَالَ‏:‏ حَدَّثَنَا سُفْيَانُ، عَنْ عَطَاءِ بْنِ السَّائِبِ، عَنْ أَبِيهِ، عَنْ عَبْدِ اللهِ بْنِ عَمْرٍو قَالَ‏:‏ جَاءَ رَجُلٌ إِلَى النَّبِيِّ صلى الله عليه وسلم فَقَالَ‏:‏ جِئْتُ أُبَايِعُكَ عَلَى الْهِجْرَةِ، وَتَرَكْتُ أَبَوَيَّ يَبْكِيَانِ‏؟‏ قَالَ‏:‏ ارْجِعْ إِلَيْهِمَا فَأَضْحِكْهُمَا كَمَا أَبْكَيْتَهُمَا",
+    "text_en": "'Abdullah ibn 'Amr said, \"A man came to the Prophet, may Allah bless\nhim and grant him peace, and said, 'I have come to make you a pledge that\nwill do hijra although I have left my parents in tears.\" The Prophet said,\n'Go back to them and make them laugh as you made them cry.'\"",
+    "grade": null,
+    "chapter_number": 119,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 20,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا عَلِيُّ بْنُ الْجَعْدِ، قَالَ‏:‏ أَخْبَرَنَا شُعْبَةُ، عَنْ حَبِيبِ بْنِ أَبِي ثَابِتٍ قَالَ‏:‏ سَمِعْتُ أَبَا الْعَبَّاسِ الأَعْمَى، عَنْ عَبْدِ اللهِ بْنِ عَمْرٍو قَالَ‏:‏ جَاءَ رَجُلٌ إِلَى النَّبِيِّ صلى الله عليه وسلم يُرِيدُ الْجِهَادَ، فَقَالَ‏:‏ أَحَيٌّ وَالِدَاكَ‏؟‏ فَقَالَ‏:‏ نَعَمْ، فَقَالَ‏:‏ فَفِيهِمَا فَجَاهِدْ",
+    "text_en": "'Abdullah ibn 'Amr said, \"A man came to the Prophet, may Allah bless\nhim and grant him peace, wanting to do jihad. The Prophet asked, 'Are your\nparents alive?' 'Yes,' he replied. he said, 'Then exert yourself on their\nbehalf.'\"",
+    "grade": null,
+    "chapter_number": 120,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 21,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا خَالِدُ بْنُ مَخْلَدٍ، قَالَ‏:‏ حَدَّثَنَا سُلَيْمَانُ بْنُ بِلاَلٍ، قَالَ‏:‏ حَدَّثَنَا سُهَيْلٌ، عَنْ أَبِيهِ، عَنْ أَبِي هُرَيْرَةَ، عَنِ النَّبِيِّ صلى الله عليه وسلم قَالَ‏:‏ رَغِمَ أَنْفُهُ، رَغِمَ أَنْفُهُ، رَغِمَ أَنْفُهُ، قَالُوا‏:‏ يَا رَسُولَ اللهِ مَنْ‏؟‏ قَالَ‏:‏ مَنْ أَدْرَكَ وَالِدَيْهِ عِنْدَ الْكِبْرِ، أَوْ أَحَدَهُمَا، فَدَخَلَ النَّارَ‏.‏",
+    "text_en": "Abu Hurayra reported that the Prophet, may Allah bless him and grant\nhim peace, said, \"May his nose be dusted (i.e. may he be disgraced), may his nose be dusted, may his nose be dusted.\" They said, \"Messenger of Allah, who?\" He said, \"The one who lives to see his parents or one of them in old age, and (still) enters the Fire.\"",
+    "grade": null,
+    "chapter_number": 121,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 22,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا أَصْبَغُ بْنُ الْفَرَجِ قَالَ‏:‏ أَخْبَرَنِي ابْنُ وَهْبٍ، عَنْ يَحْيَى بْنِ أَيُّوبَ، عَنْ زَبَّانَ بْنِ فَائِدٍ، عَنْ سَهْلِ بْنِ مُعَاذٍ، عَنْ أَبِيهِ قَالَ‏:‏ قَالَ النَّبِيُّ صلى الله عليه وسلم‏:‏ مَنْ بَرَّ وَالِدَيْهِ طُوبَى لَهُ، زَادَ اللَّهُ عَزَّ وَجَلَّ فِي عُمْرِهِ‏.‏",
+    "text_en": "Mu'adh said, \"Bliss belongs to someone who is dutiful towards his parents.\nAllah Almighty will prolong his life.\"",
+    "grade": null,
+    "chapter_number": 122,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 23,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا إِسْحَاقُ، قَالَ‏:‏ أَخْبَرَنَا عَلِيُّ بْنُ حُسَيْنٍ قَالَ‏:‏ حَدَّثَنِي أَبِي، عَنْ يَزِيدَ النَّحْوِيِّ، عَنْ عِكْرِمَةَ، عَنِ ابْنِ عَبَّاسٍ، فِي قَوْلِهِ عَزَّ وَجَلَّ‏:‏ ‏{‏إِمَّا يَبْلُغَنَّ عِنْدَكَ الْكِبَرَ أَحَدُهُمَا أَوْ كِلاَهُمَا فَلاَ تَقُلْ لَهُمَا أُفٍّ‏}‏ إِلَى قَوْلِهِ‏:‏ ‏{‏كَمَا رَبَّيَانِي صَغِيرًا‏}‏، فَنَسَخَتْهَا الْآيَةُ فِي بَرَاءَةَ‏:‏ ‏{‏مَا كَانَ لِلنَّبِيِّ وَالَّذِينَ آمَنُوا أَنْ يَسْتَغْفِرُوا لِلْمُشْرِكِينَ وَلَوْ كَانُوا أُولِي قُرْبَى مِنْ بَعْدِ مَا تَبَيَّنَ لَهُمْ أَنَّهُمْ أَصْحَابُ الْجَحِيمِ‏}‏‏.‏",
+    "text_en": "Ibn 'Abbas mentioned the words of the Almighty, \"When one or both\nof them reach old age with you, do not say 'Ugh!' to them out of irritation\nand do not be harsh with them but speak to them with gentleness and generosity.\nTake them under your wing, out of mercy, with due humility and say:'Lord,\nshow mercy to them as they did in looking after me when I was small.\"\n(17:23-24) He said, \"This was abrogated in Surat at-Tawba: 'It\nis not right for the Prophet and those who have iman to ask forgiveness for\nthe mushrikun even if they are close relatives after it has become clear\nto them that they are the Companions of the Blazing Fire.' (9:113)\"",
+    "grade": null,
+    "chapter_number": 123,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 24,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُحَمَّدُ بْنُ يُوسُفَ، قَالَ‏:‏ حَدَّثَنَا إِسْرَائِيلُ، قَالَ‏:‏ حَدَّثَنَا سِمَاكٌ، عَنْ مُصْعَبِ بْنِ سَعْدٍ، عَنْ أَبِيهِ سَعْدِ بْنِ أَبِي وَقَّاصٍ قَالَ‏:‏ نَزَلَتْ فِيَّ أَرْبَعُ آيَاتٍ مِنْ كِتَابِ اللهِ تَعَالَى‏:‏ كَانَتْ أُمِّي حَلَفَتْ أَنْ لاَ تَأْكُلَ وَلاَ تَشْرَبَ حَتَّى أُفَارِقَ مُحَمَّدًا صلى الله عليه وسلم، فَأَنْزَلَ اللَّهُ عَزَّ وَجَلَّ‏:‏ ‏{‏وَإِنْ جَاهَدَاكَ عَلَى أَنْ تُشْرِكَ بِي مَا لَيْسَ لَكَ بِهِ عِلْمٌ فَلاَ تُطُعْهُمَا وَصَاحِبْهُمَا فِي الدُّنْيَا مَعْرُوفًا‏}‏‏.‏ وَالثَّانِيَةُ‏:‏ أَنِّي كُنْتُ أَخَذْتُ سَيْفًا أَعْجَبَنِي، فَقُلْتُ‏:‏ يَا رَسُولَ اللهِ، هَبْ لِي هَذَا، فَنَزَلَتْ‏:‏ ‏{‏يَسْأَلُونَكَ عَنِ الأَنْفَالِ‏}‏‏.‏ وَالثَّالِثَةُ‏:‏ أَنِّي مَرِضْتُ فَأَتَانِي رَسُولُ اللهِ صلى الله عليه وسلم، فَقُلْتُ‏:‏ يَا رَسُولَ اللهِ، إِنِّي أُرِيدُ أَنْ أَقْسِمَ مَالِي، أَفَأُوصِي بِالنِّصْفِ‏؟‏ فَقَالَ‏:‏ لاَ، فَقُلْتُ‏:‏ الثُّلُثُ‏؟‏ فَسَكَتَ، فَكَانَ الثُّلُثُ بَعْدَهُ جَائِزًا‏.‏ وَالرَّابِعَةُ‏:‏ إِنِّي شَرِبْتُ الْخَمْرَ مَعَ قَوْمٍ مِنَ الأَنْصَارِ، فَضَرَبَ رَجُلٌ مِنْهُمْ أَنْفِي بِلَحْيِ جَمَلٍ، فَأَتَيْتُ النَّبِيَّ صلى الله عليه وسلم فَأَنْزَلَ عَزَّ وَجَلَّ تَحْرِيمَ الْخَمْرِ‏.‏",
+    "text_en": "Sa'id ibn Abi Waqqas said:\"Four ayats were revealed about me. The first\nwas when my mother swore she would neither eat nor drink until I left Muhammad,\nmay Allah bless him and grant him peace. Allah Almighty revealed, 'But\nif they try to make you associate something with Me about which you have\nno knowledge, do not obey them. Keep company with them correctly and courteously\nin this world' (31:15) The second was when I took a sword that\nI admired and said, 'Messenger of Allah, give me this!' Then the ayat\nwas revealed: 'They will ask you about booty.' (8:1) The third was\nwhen I was ill and the Messenger of Allah, may Allah bless him and grant\nhim peace, came to me and I said, 'Messenger of Allah, I want to divide my\nproperty. Can I will away a half?' He said, 'No.' 'A third?' I asked. He\nwas silent and so after that it was allowed to will away a third. The fourth\nwas when I had been drinking wine with some of the Ansar. One of them hit\nmy nose with the jawbone of a camel. I went to the Prophet, may Allah bless\nhim and grant him peace, and Allah Almighty revealed the prohibition of wine.\"",
+    "grade": null,
+    "chapter_number": 124,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 25,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا الْحُمَيْدِيُّ، قَالَ‏:‏ حَدَّثَنَا ابْنُ عُيَيْنَةَ، قَالَ‏:‏ حَدَّثَنَا هِشَامُ بْنُ عُرْوَةَ قَالَ‏:‏ أَخْبَرَنِي أَبِي قَالَ‏:‏ أَخْبَرَتْنِي أَسْمَاءُ بِنْتُ أَبِي بَكْرٍ قَالَتْ‏:‏ أَتَتْنِي أُمِّي رَاغِبَةً، فِي عَهْدِ النَّبِيِّ صلى الله عليه وسلم، فَسَأَلْتُ النَّبِيَّ صلى الله عليه وسلم‏:‏ أَصِلُهَا‏؟‏ قَالَ‏:‏ نَعَمْ‏.‏ قَالَ ابْنُ عُيَيْنَةَ‏:‏ فَأَنْزَلَ اللَّهُ عَزَّ وَجَلَّ فِيهَا‏:‏ ‏{‏لاَ يَنْهَاكُمُ اللَّهُ عَنِ الَّذِينَ لَمْ يُقَاتِلُوكُمْ فِي الدِّينِ‏}‏‏.‏",
+    "text_en": "Asma' bint Abi Bakr said, \"In the time of the Prophet, may Allah bless\nhim and grant him peace, my mother came to me hoping (I would be dutiful).\nI asked the Prophet, may Allah bless him and grant him peace, 'Do I have\nto treat her well?' 'Yes,' he replied.\"",
+    "grade": null,
+    "chapter_number": 125,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 26,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُوسَى، قَالَ‏:‏ حَدَّثَنَا عَبْدُ الْعَزِيزِ بْنُ مُسْلِمٍ، عَنْ عَبْدِ اللهِ بْنِ دِينَارٍ قَالَ‏:‏ سَمِعْتُ ابْنَ عُمَرَ يَقُولُ‏:‏ رَأَى عُمَرُ رَضِيَ اللَّهُ عَنْهُ حُلَّةً سِيَرَاءَ تُبَاعُ فَقَالَ‏:‏ يَا رَسُولَ اللهِ، ابْتَعْ هَذِهِ، فَالْبَسْهَا يَوْمَ الْجُمُعَةِ، وَإِذَا جَاءَكَ الْوُفُودُ، قَالَ‏:‏ إِنَّمَا يَلْبَسُ هَذِهِ مَنْ لاَ خَلاَقَ لَهُ، فَأُتِيَ النَّبِيُّ صلى الله عليه وسلم مِنْهَا بِحُلَلٍ، فَأَرْسَلَ إِلَى عُمَرَ بِحُلَّةٍ، فَقَالَ‏:‏ كَيْفَ أَلْبَسُهَا وَقَدْ قُلْتَ فِيهَا مَا قُلْتَ‏؟‏ قَالَ‏:‏ إِنِّي لَمْ أُعْطِكَهَا لِتَلْبَسَهَا، وَلَكِنْ تَبِيعَهَا أَوْ تَكْسُوَهَا، فَأَرْسَلَ بِهَا عُمَرُ إِلَى أَخٍ لَهُ مِنْ أَهْلِ مَكَّةَ قَبْلَ أَنْ يُسْلِمَ‏.‏",
+    "text_en": "Ibn 'Umar said, \"'Umar saw a silk robe for sale. He said, 'Messenger\nof Allah, would you buy this robe and wear it on Jumu'a and when delegations\nvisit you?' He replied, 'Only a person who has no portion in the Next World\ncould wear this.' Then the Messenger of Allah, may Allah bless him and grant\nhim peace, was given some robes made of the same material. He sent one of\nthe robes to 'Umar. 'Umar exclaimed, 'How can I wear it when you said what\nyou said about it?' The Prophet replied, 'I did not give it to you so that\nyou could wear it. You can sell it or give it to someone.' 'Umar sent it\nto a brother of his in Makka who had not yet become Muslim.\"",
+    "grade": null,
+    "chapter_number": 126,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 27,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُحَمَّدُ بْنُ كَثِيرٍ، قَالَ‏:‏ أَخْبَرَنَا سُفْيَانُ قَالَ‏:‏ حَدَّثَنِي سَعْدُ بْنُ إِبْرَاهِيمَ، عَنْ حُمَيْدِ بْنِ عَبْدِ الرَّحْمَنِ، عَنْ عَبْدِ اللهِ بْنِ عَمْرٍو قَالَ‏:‏ قَالَ النَّبِيُّ صلى الله عليه وسلم‏:‏ مِنَ الْكَبَائِرِ أَنْ يَشْتِمَ الرَّجُلُ وَالِدَيْهِ، فَقَالُوا‏:‏ كَيْفَ يَشْتِمُ‏؟‏ قَالَ‏:‏ يَشْتِمُ الرَّجُلَ، فَيَشْتُمُ أَبَاهُ وَأُمَّهُ‏.‏",
+    "text_en": "'Abdullah ibn 'Amr said that the Prophet, may Allah bless him and grant\nhim peace, said, \"Reviling one's parents is one of the great wrong actions.\"\nThey asked, \"How could he revile them?\" He said, \"He reviles a man who then\nin turn reviles his mother and father.\"",
+    "grade": null,
+    "chapter_number": 127,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 28,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُحَمَّدُ بْنُ سَلاَمٍ، قَالَ‏:‏ أَخْبَرَنَا مَخْلَدٌ، قَالَ‏:‏ أَخْبَرَنَا ابْنُ جُرَيْجٍ قَالَ‏:‏ سَمِعْتُ مُحَمَّدَ بْنَ الْحَارِثِ بْنِ سُفْيَانَ يَزْعُمُ، أَنَّ عُرْوَةَ بْنَ عِيَاضٍ أَخْبَرَهُ، أَنَّهُ سَمِعَ عَبْدَ اللهِ بْنَ عَمْرِو بْنِ الْعَاصِ يَقُولُ‏:‏ مِنَ الْكَبَائِرِ عِنْدَ اللهِ تَعَالَى أَنْ يَسْتَسِبَّ الرَّجُلُ لِوَالِدِهِ‏.‏",
+    "text_en": "'Abdullah ibn 'Amr said, \"A man's reviling his father is one of the major\nwrong actions in the sight of Allah Almighty.\"",
+    "grade": null,
+    "chapter_number": 128,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 29,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا عَبْدُ اللهِ بْنُ يَزِيدَ، قَالَ‏:‏ حَدَّثَنَا عُيَيْنَةُ بْنُ عَبْدِ الرَّحْمَنِ، عَنْ أَبِيهِ، عَنْ أَبِي بَكْرَةَ، عَنِ النَّبِيِّ صلى الله عليه وسلم قَالَ‏:‏ مَا مِنْ ذَنْبٍ أَجْدَرُ أَنْ يُعَجَّلَ لِصَاحِبِهِ الْعُقُوبَةُ مَعَ مَا يُدَّخَرُ لَهُ، مِنَ الْبَغِيِّ وَقَطِيعَةِ الرَّحِمِ.",
+    "text_en": "Abu Bakra reported that the Prophet, may Allah bless him and grant him\npeace, said, \"There is no wrong action more likely to bring punishment in\nthis world in addition to what is stored up in the Next World than oppression\nand severing ties of kinship.\"",
+    "grade": null,
+    "chapter_number": 129,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 30,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا الْحَسَنُ بْنُ بِشْرٍ، قَالَ‏:‏ حَدَّثَنَا الْحَكَمُ بْنُ عَبْدِ الْمَلِكِ، عَنْ قَتَادَةَ، عَنِ الْحَسَنِ، عَنْ عِمْرَانَ بْنِ حُصَيْنٍ قَالَ‏:‏ قَالَ رَسُولُ اللهِ صلى الله عليه وسلم‏:‏ مَا تَقُولُونَ فِي الزِّنَا، وَشُرْبِ الْخَمْرِ، وَالسَّرِقَةِ‏؟‏ قُلْنَا‏:‏ اللَّهُ وَرَسُولُهُ أَعْلَمُ، قَالَ‏:‏ هُنَّ الْفَوَاحِشُ، وَفِيهِنَّ الْعُقُوبَةُ، أَلاَ أُنَبِّئُكُمْ بِأَكْبَرِ الْكَبَائِرِ‏؟‏ الشِّرْكُ بِاللَّهِ عَزَّ وَجَلَّ، وَعُقُوقُ الْوَالِدَيْنِ، وَكَانَ مُتَّكِئًا فَاحْتَفَزَ قَالَ‏:‏ وَالزُّورُ‏.‏",
+    "text_en": "'Imran ibn Husayn said, \"The Messenger of Allah, may Allah bless him\nand grant him peace, said, 'What do you say about fornication, drinking wine\nand theft?' 'Allah and His Messenger know best,' we replied. He stated, 'They\nare acts of outrage and there is punishment for them, but shall I tell you\nwhich is the greatest of the great wrong actions? Associating with Allah\nAlmighty and disobeying parents.' He had been reclining, but then he sat\nup and said, 'and lying.'\"",
+    "grade": null,
+    "chapter_number": 130,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 31,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُوسَى، قَالَ‏:‏ حَدَّثَنَا حَمَّادُ بْنُ سَلَمَةَ، عَنْ زِيَادِ بْنِ مِخْرَاقٍ، عَنْ طَيْسَلَةَ، أَنَّهُ سَمِعَ ابْنَ عُمَرَ يَقُولُ‏:‏ بُكَاءُ الْوَالِدَيْنِ مِنَ الْعُقُوقِ وَالْكَبَائِرِ‏.‏",
+    "text_en": "Ibn 'Umar said, \"Making parents weep is part of disobedience and one\nof the major wrong actions.\"",
+    "grade": null,
+    "chapter_number": 131,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 32,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُعَاذُ بْنُ فَضَالَةَ، قَالَ‏:‏ حَدَّثَنَا هِشَامٌ، عَنْ يَحْيَى هُوَ ابْنُ أَبِي كَثِيرٍ، عَنْ أَبِي جَعْفَرٍ، أَنَّهُ سَمِعَ أَبَا هُرَيْرَةَ يَقُولُ‏:‏ قَالَ النَّبِيُّ صلى الله عليه وسلم‏:‏ ثَلاَثُ دَعَوَاتٍ مُسْتَجَابَاتٌ لَهُنَّ، لاَ شَكَّ فِيهِنَّ‏:‏ دَعْوَةُ الْمَظْلُومِ، وَدَعْوَةُ الْمُسَافِرِ، وَدَعْوَةُ الْوَالِدِيْنِ عَلَى وَلَدِهِمَا‏.‏",
+    "text_en": "Abu Hurayra reported that the Prophet, may Allah bless him and grant\nhim peace, said, \"Three supplications are answered without a doubt:the\nsupplication of someone who is oppressed, the supplication of someone on\na journey, and the supplication of parents for their children.\"",
+    "grade": null,
+    "chapter_number": 132,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 33,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا عَيَّاشُ بْنُ الْوَلِيدِ، قَالَ‏:‏ حَدَّثَنَا عَبْدُ الأَعْلَى، قَالَ‏:‏ حَدَّثَنَا مُحَمَّدُ بْنُ إِسْحَاقَ، عَنْ يَزِيدَ بْنِ عَبْدِ اللهِ بْنِ قُسَيْطٍ، عَنْ مُحَمَّدِ بْنِ شُرَحْبِيلَ، أَخِي بَنِي عَبْدِ الدَّارِ، عَنْ أَبِي هُرَيْرَةَ قَالَ‏:‏ سَمِعْتُ رَسُولَ اللهِ صلى الله عليه وسلم يَقُولُ‏:‏ مَا تَكَلَّمَ مَوْلُودٌ مِنَ النَّاسِ فِي مَهْدٍ إِلاَّ عِيسَى ابْنُ مَرْيَمَ صلى الله عليه وسلم، وَصَاحِبُ جُرَيْجٍ، قِيلَ‏:‏ يَا نَبِيَّ اللهِ، وَمَا صَاحِبُ جُرَيْجٍ‏؟‏ قَالَ‏:‏ فَإِنَّ جُرَيْجًا كَانَ رَجُلاً رَاهِبًا فِي صَوْمَعَةٍ لَهُ، وَكَانَ رَاعِيَ بَقَرٍ يَأْوِي إِلَى أَسْفَلِ صَوْمَعَتِهِ، وَكَانَتِ امْرَأَةٌ مِنْ أَهْلِ الْقَرْيَةِ تَخْتَلِفُ إِلَى الرَّاعِي، فَأَتَتْ أُمُّهُ يَوْمًا فَقَالَتْ‏:‏ يَا جُرَيْجُ، وَهُوَ يُصَلِّي، فَقَالَ فِي نَفْسِهِ وَهُوَ يُصَلِّي‏:‏ أُمِّي وَصَلاَتِي‏؟‏ فَرَأَى أَنْ يُؤْثِرَ صَلاَتَهُ، ثُمَّ صَرَخَتْ بِهِ الثَّانِيَةَ، فَقَالَ فِي نَفْسِهِ‏:‏ أُمِّي وَصَلاَتِي‏؟‏ فَرَأَى أَنْ يُؤْثِرَ صَلاَتَهُ، ثُمَّ صَرَخَتْ بِهِ الثَّالِثَةَ، فَقَالَ‏:‏ أُمِّي وَصَلاَتِي‏؟‏ فَرَأَى أَنْ يُؤْثِرَ صَلاَتَهُ، فَلَمَّا لَمْ يُجِبْهَا قَالَتْ‏:‏ لاَ أَمَاتَكَ اللَّهُ يَا جُرَيْجُ حَتَّى تَنْظُرَ فِي وَجْهِ الْمُومِسَاتِ، ثُمَّ انْصَرَفَتْ‏.‏ فَأُتِيَ الْمَلِكُ بِتِلْكَ الْمَرْأَةِ وَلَدَتْ، فَقَالَ‏:‏ مِمَّنْ‏؟‏ قَالَتْ‏:‏ مِنْ جُرَيْجٍ، قَالَ‏:‏ أَصَاحِبُ الصَّوْمَعَةِ‏؟‏ قَالَتْ‏:‏ نَعَمْ، قَالَ‏:‏ اهْدِمُوا صَوْمَعَتَهُ، وَأْتُونِي بِهِ، فَضَرَبُوا صَوْمَعَتَهُ بِالْفُئُوسِ حَتَّى وَقَعَتْ‏.‏ فَجَعَلُوا يَدَهُ إِلَى عُنُقِهِ بِحَبْلٍ، ثُمَّ انْطُلِقَ بِهِ، فَمَرَّ بِهِ عَلَى الْمُومِسَاتِ، فَرَآهُنَّ فَتَبَسَّمَ، وَهُنَّ يَنْظُرْنَ إِلَيْهِ فِي النَّاسِ، فَقَالَ الْمَلِكُ‏:‏ مَا تَزْعُمُ هَذِهِ‏؟‏ قَالَ‏:‏ مَا تَزْعُمُ‏؟‏ قَالَ‏:‏ تَزْعُمُ أَنَّ وَلَدَهَا مِنْكَ، قَالَ‏:‏ أَنْتِ تَزْعُمِينَ‏؟‏ قَالَتْ‏:‏ نَعَمْ، قَالَ‏:‏ أَيْنَ هَذَا الصَّغِيرُ‏؟‏ قَالُوا‏:‏ هَذا هُوَ فِي حِجْرِهَا، فَأَقْبَلَ عَلَيْهِ فَقَالَ‏:‏ مَنْ أَبُوكَ‏؟‏ قَالَ‏:‏ رَاعِي الْبَقَرِ‏.‏ قَالَ الْمَلِكُ‏:‏ أَنَجْعَلُ صَوْمَعَتَكَ مِنْ ذَهَبٍ‏؟‏ قَالَ‏:‏ لاَ، قَالَ‏:‏ مِنْ فِضَّةٍ‏؟‏ قَالَ‏:‏ لاَ، قَالَ‏:‏ فَمَا نَجْعَلُهَا‏؟‏ قَالَ‏:‏ رُدُّوهَا كَمَا كَانَتْ، قَالَ‏:‏ فَمَا الَّذِي تَبَسَّمْتَ‏؟‏ قَالَ‏:‏ أَمْرًا عَرَفْتُهُ، أَدْرَكَتْنِي دَعْوَةُ أُمِّي، ثُمَّ أَخْبَرَهُمْ‏.‏",
+    "text_en": "Abu Hurayra reported that he heard the Messenger of Allah, may Allah\nbless him and grant him peace, say, \"No human child has ever spoken in the\ncradle except for 'Isa ibn Maryam, may Allah bless him and grant him peace,\nand the companion of Jurayj.\" Abu Hurayra asked, \"Prophet of Allah, who was\nthe companion of Jurayj?\" The Prophet replied, \"Jurayj was a monk who lived\nin a hermitage. There was a cowherd who used to come to the foot of his hermitage\nand a woman from the village used to come to the cowherd.",
+    "grade": null,
+    "chapter_number": 133,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 34,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا أَبُو الْوَلِيدِ هِشَامُ بْنُ عَبْدِ الْمَلِكِ، قَالَ‏:‏ حَدَّثَنَا عِكْرِمَةُ بْنُ عَمَّارٍ قَالَ‏:‏ حَدَّثَنِي أَبُو كَثِيرٍ السُّحَيْمِيُّ قَالَ‏:‏ سَمِعْتُ أَبَا هُرَيْرَةَ يَقُولُ‏:‏ مَا سَمِعَ بِي أَحَدٌ، يَهُودِيٌّ وَلاَ نَصْرَانِيٌّ، إِلاَّ أَحَبَّنِي، إِنَّ أُمِّي كُنْتُ أُرِيدُهَا عَلَى الإِسْلاَمِ فَتَأْبَى، فَقُلْتُ لَهَا، فَأَبَتْ، فَأَتَيْتُ النَّبِيَّ صلى الله عليه وسلم فَقُلْتُ‏:‏ ادْعُ اللَّهَ لَهَا، فَدَعَا، فَأَتَيْتُهَا، وَقَدْ أَجَافَتْ عَلَيْهَا الْبَابَ، فَقَالَتْ‏:‏ يَا أَبَا هُرَيْرَةَ، إِنِّي أَسْلَمْتُ، فَأَخْبَرْتُ النَّبِيَّ صلى الله عليه وسلم فَقُلْتُ‏:‏ ادْعُ اللَّهَ لِي وَلِأُمِّي، فَقَالَ‏:‏ اللَّهُمَّ، عَبْدُكَ أَبُو هُرَيْرَةَ وَأُمُّهُ، أَحِبَّهُمَا إِلَى النَّاسِ‏.‏",
+    "text_en": "Abu Hurayra said, \"Neither Jew nor Christian has heard me and then not\nloved me. I wanted my mother to become Muslim, but she refused. I told her\nabout it and she still refused. I went to the Prophet, may Allah bless him\nand grant him peace, and said, 'Pray to Allah for me.' He did so and I went\nto her. She was inside the door of the house and said, 'Abu Hurayra, I have\nbecome Muslim.' I told the Prophet, may Allah bless him and grant him peace,\nand I asked, 'Make supplication to Allah for me and my mother.' He said,\n'O Allah, make people love Abu Hurayra and his mother.'\"",
+    "grade": null,
+    "chapter_number": 134,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 35,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا أَبُو نُعَيْمٍ، قَالَ‏:‏ حَدَّثَنَا عَبْدُ الرَّحْمَنِ بْنُ الْغَسِيلِ قَالَ‏:‏ أَخْبَرَنِي أُسَيْدُ بْنُ عَلِيِّ بْنِ عُبَيْدٍ، عَنْ أَبِيهِ، أَنَّهُ سَمِعَ أَبَا أُسَيْدٍ يُحَدِّثُ الْقَوْمَ قَالَ‏:‏ كُنَّا عِنْدَ النَّبِيِّ صلى الله عليه وسلم فَقَالَ رَجُلٌ‏:‏ يَا رَسُولَ اللهِ، هَلْ بَقِيَ مِنْ بِرِّ أَبَوَيَّ شَيْءٌ بَعْدَ مَوْتِهِمَا أَبَرُّهُمَا‏؟‏ قَالَ‏:‏ نَعَمْ، خِصَالٌ أَرْبَعٌ‏:‏ الدُّعَاءُ لَهُمَا، وَالِاسْتِغْفَارُ لَهُمَا، وَإِنْفَاذُ عَهْدِهِمَا، وَإِكْرَامُ صَدِيقِهِمَا، وَصِلَةُ الرَّحِمِ الَّتِي لاَ رَحِمَ لَكَ إِلاَّ مِنْ قِبَلِهِمَا‏.‏",
+    "text_en": "Abu Usayd said, \"We were with the Messenger of Allah, may Allah bless\nhim and grant him peace, when a man asked, 'Messenger of Allah, is there\nany act of dutifulness which I can do for my parents after their death?'\nHe replied, 'Yes. There are four things:Supplication for them, asking\nforgiveness for them, fulfilling their pledges, and being generous to friends\nof theirs. You only have ties of kinship through your parents.\"",
+    "grade": null,
+    "chapter_number": 135,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 36,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا أَحْمَدُ بْنُ يُونُسَ، قَالَ‏:‏ حَدَّثَنَا أَبُو بَكْرٍ، عَنْ عَاصِمٍ، عَنْ أَبِي صَالِحٍ، عَنْ أَبِي هُرَيْرَةَ قَالَ‏:‏ تُرْفَعُ لِلْمَيِّتِ بَعْدَ مَوْتِهِ دَرَجَتُهُ‏.‏ فَيَقُولُ‏:‏ أَيْ رَبِّ، أَيُّ شَيْءٍ هَذِهِ‏؟‏ فَيُقَالُ‏:‏ وَلَدُكَ اسْتَغْفَرَ لَكَ‏.‏",
+    "text_en": "Abu Hurayra said, \"The dead person can be raised a degree after his death.\nHe said, 'My Lord, how is this?' He was told, 'Your child can ask for forgiveness\nfor you.'\"",
+    "grade": null,
+    "chapter_number": 136,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 37,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا مُوسَى، قَالَ‏:‏ حَدَّثَنَا سَلاَّمُ بْنُ أَبِي مُطِيعٍ، عَنْ غَالِبٍ قَالَ‏:‏ قَالَ مُحَمَّدُ بْنُ سِيرِينَ‏:‏ كُنَّا عِنْدَ أَبِي هُرَيْرَةَ لَيْلَةً، فَقَالَ‏:‏ اللَّهُمَّ اغْفِرْ لأَبِي هُرَيْرَةَ، وَلِأُمِّي، وَلِمَنِ اسْتَغْفَرَ لَهُمَا قَالَ لِي مُحَمَّدٌ‏:‏ فَنَحْنُ نَسْتَغْفِرُ لَهُمَا حَتَّى نَدْخُلَ فِي دَعْوَةِ أَبِي هُرَيْرَةَ‏.‏",
+    "text_en": "Ibn Sirin said, \"We were with Abu Hurayra one night and he said, 'O Allah,\nforgive Abu Hurayra and his mother and whoever asks for forgiveness for both\nof them.'\" Muhammad said, \"We used to ask for forgiveness for them so that\nwe would be included in Abu Hurayra's supplication.\"",
+    "grade": null,
+    "chapter_number": 137,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 38,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا أَبُو الرَّبِيعِ، قَالَ‏:‏ حَدَّثَنَا إِسْمَاعِيلُ بْنُ جَعْفَرٍ، قَالَ‏:‏ أَخْبَرَنَا الْعَلاَءُ، عَنْ أَبِيهِ، عَنْ أَبِي هُرَيْرَةَ، أَنَّ رَسُولَ اللهِ صلى الله عليه وسلم قَالَ‏:‏ إِذَا مَاتَ الْعَبْدُ انْقَطَعَ عَنْهُ عَمَلُهُ إِلاَّ مِنْ ثَلاَثٍ‏:‏ صَدَقَةٍ جَارِيَةٍ، أَوْ عِلْمٍ يُنْتَفَعُ بِهِ، أَوْ وَلَدٍ صَالِحٍ يَدْعُو لَهُ‏.‏",
+    "text_en": "Abu Hurayra reported that the Messenger of Allah, may Allah bless him\nand grant him peace, said, \"When a person dies, all action is cut off for\nhim with the exception of three things:sadaqa which continues, knowledge\nwhich benefits, or a righteous child who makes supplication for him.\"",
+    "grade": null,
+    "chapter_number": 138,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 39,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا يَسَرَةُ بْنُ صَفْوَانَ، قَالَ‏:‏ حَدَّثَنَا مُحَمَّدُ بْنُ مُسْلِمٍ، عَنْ عَمْرٍو، عَنْ عِكْرِمَةَ، عَنِ ابْنِ عَبَّاسٍ، أَنَّ رَجُلاً قَالَ‏:‏ يَا رَسُولَ اللهِ، إِنَّ أُمِّي تُوُفِّيَتْ وَلَمْ تُوصِ، أَفَيَنْفَعُهَا أَنْ أَتَصَدَّقَ عَنْهَا‏؟‏ قَالَ‏:‏ نَعَمْ‏.‏",
+    "text_en": "Ibn 'Abbas reported that a man said, \"Messenger of Allah, my mother died\nwithout a will. Will it help her if I give sadaqa on her behalf?\"\n\"Yes,\" he replied.",
+    "grade": null,
+    "chapter_number": 139,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 40,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا عَبْدُ اللهِ بْنُ صَالِحٍ قَالَ‏:‏ حَدَّثَنِي اللَّيْثُ، عَنْ خَالِدِ بْنِ يَزِيدَ، عَنْ عَبْدِ اللهِ بْنِ دِينَارٍ، عَنِ ابْنِ عُمَرَ‏:‏ مَرَّ أَعْرَابِيٌّ فِي سَفَرٍ، فَكَانَ أَبُو الأعْرَابِيِّ صَدِيقًا لِعُمَرَ رَضِيَ اللَّهُ عَنْهُ، فَقَالَ لِلأَعْرَابِيِّ‏:‏ أَلَسْتَ ابْنَ فُلاَنٍ‏؟‏ قَالَ‏:‏ بَلَى، فَأَمَرَ لَهُ ابْنُ عُمَرَ بِحِمَارٍ كَانَ يَسْتَعْقِبُ، وَنَزَعَ عِمَامَتَهُ عَنْ رَأْسِهِ فَأَعْطَاهُ‏.‏ فَقَالَ بَعْضُ مَنْ مَعَهُ‏:‏ أَمَا يَكْفِيهِ دِرْهَمَانِ‏؟‏ فَقَالَ‏:‏ قَالَ النَّبِيُّ صلى الله عليه وسلم‏:‏ احْفَظْ وُدَّ أَبِيكَ، لاَ تَقْطَعْهُ فَيُطْفِئَ اللَّهُ نُورَكَ‏.‏",
+    "text_en": "'Abdullah ibn Dinar reported that Ibn 'Umar passed by a bedouin during\na journey. The bedouin's father had been a friend of 'Umar's. The bedouin\nsaid, \"Am I not the son of so-and-so?\" He said, \"Yes, indeed.\" Ibn 'Umar\nordered that he be given a donkey which was following him. He also took off\nhis turban and gave it to him, One of the men with him said, \"Wouldn't two\ndirhams be enough for him?\" He replied, \"The Prophet, may Allah bless him\nand grant him peace, said, 'Maintain what your father loved. Do not cut it\noff so that Allah puts out your light.\"",
+    "grade": null,
+    "chapter_number": 140,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 41,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا عَبْدُ اللهِ بْنُ يَزِيدَ، قَالَ‏:‏ حَدَّثَنَا حَيْوَةُ قَالَ‏:‏ حَدَّثَنِي أَبُو عُثْمَانَ الْوَلِيدُ بْنُ أَبِي الْوَلِيدِ، عَنْ عَبْدِ اللهِ بْنِ دِينَارٍ، عَنِ ابْنِ عُمَرَ، عَنْ رَسُولِ اللهِ صلى الله عليه وسلم قَالَ‏:‏ إِنَّ أَبَرَّ الْبِرِّ أَنْ يَصِلَ الرَّجُلُ أَهْلَ وُدِّ أَبِيهِ‏.‏",
+    "text_en": "Ibn 'Umar reported that the Messenger of Allah, may Allah bless him and\ngrant him peace, said, \"The strongest form of dutifulness is when a man maintains\nrelations with the people his father loved.\"",
+    "grade": null,
+    "chapter_number": 141,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 42,
+    "book_number": 1,
+    "text_ar": "أَخْبَرَنَا بِشْرُ بْنُ مُحَمَّدٍ، قَالَ‏:‏ أَخْبَرَنَا عَبْدُ اللهِ، قَالَ‏:‏ أَخْبَرَنَا عَبْدُ اللهِ بْنُ لاَحِقٍ قَالَ‏:‏ أَخْبَرَنِي سَعْدُ بْنُ عُبَادَةَ الزُّرَقِيُّ، أَنَّ أَبَاهُ قَالَ‏:‏ كُنْتُ جَالِسًا فِي مَسْجِدِ الْمَدِينَةِ مَعَ عَمْرِو بْنِ عُثْمَانَ، فَمَرَّ بِنَا عَبْدُ اللهِ بْنُ سَلاَّمٍ مُتَّكِئًا عَلَى ابْنِ أَخِيهِ، فَنَفَذَ عَنِ الْمَجْلِسِ، ثُمَّ عَطَفَ عَلَيْهِ، فَرَجَعَ عَلَيْهِمْ فَقَالَ‏:‏ مَا شِئْتَ عَمْرَو بْنَ عُثْمَانَ‏؟‏ مَرَّتَيْنِ أَوْ ثَلاَثًا، فَوَالَّذِي بَعَثَ مُحَمَّدًا صلى الله عليه وسلم بِالْحَقِّ، إِنَّهُ لَفِي كِتَابِ اللهِ عَزَّ وَجَلَّ، مَرَّتَيْنِ‏:‏ لاَ تَقْطَعْ مَنْ كَانَ يَصِلُ أَبَاكَ فَيُطْفَأَ بِذَلِكَ نُورُكَ‏.‏",
+    "text_en": "Sa'd ibn 'Ubada az-Zurqi reported that his father said, \"I was sitting\nin the mosque in Madina with 'Amr ibn 'Uthman when 'Abdullah ibn Salam walked\nby, leaning on his nephew. 'Amr left the assembly and showed his concern\nfor him.\" Then Ibn Salam returned to them and said, \"Do what you like, 'Amr\nibn 'Uthman,\" (and he said it two or three times) By the One who sent Muhammad,\nmay Allah bless him and grant him peace, with the Truth, it is in the Book\nof Allah Almighty (and he said it twice), 'Do not cut off those your father\nhas joined so that that extinguishes your light.'\"",
+    "grade": null,
+    "chapter_number": 142,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 43,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا بِشْرُ بْنُ مُحَمَّدٍ، قَالَ‏:‏ أَخْبَرَنَا عَبْدُ اللهِ، قَالَ‏:‏ أَخْبَرَنَا مُحَمَّدُ بْنُ عَبْدِ الرَّحْمَنِ، عَنْ مُحَمَّدِ بْنِ فُلاَنِ بْنِ طَلْحَةَ، عَنْ أَبِي بَكْرِ بْنِ حَزْمٍ، عَنْ رَجُلٍ مِنْ أَصْحَابِ النَّبِيِّ صلى الله عليه وسلم قَالَ‏:‏ كَفَيْتُكَ أَنَّ رَسُولَ اللهِ صلى الله عليه وسلم قَالَ‏:‏ إِنَّ الْوُدَّ يُتَوَارَثُ‏.‏",
+    "text_en": "Abu Bakr ibn Hazm reported that one of the Companions of the Prophet,\nmay Allah bless him and grant him peace, said, \"It is enough that I tell\nyou that the Messenger of Allah, may Allah bless him and grant him peace,\nsaid, 'Love is inherited.'\"",
+    "grade": null,
+    "chapter_number": 143,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 44,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا أَبُو الرَّبِيعِ، عَنْ إِسْمَاعِيلَ بْنِ زَكَرِيَّا، قَالَ‏:‏ حَدَّثَنَا هِشَامُ بْنُ عُرْوَةَ، عَنْ أَبِيهِ ‏,‏ أَوْ غَيْرِهِ أَنَّ أَبَا هُرَيْرَةَ أَبْصَرَ رَجُلَيْنِ، فَقَالَ لأَحَدِهِمَا‏:‏ مَا هَذَا مِنْكَ‏؟‏ فَقَالَ‏:‏ أَبِي، فَقَالَ‏:‏ لاَ تُسَمِّهِ بِاسْمِهِ، وَلاَ تَمْشِ أَمَامَهُ، وَلا تَجْلِسْ قَبْلَهُ‏.‏",
+    "text_en": "Abu Hurayra saw two men and said to one of them, \"Who is this man in\nrelation to you?\" He is my father,\" he replied. He said, \"Do not call him\nby his own name nor walk in front of him nor sit down before him.\"",
+    "grade": null,
+    "chapter_number": 144,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 45,
+    "book_number": 1,
+    "text_ar": "حَدَّثَنَا عَبْدُ الرَّحْمَنِ بْنُ شَيْبَةَ قَالَ‏:‏ أَخْبَرَنِي يُونُسُ بْنُ يَحْيَى بْنِ نُبَاتَةَ، عَنْ عُبَيْدِ اللهِ بْنِ مَوْهَبٍ، عَنْ شَهْرِ بْنِ حَوْشَبٍ قَالَ‏:‏ خَرَجْنَا مَعَ ابْنِ عُمَرَ، فَقَال لَهُ سَالِمٌ‏:‏ الصَّلاَةَ يَا أَبَا عَبْدِ الرَّحْمَنِ‏.‏",
+    "text_en": "Shahr ibn Hawshab said, \"We went out with Ibn 'Umar and Salim said to\nhim, 'Peace, Abu 'Abdu'r-Rahman.'\"",
+    "grade": null,
+    "chapter_number": 145,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  },
+  {
+    "hadith_number": 46,
+    "book_number": 1,
+    "text_ar": "قَالَ أَبُو عَبْدِ اللهِ يَعْنِي‏:‏ الْبُخَارِيَّ‏:‏ حَدَّثَنَا أَصْحَابُنَا، عَنْ وَكِيعٍ، عَنْ سُفْيَانَ، عَنْ عَبْدِ اللهِ بْنِ دِينَارٍ، عَنِ ابْنِ عُمَرَ قَالَ‏:‏ لَكِنْ أَبُو حَفْصٍ عُمَرُ قَضَى‏.‏",
+    "text_en": "'Abdullah ibn Dinar said reported that Ibn 'Umar said, \"But Abu Hafs\n'Umar decided...\"",
+    "grade": null,
+    "chapter_number": 146,
+    "chapter_name_ar": "كتاب الْوَالِدَيْنِ",
+    "chapter_name_en": "Parents"
+  }
+]

--- a/tests/integration/test_sunnah_scraped_multicollection.py
+++ b/tests/integration/test_sunnah_scraped_multicollection.py
@@ -1,0 +1,98 @@
+"""Live-Neo4j multi-collection light-up for the sunnah.com scraper (da#84).
+
+Extends the riyadussalihin first-light (da#73) *beyond a single collection*:
+parses two REAL committed sunnah.com samples — ``riyadussalihin`` (47) and
+``adab`` (46) — through the real batch loaders into a live ``neo4j:5`` container
+and asserts both collections' Hadith and Collection nodes land, correctly
+``sect`` / ``source_corpus`` tagged, with ``APPEARS_IN`` edges pointing at the
+right collection. Real data, real graph — the owner's live-local acceptance bar.
+
+Skips cleanly when Docker is unreachable (see ``tests/integration/conftest.py``),
+so it degrades to a SKIP off-CI rather than a red ERROR.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from src.graph.load_edges import load_all_edges
+from src.graph.load_nodes import load_all_nodes
+from src.parse import sunnah_scraped
+
+_SAMPLE_DIR = (
+    Path(__file__).resolve().parents[2] / "scripts" / "first_light" / "sample" / "sunnah_scraped"
+)
+
+# Real committed samples: book 1 of each collection. Counts are locked so a
+# parse/keying regression that drops or duplicates rows is caught.
+EXPECTED_PER_COLLECTION = {"riyadussalihin": 47, "adab": 46}
+EXPECTED_HADITHS = sum(EXPECTED_PER_COLLECTION.values())
+
+
+@pytest.fixture
+def staged_multi(tmp_path: Path) -> Path:
+    """Parse both real samples into one staging dir and return it."""
+    raw = tmp_path / "raw" / "sunnah_scraped"
+    raw.mkdir(parents=True)
+    for collection in EXPECTED_PER_COLLECTION:
+        sample = _SAMPLE_DIR / f"{collection}.json"
+        assert sample.exists(), f"committed sample missing: {sample}"
+        shutil.copyfile(sample, raw / f"{collection}.json")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    sunnah_scraped.run(tmp_path / "raw", staging)
+    return staging
+
+
+@pytest.mark.integration
+class TestSunnahScrapedMultiCollectionLive:
+    def test_both_collections_load_sect_tagged(
+        self, neo4j_client, staged_multi: Path, tmp_path: Path
+    ) -> None:
+        """Two Collection nodes + every Hadith node tagged sunni / sunnah."""
+        curated = tmp_path / "curated"
+        curated.mkdir()
+        load_all_nodes(neo4j_client, staged_multi, curated, strict=False)
+
+        collections = neo4j_client.execute_read(
+            "MATCH (c:Collection) "
+            "RETURN c.id AS id, c.sect AS sect, c.source_corpus AS corpus ORDER BY c.id"
+        )
+        assert [c["id"] for c in collections] == ["col:sunnah:adab", "col:sunnah:riyadussalihin"]
+        assert all(c["sect"] == "sunni" and c["corpus"] == "sunnah" for c in collections)
+
+        tally = neo4j_client.execute_read(
+            "MATCH (h:Hadith) RETURN count(h) AS total, "
+            "sum(CASE WHEN h.sect = 'sunni' AND h.source_corpus = 'sunnah' THEN 1 ELSE 0 END) "
+            "AS tagged"
+        )[0]
+        assert tally["total"] == EXPECTED_HADITHS
+        assert tally["tagged"] == EXPECTED_HADITHS, "some Hadith nodes missing sunni/sunnah tags"
+
+    def test_appears_in_routes_each_hadith_to_its_collection(
+        self, neo4j_client, staged_multi: Path, tmp_path: Path
+    ) -> None:
+        """Every hadith gets an APPEARS_IN edge to ITS OWN collection — adab
+        hadiths to col:sunnah:adab, riyad hadiths to col:sunnah:riyadussalihin,
+        with no cross-collection leakage and no dangling edges."""
+        curated = tmp_path / "curated"
+        curated.mkdir()
+        load_all_nodes(neo4j_client, staged_multi, curated, strict=False)
+        load_all_edges(neo4j_client, staged_multi, curated, strict=False)
+
+        per_collection = neo4j_client.execute_read(
+            "MATCH (:Hadith)-[:APPEARS_IN]->(c:Collection) "
+            "RETURN c.id AS coll, count(*) AS n ORDER BY c.id"
+        )
+        assert {r["coll"]: r["n"] for r in per_collection} == {
+            "col:sunnah:adab": EXPECTED_PER_COLLECTION["adab"],
+            "col:sunnah:riyadussalihin": EXPECTED_PER_COLLECTION["riyadussalihin"],
+        }
+
+        total_edges = neo4j_client.execute_read(
+            "MATCH (:Hadith)-[r:APPEARS_IN]->(:Collection) RETURN count(r) AS n"
+        )[0]["n"]
+        assert total_edges == EXPECTED_HADITHS, "an APPEARS_IN edge is dangling or missing"

--- a/tests/test_graph/test_first_light_slice.py
+++ b/tests/test_graph/test_first_light_slice.py
@@ -147,3 +147,63 @@ def test_appears_in_edges_match_collection(staged_sample: Path, tmp_path: Path) 
     edge_collection_id = f"col:{h0['source_corpus']}:{h0['collection_name']}"
     node_collection_id = f"col:{coll_rows[0]['collection_id']}"
     assert edge_collection_id == node_collection_id == "col:sunnah:riyadussalihin"
+
+
+# ---------------------------------------------------------------------------
+# da#84: extend the scraped light-up beyond riyadussalihin — multi-collection.
+# Locks the multi-collection parse + load path in CI (no Docker); the live
+# neo4j:5 proof is tests/integration/test_sunnah_scraped_multicollection.py.
+# ---------------------------------------------------------------------------
+
+ADAB_SAMPLE_JSON = SAMPLE_JSON.parent / "adab.json"
+
+# Per-collection book-1 counts; total = 47 + 46.
+EXPECTED_PER_COLLECTION = {"riyadussalihin": 47, "adab": 46}
+EXPECTED_MULTI_HADITHS = sum(EXPECTED_PER_COLLECTION.values())
+EXPECTED_MULTI_COLLECTIONS = len(EXPECTED_PER_COLLECTION)
+
+
+@pytest.fixture
+def staged_multi(tmp_path: Path) -> Path:
+    """Parse both real samples (riyadussalihin + adab) into one staging dir."""
+    raw = tmp_path / "raw" / "sunnah_scraped"
+    raw.mkdir(parents=True)
+    for sample in (SAMPLE_JSON, ADAB_SAMPLE_JSON):
+        assert sample.exists(), f"committed sample missing: {sample}"
+        shutil.copyfile(sample, raw / sample.name)
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    sunnah_scraped.run(tmp_path / "raw", staging)
+    return staging
+
+
+def test_multi_collection_parses_to_distinct_source_ids(staged_multi: Path) -> None:
+    """Both collections parse: 93 hadiths, 2 collections, no source_id collision
+    across collections, each adab id namespaced under sunnah:adab."""
+    hadiths = pq.read_table(staged_multi / "hadiths_sunnah_scraped.parquet").to_pylist()
+    collections = pq.read_table(staged_multi / "collections_sunnah_scraped.parquet").to_pylist()
+    assert len(hadiths) == EXPECTED_MULTI_HADITHS
+    assert {c["collection_id"] for c in collections} == {"sunnah:adab", "sunnah:riyadussalihin"}
+    assert len({h["source_id"] for h in hadiths}) == EXPECTED_MULTI_HADITHS
+    adab = [h for h in hadiths if h["collection_name"] == "adab"]
+    assert len(adab) == EXPECTED_PER_COLLECTION["adab"]
+    assert all(h["source_id"].startswith("sunnah:adab:") for h in adab)
+    # Every row is Sunni / sunnah-tagged regardless of collection.
+    assert all(h["sect"] == "sunni" and h["source_corpus"] == "sunnah" for h in hadiths)
+
+
+def test_multi_collection_node_and_edge_counts(staged_multi: Path, tmp_path: Path) -> None:
+    """load_all_nodes/edges load both collections: 93 Hadith + 2 Collection,
+    93 APPEARS_IN edges, no dangling endpoints."""
+    curated = tmp_path / "curated"
+    curated.mkdir()
+    client = _AllEndpointsExistMock()
+    node_results = load_all_nodes(cast(Neo4jClient, client), staged_multi, curated, strict=False)
+    by_node = {r.node_type: r for r in node_results}
+    assert by_node["Hadith"].created == EXPECTED_MULTI_HADITHS
+    assert by_node["Collection"].created == EXPECTED_MULTI_COLLECTIONS
+
+    edge_results = load_all_edges(cast(Neo4jClient, client), staged_multi, curated, strict=False)
+    by_edge = {r.edge_type: r for r in edge_results}
+    assert by_edge["APPEARS_IN"].created == EXPECTED_MULTI_HADITHS
+    assert by_edge["APPEARS_IN"].missing_endpoints == 0


### PR DESCRIPTION
## da#84 (L1): extend the sunnah_scraper light-up beyond riyadussalihin

First-light (da#73) lit up **riyadussalihin** (47 hadiths) via an in-process **mock** Neo4j. This brings a **second real collection** through the same path and proves the load against a **live `neo4j:5` container** (the owner's live-local acceptance bar). Builds on the #82 identity contract.

### What
- **`scripts/first_light/sample/sunnah_scraped/adab.json`** — real scraped sample: **Al-Adab Al-Mufrad book 1, 46 bilingual hadiths**, same JSON shape as the riyadussalihin sample (scraped live via the existing `sunnah_scraper._scrape_book_page`).
- **`tests/integration/test_sunnah_scraped_multicollection.py`** — live `neo4j:5`: parses both real samples → real batch loaders → asserts 2 Collection nodes + 93 Hadith nodes tagged `sunni`/`sunnah`, and `APPEARS_IN` routes each hadith to **its own** collection (46 → `col:sunnah:adab`, 47 → `col:sunnah:riyadussalihin`), no dangling/cross-leakage. **2/2 pass locally (~16s).**
- **`tests/test_graph/test_first_light_slice.py`** — CI (no-Docker) multi-collection lock: 93 hadiths / 2 collections, distinct source_ids (adab namespaced `sunnah:adab:…`), node + edge counts.

No parser change was needed — the parser is already collection-agnostic and `source_id`s build via `generate_source_id` (corpus-validated against the identity contract from #82, never hand-concatenated). The real gap was multi-collection **data flowing E2E** + a **live-Neo4j** proof.

### Reachability + licensing
- sunnah.com reachable 2026-06-12 (`robots.txt` 200; live scrape of `adab/1` 200). The scraper checks `robots.txt`, sets a research User-Agent, and rate-limits (0.5 s+/request).
- The committed sample is a small book-1 slice for test/first-light purposes; full-collection acquisition remains the runtime `make acquire` path.

### Test plan
- Live: `pytest tests/integration/test_sunnah_scraped_multicollection.py -m integration` → 2/2 pass against neo4j:5.
- CI: full non-integration suite green (568 passed, 3 skipped); `ruff check` + `ruff format --check` clean; `mypy src/` clean (63 files).
- Staging-cluster load (cluster-internal) tracked as a **separate post-merge verify**, not a PR gate.

Closes #84
Refs #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
