### PR TITLE
feat(itqan): NEW Itqan adapter — narrator profiles → Narrator nodes (da#92a)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -115,3 +115,19 @@ muhaddithat
 thaqalayn
 riyadussalihin
 firstlight
+
+# --- Itqan rijal narrator source + jarh-wa-ta'dil vocabulary (da#92a — docs/itqan-narrators.md) ---
+itqan
+rijal
+jarh
+thiqa
+saduq
+daif
+matruk
+kadhdhab
+sahabi
+hijri
+shahid
+disambiguator
+dedups
+unioned

--- a/docs/itqan-narrators.md
+++ b/docs/itqan-narrators.md
@@ -1,0 +1,104 @@
+# Itqan narrator profiles (da#92a)
+
+The **Itqan** corpus (github [`R3GENESI5/Itqan`](https://github.com/R3GENESI5/Itqan))
+is the largest open-source narrator (rijal) database: **115,735 narrator
+profiles** drawn from 22 classical texts, **72.6 %** of them carrying a
+jarh-wa-ta'dil grade. This slice (da#92a, PR 1 of 3 in the Itqan pre-split)
+loads the **narrator profiles → `Narrator` nodes**. It is the keystone source
+for isnad-graph narrator search (isnad-graph#963 / #965).
+
+The two sibling Itqan PRs cover the rest of the corpus and are **out of scope
+here**:
+
+- **#93** — `teachers` / `students` id lists → isnad chains / `TRANSMITTED_TO`.
+- **#94** — `namings` / `by_name.json` → narrator name variants / aliases.
+
+## Source shape
+
+`app/data/rijal/manifest.json` enumerates one JSON file per grade bucket:
+
+| bucket file | grade | profiles |
+|---|---|---|
+| `profiles_reliable.json` | reliable | 26,467 |
+| `profiles_mostly_reliable.json` | mostly_reliable | 21,800 |
+| `profiles_weak.json` | weak | 21,413 |
+| `profiles_companion.json` | companion | 10,880 |
+| `profiles_unknown.json` | unknown | 31,695 |
+| `profiles_fabricator.json` | fabricator | 2,094 |
+| `profiles_abandoned.json` | abandoned | 1,386 |
+
+Each file is a JSON object keyed by narrator id (globally unique across buckets).
+The grade bucket = the per-profile `grade_en` field; the Arabic verdict is in
+`grade_ar`.
+
+### Field mapping (→ `NARRATOR_BIO_SCHEMA`)
+
+| Itqan field | bio field | notes |
+|---|---|---|
+| `id` | `external_id`, `bio_id`=`itqan:{id}` | globally unique |
+| `full_name` | `name_ar` | Arabic-only source — `name_en` is null |
+| `grade_en` | `trustworthiness` | reliable→thiqa, mostly_reliable→saduq, weak→daif, abandoned→matruk, fabricator→kadhdhab, companion→thiqa, unknown→unknown |
+| `grade_ar` | `bio_text` | the jarh-wa-ta'dil verdict text |
+| `death` | `death_year_ah` | free text ("بين 161 هـ إلى 170 هـ"); first Hijri year taken as an **approximate** anchor |
+| `tabaqat` / companion bucket | `generation` | companion→sahabi; a conservative Arabic-ordinal map otherwise, else null |
+| `city` | `birth_location` | primary city of activity |
+| `kunya`/`nasab`/`laqab` | `kunya`/`nisba`/`laqab` | `-` placeholder → null |
+
+`gender` and `birth_year_ah` are not recorded by Itqan → null.
+
+## Why a bio-direct promoter
+
+The mention-driven disambiguator (`src/resolve/disambiguate.py`) only mints a
+canonical `Narrator` when an **isnad mention** resolves to a bio candidate — so a
+profile-only source (bios, no chains in this slice) would yield **zero** Narrator
+nodes. `src/resolve/bio_promote.py` bridges that: each bio is promoted to a
+canonical narrator keyed by the **same** `nar:<uuid5(normalized-name)>` identity
+the disambiguator uses (`src.parse.identity.make_canonical_id`), so the two paths
+converge — a later mention-driven run dedups onto the same node — and the graph
+loader ingests the output unchanged. It is merge-safe: an existing
+`narrators_canonical.parquet` is unioned, not overwritten.
+
+> The graph loader (`load_nodes._load_narrators`) reads
+> `narrators_canonical.parquet` from the **staging** dir, so the promoter must be
+> pointed at staging for the load to pick it up.
+
+## Full-load runbook (all 115,735 profiles)
+
+```bash
+# 1. Acquire — downloads the 7 profile buckets (~150 MB) into data/raw/itqan/
+uv run python -m src.cli acquire        # or: only this source via src.acquire.itqan.run(raw_dir)
+
+# 2. Parse — narrators_bio_itqan.parquet (NARRATOR_BIO_SCHEMA)
+uv run python -m src.cli parse
+
+# 3. Promote bios → narrators_canonical.parquet IN the staging dir
+uv run python - <<'PY'
+from pathlib import Path
+from src.config import get_settings
+from src.resolve.bio_promote import promote_bios_to_canonical
+s = get_settings()
+promote_bios_to_canonical(Path(s.data_staging_dir), Path(s.data_staging_dir), sources={"itqan"})
+PY
+
+# 4. Load Narrator nodes into Neo4j
+uv run python -m src.cli load --nodes-only
+```
+
+### Representative live proof (committed)
+
+`tests/integration/test_itqan_load.py` loads a committed 24-profile real sample
+(abandoned + fabricator + companion) into a live `neo4j:5` container and asserts
+`nar:` ids, the `external_id` provenance tag, and the three jarh tiers. A larger
+local proof run (3 real buckets, 14,360 bios) promoted to **12,820 canonical
+narrators** and loaded **12,820 `Narrator` nodes** into `neo4j:5` with 0 errors
+(trust split: thiqa 9,922 · kadhdhab 1,639 · matruk 1,259).
+
+## Reachability & licensing
+
+- **Reachability:** plain HTTPS from `raw.githubusercontent.com` — no auth, no
+  API key. The 7 buckets total ~150 MB.
+- **Licensing:** the upstream repo ships **no LICENSE file** → all-rights-reserved
+  by default. Acquisition here is for research/analysis. Redistribution or
+  production publication of the raw corpus needs an explicit usage grant from the
+  upstream author (Ali Bin Shahid) — **flagged for owner confirmation; not
+  cleared for redistribution.**

--- a/docs/itqan-narrators.md
+++ b/docs/itqan-narrators.md
@@ -98,7 +98,23 @@ narrators** and loaded **12,820 `Narrator` nodes** into `neo4j:5` with 0 errors
 - **Reachability:** plain HTTPS from `raw.githubusercontent.com` — no auth, no
   API key. The 7 buckets total ~150 MB.
 - **Licensing:** the upstream repo ships **no LICENSE file** → all-rights-reserved
-  by default. Acquisition here is for research/analysis. Redistribution or
-  production publication of the raw corpus needs an explicit usage grant from the
-  upstream author (Ali Bin Shahid) — **flagged for owner confirmation; not
-  cleared for redistribution.**
+  by default. We do not redistribute their files — we ingest **facts** (names,
+  grades, dates) re-expressed in our own schema, with full provenance. Cleared by
+  the owner for this non-profit use on that basis (upstream author: Ali Bin Shahid).
+
+### Provenance & removability
+
+Every `Narrator` node carries `source_ids` (a `<corpus>:<bare-id>` list, e.g.
+`["itqan:320"]`), so the Itqan contribution is auditable and **cleanly removable
+on the graph** if the upstream author ever objects:
+
+```cypher
+// remove every narrator that came (solely) from Itqan
+MATCH (n:Narrator) WHERE any(s IN n.source_ids WHERE s STARTS WITH 'itqan:')
+DETACH DELETE n
+```
+
+> `source_ids` (a list) is the correct removal handle rather than a scalar
+> `source_corpus`: after cross-source dedup a canonical narrator can carry ids
+> from several corpora, so to *strip* Itqan from a multi-source narrator you would
+> remove its `itqan:` entries rather than delete the whole node.

--- a/src/acquire/__init__.py
+++ b/src/acquire/__init__.py
@@ -12,6 +12,7 @@ from types import ModuleType
 
 from src.acquire import (
     fawaz,
+    itqan,
     lk_corpus,
     muhaddithat,
     open_hadith,
@@ -35,6 +36,7 @@ SOURCES: list[tuple[str, ModuleType | None]] = [
     ("sunnah_scraped", sunnah_scraper),
     ("open_hadith", open_hadith),
     ("muhaddithat", muhaddithat),
+    ("itqan", itqan),
 ]
 
 

--- a/src/acquire/itqan.py
+++ b/src/acquire/itqan.py
@@ -1,0 +1,78 @@
+"""Acquire the Itqan narrator (rijal) profile dataset from GitHub.
+
+Itqan (github ``R3GENESI5/Itqan``) is the largest open-source narrator
+database: 115,735 narrator profiles drawn from 22 classical rijal texts, 72.6%
+of them carrying a jarh-wa-ta'dil grade. The profiles live under
+``app/data/rijal/`` as one JSON file per grade bucket (``profiles_<grade>.json``)
+plus a ``manifest.json`` that enumerates the buckets and their counts.
+
+This downloader fetches **only the narrator-profile buckets** (the highest-value
+slice — da#92a). The sibling artefacts are intentionally left for the other two
+Itqan PRs in the pre-split (per epic da#81):
+
+* ``teachers`` / ``students`` id lists inside each profile → isnad chains (#93).
+* ``by_name.json`` (the name-variant index) and the per-profile ``namings`` →
+  name variants (#94).
+
+Reachability: served from ``raw.githubusercontent.com`` over HTTPS — no auth,
+no API key. The seven profile buckets total ~150 MB.
+
+Licensing: the upstream repo ships **no LICENSE file** (all-rights-reserved by
+default). Acquisition here is for research/analysis; redistribution or
+production publication of the raw corpus needs an explicit usage grant from the
+upstream author (Ali Bin Shahid) — flagged for owner confirmation, do NOT treat
+as cleared for redistribution.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.acquire.base import download_file, ensure_dir, write_manifest
+from src.messaging import emit_raw_new_for_manifest
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+RIJAL_BASE_URL = "https://raw.githubusercontent.com/R3GENESI5/Itqan/master/app/data/rijal"
+MANIFEST_URL = f"{RIJAL_BASE_URL}/manifest.json"
+
+
+def run(raw_dir: Path) -> Path:
+    """Download the Itqan rijal narrator-profile buckets.
+
+    Idempotent: ``download_file`` skips a non-empty existing file, so re-running
+    only fetches what is missing (the manifest itself is always refreshed so a
+    new upstream version is noticed).
+    """
+    dest = ensure_dir(raw_dir / "itqan")
+
+    # Manifest first — it is the source of truth for which buckets exist.
+    manifest_path = download_file(MANIFEST_URL, dest / "manifest.json", overwrite=True)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    profile_entries = [e for e in manifest.get("files", []) if e.get("type") == "profiles"]
+    if not profile_entries:
+        msg = f"Itqan manifest has no profile buckets: {manifest_path}"
+        raise AssertionError(msg)
+
+    downloaded: list[Path] = [manifest_path]
+    expected_total = 0
+    for entry in profile_entries:
+        name = entry["name"]
+        expected_total += int(entry.get("count", 0))
+        path = download_file(f"{RIJAL_BASE_URL}/{name}", dest / name)
+        downloaded.append(path)
+
+    logger.info(
+        "itqan_acquired",
+        buckets=len(profile_entries),
+        expected_profiles=expected_total,
+        manifest_total=manifest.get("total_profiles"),
+        version=manifest.get("version"),
+    )
+
+    write_manifest(dest, downloaded)
+    emit_raw_new_for_manifest(source="itqan", local_dir=dest, files=downloaded)
+    return dest

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -80,6 +80,7 @@ SET n.name_ar           = row.name_ar,
     n.trustworthiness   = row.trustworthiness,
     n.aliases           = row.aliases,
     n.external_id       = row.external_id,
+    n.source_ids        = row.source_ids,
     n.mention_count     = row.mention_count
 """
 
@@ -128,6 +129,10 @@ def _load_narrators(
                 "trustworthiness": _val(row, "trustworthiness"),
                 "aliases": _val(row, "aliases", []),
                 "external_id": _val(row, "external_id"),
+                # Per-source provenance (``<corpus>:<bare-id>`` list) so a corpus is
+                # auditable/removable on the graph itself, e.g.
+                # ``MATCH (n:Narrator) WHERE any(s IN n.source_ids WHERE s STARTS WITH 'itqan:')``.
+                "source_ids": _val(row, "source_ids", []),
                 "mention_count": _val(row, "mention_count"),
             }
         )

--- a/src/models/enums.py
+++ b/src/models/enums.py
@@ -151,6 +151,7 @@ class SourceCorpus(StrEnum):
     FAWAZ = "fawaz"
     OPEN_HADITH = "open_hadith"
     MUHADDITHAT = "muhaddithat"
+    ITQAN = "itqan"
 
 
 class Sect(StrEnum):

--- a/src/parse/__init__.py
+++ b/src/parse/__init__.py
@@ -7,6 +7,7 @@ from types import ModuleType
 
 from src.parse import (
     fawaz,
+    itqan,
     lk_corpus,
     muhaddithat,
     open_hadith,
@@ -28,6 +29,7 @@ PARSERS: list[tuple[str, ModuleType | None]] = [
     ("sunnah_scraped", sunnah_scraped),
     ("open_hadith", open_hadith),
     ("muhaddithat", muhaddithat),
+    ("itqan", itqan),
 ]
 
 

--- a/src/parse/identity.py
+++ b/src/parse/identity.py
@@ -44,6 +44,8 @@ Two historical identity hazards this module designs out
 
 from __future__ import annotations
 
+import uuid
+
 from src.models.enums import SourceCorpus
 from src.utils.logging import get_logger
 
@@ -66,7 +68,18 @@ __all__ = [
     "grading_node_id",
     "is_double_prefixed",
     "validate_source_id",
+    "CANONICAL_NAMESPACE",
+    "make_canonical_id",
 ]
+
+# Fixed UUID5 namespace for canonical Narrator ids. A canonical narrator's id is
+# ``nar:<uuid5(CANONICAL_NAMESPACE, normalized-name)>`` — deterministic from the
+# narrator's normalized name so every producer (the mention-driven disambiguator
+# in ``src/resolve/disambiguate.py`` and the bio-direct promoter in
+# ``src/resolve/bio_promote.py``) that sees the same name converges on the same
+# Narrator node. This namespace value is load-bearing: changing it re-keys every
+# existing canonical narrator, so it is pinned here as the single source of truth.
+CANONICAL_NAMESPACE = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 
 # The corpus namespace — derived from the enum so the two never drift. Note that
 # ``sunnah_scraped`` intentionally shares the ``sunnah`` corpus (the scraper and
@@ -157,6 +170,21 @@ def collection_node_id(collection_id: str) -> str:
 def narrator_node_id(canonical_id: str) -> str:
     """Canonical Narrator graph node id (``nar:<canonical-id>``)."""
     return apply_prefix(canonical_id, NARRATOR_ID_PREFIX)
+
+
+def make_canonical_id(name_normalized: str) -> str:
+    """Deterministic canonical Narrator id from a *normalized* name.
+
+    Returns ``nar:<uuid5(CANONICAL_NAMESPACE, name_normalized)>``. THE one rule
+    for minting a canonical narrator id — both the mention-driven disambiguator
+    (``src/resolve/disambiguate.py``) and the bio-direct promoter
+    (``src/resolve/bio_promote.py``) route through it so the same normalized name
+    always maps to the same Narrator node (and the ``nar:`` prefix the graph
+    loader ``load_nodes._load_narrators`` validates on import). The input must be
+    pre-normalized (see ``src.utils.arabic.normalize_arabic``) so equivalent
+    spellings collapse to one id.
+    """
+    return narrator_node_id(str(uuid.uuid5(CANONICAL_NAMESPACE, name_normalized)))
 
 
 def chain_node_id(source_id: str, index: int = 0) -> str:

--- a/src/parse/itqan.py
+++ b/src/parse/itqan.py
@@ -1,0 +1,194 @@
+"""Parse the Itqan rijal dataset into NARRATOR_BIO staging Parquet.
+
+Produces one output file — ``narrators_bio_itqan.parquet`` (NARRATOR_BIO_SCHEMA)
+— from the per-grade profile buckets downloaded by ``src/acquire/itqan.py``.
+
+Each bucket file (``profiles_<grade>.json``) is a JSON object keyed by the
+narrator id; every value is a profile dict. The jarh-wa-ta'dil grade is carried
+both by the filename bucket and the per-profile ``grade_en`` field (they agree);
+we trust the per-profile field and fall back to the bucket.
+
+Scope (da#92a — narrators only): the ``teachers``/``students`` id lists (isnad
+edges, #93) and the ``namings``/``by_name`` name variants (#94) are deliberately
+NOT emitted here — this PR populates Narrator bios only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pyarrow as pa
+
+from src.parse.base import safe_str, write_parquet
+from src.parse.schemas import NARRATOR_BIO_SCHEMA
+from src.utils.arabic import normalize_arabic
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+SOURCE = "itqan"
+
+# Itqan grade bucket -> classical trustworthiness tier (TrustworthinessGrade).
+# ``companion`` is a status rather than a jarh verdict; by the rijal consensus
+# that the Companions are ``udul`` (all reliable) it maps to ``thiqa`` while the
+# generation field separately records ``sahabi``.
+_GRADE_TO_TRUST: dict[str, str] = {
+    "reliable": "thiqa",
+    "mostly_reliable": "saduq",
+    "weak": "daif",
+    "abandoned": "matruk",
+    "fabricator": "kadhdhab",
+    "companion": "thiqa",
+    "unknown": "unknown",
+}
+
+# Coarse map from the Ibn-Hajar tabaqat ordinal (Arabic) to NarratorGeneration.
+# Deliberately conservative: only the unambiguous ordinal words are mapped; the
+# rest yield ``None`` rather than guess. The ``companion`` bucket overrides this
+# to ``sahabi`` regardless of tabaqat.
+_TABAQAT_GENERATION: list[tuple[str, str]] = [
+    ("صحاب", "sahabi"),  # صحابي / صحابة
+    ("الأولى", "sahabi"),
+    ("الثانية", "tabii"),
+    ("الثالثة", "tabii"),
+    ("الرابعة", "tabii"),
+    ("الخامسة", "taba_tabii"),
+    ("السادسة", "taba_tabii"),
+    ("السابعة", "taba_tabii"),
+    ("الثامنة", "taba_tabii"),
+    ("التاسعة", "atba_taba_tabiin"),
+    ("العاشرة", "atba_taba_tabiin"),
+    ("الحادية", "later"),  # الحادية عشرة (11th)
+    ("الثانية عشرة", "later"),
+]
+
+# A Hijri year inside a free-text death string ("168 هـ", "بين 161 هـ إلى 170 هـ").
+_YEAR_RE = re.compile(r"\d+")
+
+
+def _clean(value: object) -> str | None:
+    """Itqan uses ``"-"`` as a placeholder for missing fields; treat it as null."""
+    s = safe_str(value)
+    if s is None or s == "-":
+        return None
+    return s
+
+
+def _extract_death_year(value: object) -> int | None:
+    """Best-effort Hijri death year from a free-text death field.
+
+    The field is prose — exact years, ranges ("بين 161 هـ إلى 170 هـ") and
+    approximations ("180 هـ تقريبا"). We take the FIRST year mentioned as an
+    approximate anchor; ranges/approximations are inherently lossy, so this is
+    a hint for timelines, not an authoritative date.
+    """
+    s = _clean(value)
+    if s is None:
+        return None
+    match = _YEAR_RE.search(s)
+    if not match:
+        return None
+    year = int(match.group())
+    # Guard against absurd values (no narrator died in year 0 or > ~1500 AH).
+    if 1 <= year <= 1500:
+        return year
+    return None
+
+
+def _generation(profile: dict[str, object], grade: str | None) -> str | None:
+    """Map a profile to a NarratorGeneration value (or ``None`` if unclear)."""
+    if grade == "companion":
+        return "sahabi"
+    tabaqat = _clean(profile.get("tabaqat"))
+    if tabaqat is None:
+        return None
+    for needle, generation in _TABAQAT_GENERATION:
+        if needle in tabaqat:
+            return generation
+    return None
+
+
+def _parse_profile(raw_id: str, profile: dict[str, object]) -> dict[str, object | None] | None:
+    """Map one Itqan profile to a NARRATOR_BIO_SCHEMA row dict."""
+    name_ar = _clean(profile.get("full_name"))
+    if name_ar is None:
+        return None  # a bio with no name cannot key a canonical narrator
+
+    # ``id`` is globally unique across all buckets (verified); fall back to the
+    # JSON key when the field is absent.
+    profile_id = safe_str(profile.get("id")) or safe_str(raw_id)
+    grade = _clean(profile.get("grade_en"))
+    trustworthiness = _GRADE_TO_TRUST.get(grade) if grade else None
+
+    return {
+        "bio_id": f"{SOURCE}:{profile_id}",
+        "source": SOURCE,
+        "name_ar": name_ar,
+        "name_en": None,  # Itqan is Arabic-only — no transliteration in the source
+        "name_ar_normalized": normalize_arabic(name_ar),
+        "name_en_normalized": None,
+        "kunya": _clean(profile.get("kunya")),
+        "nisba": _clean(profile.get("nasab")),
+        "laqab": _clean(profile.get("laqab")),
+        "birth_year_ah": None,  # not present in the source
+        "death_year_ah": _extract_death_year(profile.get("death")),
+        "birth_location": _clean(profile.get("city")),  # primary city of activity
+        "death_location": None,
+        "generation": _generation(profile, grade),
+        "gender": None,  # not recorded by Itqan
+        "trustworthiness": trustworthiness,
+        "bio_text": _clean(profile.get("grade_ar")),  # the jarh-wa-ta'dil verdict text
+        "external_id": profile_id,
+    }
+
+
+def _parse_profiles_file(path: Path) -> list[dict[str, object | None]]:
+    """Parse one ``profiles_<grade>.json`` bucket into bio rows."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    rows: list[dict[str, object | None]] = []
+    for raw_id, profile in data.items():
+        if not isinstance(profile, dict):
+            continue
+        row = _parse_profile(raw_id, profile)
+        if row is not None:
+            rows.append(row)
+    logger.info("itqan_bucket_parsed", file=path.name, rows=len(rows))
+    return rows
+
+
+def run(raw_dir: Path, staging_dir: Path) -> Path:
+    """Parse Itqan rijal buckets into ``narrators_bio_itqan.parquet``."""
+    source_dir = raw_dir / "itqan"
+    if not source_dir.exists():
+        msg = f"Source directory not found: {source_dir}"
+        raise FileNotFoundError(msg)
+
+    bucket_files = sorted(source_dir.glob("profiles_*.json"))
+    if not bucket_files:
+        msg = f"No profiles_*.json buckets under {source_dir}"
+        raise FileNotFoundError(msg)
+
+    rows: list[dict[str, object | None]] = []
+    seen_bio_ids: set[str] = set()
+    for bucket in bucket_files:
+        for row in _parse_profiles_file(bucket):
+            bio_id = str(row["bio_id"])
+            if bio_id in seen_bio_ids:
+                logger.warning("itqan_duplicate_bio_id", bio_id=bio_id)
+                continue
+            seen_bio_ids.add(bio_id)
+            rows.append(row)
+
+    if not rows:
+        msg = "No valid Itqan narrator bios parsed"
+        raise ValueError(msg)
+
+    arrays = {field.name: [r[field.name] for r in rows] for field in NARRATOR_BIO_SCHEMA}
+    table = pa.table(arrays, schema=NARRATOR_BIO_SCHEMA)
+
+    out_path = staging_dir / "narrators_bio_itqan.parquet"
+    write_parquet(table, out_path, schema=NARRATOR_BIO_SCHEMA)
+    logger.info("itqan_bios_parsed", total=len(rows), buckets=len(bucket_files))
+    return out_path

--- a/src/parse/validate.py
+++ b/src/parse/validate.py
@@ -143,6 +143,7 @@ DEFAULT_BASELINES: dict[str, dict[str, float | int]] = {
     "narrator_mentions_sanadset": {"row_count": 2789517},
     "narrators_bio_kaggle": {"row_count": 24326},
     "narrators_bio_muhaddithat": {"row_count": 113},
+    "narrators_bio_itqan": {"row_count": 115735},
     "collections_sunnah_api": {"row_count": 15},
     "collections_sunnah_scraped": {"row_count": 5},
     "collections_thaqalayn": {"row_count": 64},

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -1,0 +1,159 @@
+"""Promote narrator BIO rows directly to canonical Narrator records.
+
+The mention-driven disambiguator (``src/resolve/disambiguate.py``) only emits a
+canonical narrator when an isnad *mention* resolves to a bio candidate — with
+zero mentions it returns nothing. A **profile-only** source (a rijal database
+such as Itqan that contributes biographies but no isnad chains in its narrators
+slice) would therefore produce **no** Narrator nodes at all.
+
+This module bridges that gap. Each bio becomes — or updates — a canonical
+narrator keyed by the SAME ``nar:<uuid5(normalized-name)>`` identity the
+disambiguator uses (``src.parse.identity.make_canonical_id``), so the two paths
+converge: a later mention-driven run dedups onto the very same node, and the
+graph loader (``load_nodes._load_narrators``) ingests the output unchanged.
+
+It is **merge-safe**: when ``narrators_canonical.parquet`` already exists (e.g.
+from a disambiguator run), it is loaded and unioned by ``canonical_id`` rather
+than overwritten, so the bio-direct and mention-driven outputs compose.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from src.parse.base import safe_str, write_parquet
+from src.parse.identity import make_canonical_id
+from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = ["promote_bios_to_canonical"]
+
+# Scalar bio fields back-filled onto an existing canonical record when missing.
+_BACKFILL_FIELDS = (
+    "name_en",
+    "birth_year_ah",
+    "death_year_ah",
+    "generation",
+    "gender",
+    "trustworthiness",
+    "external_id",
+)
+
+
+def _load_existing_canonical(path: Path) -> dict[str, dict[str, Any]]:
+    """Load an existing narrators_canonical.parquet into a canonical_id -> row map."""
+    if not path.exists():
+        return {}
+    table = pq.read_table(path)
+    rows: dict[str, dict[str, Any]] = {}
+    for row in table.to_pylist():
+        cid = row.get("canonical_id")
+        if cid:
+            row.setdefault("source_ids", [])
+            row.setdefault("aliases", [])
+            rows[cid] = row
+    return rows
+
+
+def promote_bios_to_canonical(
+    staging_dir: Path,
+    output_dir: Path,
+    *,
+    sources: set[str] | None = None,
+) -> Path | None:
+    """Build/extend ``narrators_canonical.parquet`` directly from narrator bios.
+
+    Args:
+        staging_dir: directory holding ``narrators_bio_*.parquet`` files.
+        output_dir: directory the canonical Parquet is written to (and read from
+            when merging into a pre-existing file).
+        sources: if given, only bios whose ``source`` column is in this set are
+            promoted (e.g. ``{"itqan"}``).
+
+    Returns the canonical Parquet path, or ``None`` when there are no bios to
+    promote (no file written).
+    """
+    bio_files = sorted(staging_dir.glob("narrators_bio_*.parquet"))
+    if not bio_files:
+        logger.warning("bio_promote_no_bio_files", staging_dir=str(staging_dir))
+        return None
+
+    canonical_path = output_dir / "narrators_canonical.parquet"
+    canonical_map = _load_existing_canonical(canonical_path)
+    pre_existing = len(canonical_map)
+
+    promoted = 0
+    skipped_no_name = 0
+    skipped_source = 0
+
+    for bf in bio_files:
+        table = pq.read_table(bf)
+        for row in table.to_pylist():
+            source = safe_str(row.get("source"))
+            if sources is not None and source not in sources:
+                skipped_source += 1
+                continue
+
+            name_ar = safe_str(row.get("name_ar"))
+            norm = safe_str(row.get("name_ar_normalized")) or (
+                normalize_arabic(name_ar) if name_ar else None
+            )
+            if not norm:
+                skipped_no_name += 1
+                continue
+
+            bio_id = safe_str(row.get("bio_id"))
+            cid = make_canonical_id(norm)
+
+            if cid not in canonical_map:
+                canonical_map[cid] = {
+                    "canonical_id": cid,
+                    "name_ar": name_ar,
+                    "name_en": safe_str(row.get("name_en")),
+                    "name_ar_normalized": norm,
+                    "aliases": [],
+                    "birth_year_ah": row.get("birth_year_ah"),
+                    "death_year_ah": row.get("death_year_ah"),
+                    "generation": safe_str(row.get("generation")),
+                    "gender": safe_str(row.get("gender")),
+                    "trustworthiness": safe_str(row.get("trustworthiness")),
+                    "source_ids": [bio_id] if bio_id else [],
+                    "external_id": safe_str(row.get("external_id")),
+                    # mention_count stays 0: a bio is provenance, not a chain hit.
+                    "mention_count": 0,
+                }
+            else:
+                rec = canonical_map[cid]
+                src_ids = rec.setdefault("source_ids", [])
+                if bio_id and bio_id not in src_ids:
+                    src_ids.append(bio_id)
+                # Back-fill only fields the existing record is missing. Keep the
+                # raw Parquet value (already a clean str / int) — do NOT coerce,
+                # or an int column like death_year_ah gets stringified.
+                for field_name in _BACKFILL_FIELDS:
+                    if rec.get(field_name) in (None, "") and row.get(field_name) not in (None, ""):
+                        rec[field_name] = row.get(field_name)
+            promoted += 1
+
+    table_rows = list(canonical_map.values())
+    arrays = {f.name: [r.get(f.name) for r in table_rows] for f in NARRATORS_CANONICAL_SCHEMA}
+    out_table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
+    write_parquet(out_table, canonical_path, schema=NARRATORS_CANONICAL_SCHEMA)
+
+    logger.info(
+        "bio_promote_complete",
+        bio_files=len(bio_files),
+        promoted=promoted,
+        canonical_total=len(canonical_map),
+        pre_existing=pre_existing,
+        skipped_no_name=skipped_no_name,
+        skipped_source=skipped_source,
+    )
+    return canonical_path

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -12,7 +12,6 @@ mentions in batches to keep memory under 4GB.
 from __future__ import annotations
 
 import csv
-import uuid
 from collections import defaultdict
 from collections.abc import Iterator
 from dataclasses import dataclass, field
@@ -24,7 +23,7 @@ from rapidfuzz import fuzz
 from rapidfuzz.distance import Levenshtein
 
 from src.parse.base import safe_str, write_parquet
-from src.parse.identity import narrator_node_id
+from src.parse.identity import make_canonical_id
 from src.resolve.schemas import AMBIGUOUS_NARRATORS_SCHEMA, NARRATORS_CANONICAL_SCHEMA
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
@@ -32,11 +31,6 @@ from src.utils.logging import get_logger
 logger = get_logger(__name__)
 
 __all__ = ["run"]
-
-# ---------------------------------------------------------------------------
-# Fixed namespace for deterministic canonical IDs
-# ---------------------------------------------------------------------------
-_CANONICAL_NAMESPACE = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 
 # ---------------------------------------------------------------------------
 # Thresholds
@@ -438,15 +432,13 @@ def _load_mentions(
 # Canonical ID generation
 # ---------------------------------------------------------------------------
 def _make_canonical_id(name_normalized: str) -> str:
-    """Deterministic canonical ID via uuid5 with fixed namespace.
+    """Deterministic canonical ID — delegates to the identity contract.
 
-    Returns ``nar:<uuid5>`` to match the ``nar:`` prefix the graph
-    loader (``load_nodes._load_narrators``) validates on import. The ``nar:``
-    prefix is applied through the canonical :func:`narrator_node_id` helper
-    (da#82) so resolve agrees with the loaders on one prefixing rule rather than
-    hand-concatenating the prefix here.
+    Thin wrapper over :func:`src.parse.identity.make_canonical_id` so the
+    mention-driven path and the bio-direct promoter share one ``nar:<uuid5>``
+    scheme and namespace (no drift). Kept as a local name for call-site brevity.
     """
-    return narrator_node_id(str(uuid.uuid5(_CANONICAL_NAMESPACE, name_normalized)))
+    return make_canonical_id(name_normalized)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_itqan_load.py
+++ b/tests/integration/test_itqan_load.py
@@ -56,7 +56,9 @@ class TestItqanNarratorLoadLive:
         assert count == expected, "every canonical Itqan narrator should be a Narrator node"
 
         nodes = neo4j_client.execute_read(
-            "MATCH (n:Narrator) RETURN n.id AS id, n.external_id AS ext, n.trustworthiness AS trust"
+            "MATCH (n:Narrator) "
+            "RETURN n.id AS id, n.external_id AS ext, n.trustworthiness AS trust, "
+            "n.source_ids AS source_ids"
         )
         # Correct ids: canonical nar: prefix on every node.
         assert all(n["id"].startswith("nar:") for n in nodes)
@@ -65,6 +67,16 @@ class TestItqanNarratorLoadLive:
         # Grading made it onto the graph: the fixture's three real jarh tiers.
         trust = {n["trust"] for n in nodes}
         assert {"matruk", "kadhdhab", "thiqa"} <= trust
+
+        # Node-level provenance: every node carries an itqan: source_id, so the
+        # corpus is auditable AND removable on the graph itself (the property the
+        # owner's licensing clearance relies on).
+        assert all(any(s.startswith("itqan:") for s in n["source_ids"]) for n in nodes)
+        removable = neo4j_client.execute_read(
+            "MATCH (n:Narrator) WHERE any(s IN n.source_ids WHERE s STARTS WITH 'itqan:') "
+            "RETURN count(n) AS n"
+        )[0]["n"]
+        assert removable == count, "every Itqan narrator must be selectable for removal"
 
     def test_reload_is_idempotent(self, neo4j_client, tmp_path: Path) -> None:
         raw = tmp_path / "raw" / "itqan"

--- a/tests/integration/test_itqan_load.py
+++ b/tests/integration/test_itqan_load.py
@@ -1,0 +1,85 @@
+"""Live-Neo4j proof that Itqan narrator bios load as Narrator nodes (da#92a).
+
+Exercises the REAL slice of the pipeline end-to-end against a live ``neo4j:5``
+container:
+
+    parse (itqan.run) -> promote (bio_promote) -> load (load_all_nodes)
+
+and asserts the Narrator nodes land with canonical ``nar:`` ids, their Itqan
+``external_id`` provenance tag, and the jarh-wa-ta'dil trustworthiness grade.
+
+Requires Docker; the ``neo4j_client`` fixture ``pytest.skip``s when Docker is
+unreachable (see ``tests/integration/conftest.py``), so this degrades to a clean
+SKIP off-CI rather than a red ERROR.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+from src.graph.load_nodes import load_all_nodes
+from src.parse import itqan
+from src.resolve.bio_promote import promote_bios_to_canonical
+
+FIXTURE = Path(__file__).parent.parent / "test_parse" / "fixtures" / "itqan_rijal_sample.json"
+
+
+@pytest.mark.integration
+class TestItqanNarratorLoadLive:
+    def test_itqan_bios_load_as_narrator_nodes(self, neo4j_client, tmp_path: Path) -> None:
+        raw = tmp_path / "raw" / "itqan"
+        raw.mkdir(parents=True)
+        shutil.copy(FIXTURE, raw / "profiles_sample.json")
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        curated = tmp_path / "curated"
+        curated.mkdir()
+
+        # parse -> narrators_bio_itqan.parquet
+        itqan.run(tmp_path / "raw", staging)
+        # promote -> narrators_canonical.parquet IN staging (where the loader reads it)
+        canonical = promote_bios_to_canonical(staging, staging, sources={"itqan"})
+        assert canonical is not None
+        expected = pq.read_table(canonical).num_rows
+        assert expected >= 20  # the 24-profile fixture, minus any name collisions
+
+        # load into the live graph
+        results = load_all_nodes(neo4j_client, staging, curated, strict=False)
+        narrator_result = next(r for r in results if r.node_type == "Narrator")
+        assert not narrator_result.validation_errors
+
+        count = neo4j_client.execute_read("MATCH (n:Narrator) RETURN count(n) AS n")[0]["n"]
+        assert count == expected, "every canonical Itqan narrator should be a Narrator node"
+
+        nodes = neo4j_client.execute_read(
+            "MATCH (n:Narrator) RETURN n.id AS id, n.external_id AS ext, n.trustworthiness AS trust"
+        )
+        # Correct ids: canonical nar: prefix on every node.
+        assert all(n["id"].startswith("nar:") for n in nodes)
+        # Provenance tagging: the Itqan profile id is carried as external_id.
+        assert all(n["ext"] for n in nodes)
+        # Grading made it onto the graph: the fixture's three real jarh tiers.
+        trust = {n["trust"] for n in nodes}
+        assert {"matruk", "kadhdhab", "thiqa"} <= trust
+
+    def test_reload_is_idempotent(self, neo4j_client, tmp_path: Path) -> None:
+        raw = tmp_path / "raw" / "itqan"
+        raw.mkdir(parents=True)
+        shutil.copy(FIXTURE, raw / "profiles_sample.json")
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        curated = tmp_path / "curated"
+        curated.mkdir()
+
+        itqan.run(tmp_path / "raw", staging)
+        promote_bios_to_canonical(staging, staging, sources={"itqan"})
+
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+        first = neo4j_client.execute_read("MATCH (n:Narrator) RETURN count(n) AS n")[0]["n"]
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+        second = neo4j_client.execute_read("MATCH (n:Narrator) RETURN count(n) AS n")[0]["n"]
+        assert first == second  # MERGE on canonical_id — no duplicate nodes

--- a/tests/test_acquire/test_itqan.py
+++ b/tests/test_acquire/test_itqan.py
@@ -1,0 +1,67 @@
+"""Tests for the Itqan acquire downloader (da#92a) — no network."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.acquire import itqan
+
+_MANIFEST = {
+    "files": [
+        {"name": "by_name.json", "type": "name_index"},
+        {"name": "profiles_reliable.json", "type": "profiles", "grade": "reliable", "count": 2},
+        {"name": "profiles_weak.json", "type": "profiles", "grade": "weak", "count": 1},
+    ],
+    "total_profiles": 3,
+    "version": "1.20",
+}
+
+
+@pytest.fixture
+def fake_download(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Replace download_file with a local-writing stub; record requested URLs."""
+    requested: list[str] = []
+
+    def _stub(url: str, dest: Path, **_kwargs: object) -> Path:
+        requested.append(url)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if dest.name == "manifest.json":
+            dest.write_text(json.dumps(_MANIFEST), encoding="utf-8")
+        else:
+            dest.write_text(json.dumps({"1": {"id": 1, "full_name": "x"}}), encoding="utf-8")
+        return dest
+
+    monkeypatch.setattr(itqan, "download_file", _stub)
+    monkeypatch.setattr(itqan, "emit_raw_new_for_manifest", lambda **_kw: None)
+    return requested
+
+
+def test_downloads_only_profile_buckets(fake_download: list[str], tmp_path: Path) -> None:
+    dest = itqan.run(tmp_path / "raw")
+
+    assert dest == tmp_path / "raw" / "itqan"
+    # Manifest + the two profile buckets fetched; the name_index is NOT (it is #94).
+    assert any(u.endswith("manifest.json") for u in fake_download)
+    assert any(u.endswith("profiles_reliable.json") for u in fake_download)
+    assert any(u.endswith("profiles_weak.json") for u in fake_download)
+    assert not any(u.endswith("by_name.json") for u in fake_download)
+
+    # A local manifest.json (write_manifest output) lists the fetched files.
+    assert (dest / "manifest.json").exists()
+    assert (dest / "profiles_reliable.json").exists()
+
+
+def test_raises_when_no_profile_buckets(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def _stub(url: str, dest: Path, **_kwargs: object) -> Path:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(json.dumps({"files": [], "total_profiles": 0}), encoding="utf-8")
+        return dest
+
+    monkeypatch.setattr(itqan, "download_file", _stub)
+    monkeypatch.setattr(itqan, "emit_raw_new_for_manifest", lambda **_kw: None)
+
+    with pytest.raises(AssertionError, match="no profile buckets"):
+        itqan.run(tmp_path / "raw")

--- a/tests/test_parse/fixtures/itqan_rijal_sample.json
+++ b/tests/test_parse/fixtures/itqan_rijal_sample.json
@@ -1,0 +1,4581 @@
+{
+ "320": {
+  "id": 320,
+  "full_name": "سعيد بن سماك بن حرب",
+  "kunya": "أبي خزامة",
+  "grade_en": "abandoned",
+  "grade_ar": "متروك الحديث",
+  "color": "#c0392b",
+  "death": "-",
+  "tabaqat": "-",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "-",
+  "dhahabi": "-",
+  "namings": [
+   "ابن السماك بن حرب",
+   "ابن سماك بن حرب",
+   "سعيد بن سماك بن حرب",
+   "سعيد بن سماك بن حرب بن أوس بن خالد بن نزار بن معاوية بن حارثة بن ربيعة بن عامر بن ذهل بن ثعلبة",
+   "سعيد بن سماك الذهلي"
+  ],
+  "classical_sources": {
+   "mizan": {
+    "entry_id": 3208,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "lisan_mizan": {
+    "entry_id": 3433,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "jarh": {
+    "entry_id": 133,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "thiqat": {
+    "entry_id": 8134,
+    "grade_en": "reliable",
+    "grade_ar": "ذكره ابن حبان في الثقات"
+   },
+   "mughni_ducafa": {
+    "entry_id": 2408,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "diwan_ducafa": {
+    "entry_id": 1615,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   }
+  },
+  "teachers": [
+   2325,
+   7019
+  ],
+  "students": [
+   319,
+   1142,
+   2790
+  ],
+  "id_score": 70,
+  "grade_score": 45,
+  "confidence": "B",
+  "id_flags": [
+   "good_nasab",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "mizan",
+     "entry_id": 3208,
+     "grade": "abandoned"
+    },
+    {
+     "type": "lisan_mizan",
+     "entry_id": 3433,
+     "grade": "abandoned"
+    },
+    {
+     "type": "jarh",
+     "entry_id": 133,
+     "grade": "abandoned"
+    },
+    {
+     "type": "thiqat",
+     "entry_id": 8134,
+     "grade": "reliable"
+    },
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 2408,
+     "grade": "abandoned"
+    },
+    {
+     "type": "diwan_ducafa",
+     "entry_id": 1615,
+     "grade": "abandoned"
+    }
+   ],
+   "arsanad_id": 320,
+   "source_count": 6,
+   "introduced_via": {
+    "teacher_count": 1,
+    "student_count": 3
+   }
+  },
+  "unique_key": "سعيد بن سماك بن حرب",
+  "uniqueness": "name_unique",
+  "gk_id": 17988,
+  "gk_match_method": "prefix3_unique"
+ },
+ "354": {
+  "id": 354,
+  "full_name": "عمر بن حفص",
+  "kunya": "أبو حفص",
+  "grade_en": "abandoned",
+  "grade_ar": "متروك",
+  "color": "#c0392b",
+  "death": "-",
+  "tabaqat": "-",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "المعيطي",
+  "dhahabi": "-",
+  "namings": [
+   "عمر أبو حفص المعيطي",
+   "عمر بن حفص أبو حفص المعيطي"
+  ],
+  "classical_sources": {
+   "mizan": {
+    "entry_id": 6081,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "lisan_mizan": {
+    "entry_id": 5599,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "jarh": {
+    "entry_id": 537,
+    "grade_en": "weak",
+    "grade_ar": "منكر الحديث"
+   },
+   "thiqat": {
+    "entry_id": 9527,
+    "grade_en": "reliable",
+    "grade_ar": "ذكره ابن حبان في الثقات"
+   },
+   "kamil": {
+    "entry_id": 1220,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "tarikh": {
+    "entry_id": 5901,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   }
+  },
+  "teachers": [
+   173
+  ],
+  "students": [
+   353
+  ],
+  "global_id": 29655,
+  "id_score": 15,
+  "grade_score": 45,
+  "confidence": "C",
+  "id_flags": [
+   "short_nasab",
+   "has_kunya",
+   "collision_large",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded"
+  ],
+  "provenance": {
+   "kaggle_id": 29655,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "mizan",
+     "entry_id": 6081,
+     "grade": "abandoned"
+    },
+    {
+     "type": "lisan_mizan",
+     "entry_id": 5599,
+     "grade": "abandoned"
+    },
+    {
+     "type": "jarh",
+     "entry_id": 537,
+     "grade": "weak"
+    },
+    {
+     "type": "thiqat",
+     "entry_id": 9527,
+     "grade": "reliable"
+    },
+    {
+     "type": "kamil",
+     "entry_id": 1220,
+     "grade": "abandoned"
+    },
+    {
+     "type": "tarikh",
+     "entry_id": 5901,
+     "grade": "abandoned"
+    }
+   ],
+   "arsanad_id": 354,
+   "source_count": 6,
+   "kaggle_name": "'Umar bin Hafs عمر بن حفص",
+   "kaggle_grade": "Succ. (Taba' Tabi')",
+   "introduced_via": {
+    "teacher_count": 1,
+    "student_count": 1
+   }
+  },
+  "unique_key": "عمر بن حفص|k:ابو حفص|t:هشام بن عروة بن الزب|s:احمد بن محمد بن حنبل",
+  "uniqueness": "composite_unique"
+ },
+ "635": {
+  "id": 635,
+  "full_name": "هشام بن زياد بن أبي يزيد ، وهو هشام بن أبي هشام ، ويقال : هشام بن أبي الوليد",
+  "kunya": "أبو المقدام",
+  "grade_en": "abandoned",
+  "grade_ar": "متروك",
+  "color": "#c0392b",
+  "death": "-",
+  "tabaqat": "السادسة",
+  "city": "البصرة",
+  "laqab": "-",
+  "nasab": "القرشي ، المدني ، البصري ، العثماني الأموي مولاهم",
+  "dhahabi": "ضعفوه",
+  "namings": [
+   "أبو المقدام",
+   "أبو المقدام مولى لقريش",
+   "أبو المقدام هشام بن زياد",
+   "أبو المقدام هشام بن زياد مولى لعثمان",
+   "أبو المقدم",
+   "كثير بن هشام أبو المقدام",
+   "هشام أبو المقدام",
+   "هشام أبي المقدام",
+   "هشام بن أبي الوليد",
+   "هشام بن أبي هشام",
+   "هشام بن زياد",
+   "هشام بن زياد أبو المقدام",
+   "هشام بن زياد القرشي",
+   "هشام بن زياد هو أبو المقدام",
+   "هشام بن أبي هشام الحنفي"
+  ],
+  "classical_sources": {
+   "taqrib": {
+    "entry_id": 7292,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "mizan": {
+    "entry_id": 9231,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "jarh": {
+    "entry_id": 882,
+    "grade_en": "mostly_reliable",
+    "grade_ar": "يكتب حديثه"
+   },
+   "thiqat": {
+    "entry_id": 5941,
+    "grade_en": "reliable",
+    "grade_ar": "ذكره ابن حبان في الثقات"
+   },
+   "kashif": {
+    "entry_id": 5962,
+    "grade_en": "weak",
+    "grade_ar": "ضعفوه"
+   },
+   "tahdhib_tahdhib": {
+    "entry_id": 78,
+    "grade_en": "fabricator",
+    "grade_ar": "يضع"
+   },
+   "tabaqat": {
+    "entry_id": 4103,
+    "grade_en": "weak",
+    "grade_ar": "ضعيف"
+   },
+   "tahdhib_kamal": {
+    "entry_id": 6575,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "kamil": {
+    "entry_id": 2023,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   }
+  },
+  "teachers": [
+   42,
+   117,
+   173,
+   209,
+   1020,
+   1167,
+   1280,
+   1393,
+   2028,
+   2433,
+   2676,
+   3396,
+   9517,
+   9528,
+   11256,
+   11664,
+   13738,
+   15550,
+   16948
+  ],
+  "students": [
+   147,
+   171,
+   446,
+   634,
+   669,
+   670,
+   679,
+   1023,
+   1032,
+   1808,
+   2205,
+   2220,
+   2675,
+   2938,
+   3227,
+   3566,
+   4294,
+   4619,
+   7069,
+   7557,
+   7832,
+   8192,
+   8955,
+   16472
+  ],
+  "global_id": 12556,
+  "id_score": 70,
+  "grade_score": 75,
+  "confidence": "A",
+  "id_flags": [
+   "good_nasab",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "taqrib_grade",
+   "source_graded"
+  ],
+  "provenance": {
+   "kaggle_id": 12556,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "taqrib",
+     "entry_id": 7292,
+     "grade": "abandoned"
+    },
+    {
+     "type": "mizan",
+     "entry_id": 9231,
+     "grade": "abandoned"
+    },
+    {
+     "type": "jarh",
+     "entry_id": 882,
+     "grade": "mostly_reliable"
+    },
+    {
+     "type": "thiqat",
+     "entry_id": 5941,
+     "grade": "reliable"
+    },
+    {
+     "type": "kashif",
+     "entry_id": 5962,
+     "grade": "weak"
+    },
+    {
+     "type": "tahdhib_tahdhib",
+     "entry_id": 78,
+     "grade": "fabricator"
+    },
+    {
+     "type": "tabaqat",
+     "entry_id": 4103,
+     "grade": "weak"
+    },
+    {
+     "type": "tahdhib_kamal",
+     "entry_id": 6575,
+     "grade": "unknown"
+    },
+    {
+     "type": "kamil",
+     "entry_id": 2023,
+     "grade": "abandoned"
+    }
+   ],
+   "arsanad_id": 635,
+   "source_count": 9,
+   "kaggle_name": "Hisham bin Ziyad (Abi Hisham) هشام بن زياد/ بن أبي هشام",
+   "kaggle_grade": "Follower(Tabi') [6th generation]",
+   "introduced_via": {
+    "teacher_count": 19,
+    "student_count": 24
+   }
+  },
+  "unique_key": "هشام بن زياد بن ابي يزيد",
+  "uniqueness": "name_unique",
+  "gk_id": 33161,
+  "gk_match_method": "naming_variant"
+ },
+ "639": {
+  "id": 639,
+  "full_name": "محمد بن عبد العزيز بن عمر بن عبد الرحمن بن عوف",
+  "kunya": "-",
+  "grade_en": "abandoned",
+  "grade_ar": "متروك الحديث",
+  "color": "#c0392b",
+  "death": "بين 161 هـ إلى 170 هـ",
+  "tabaqat": "-",
+  "city": "المدينة",
+  "laqab": "-",
+  "nasab": "الزهري ، القاضي ، القرشي ، المديني ، العوفى",
+  "dhahabi": "-",
+  "namings": [
+   "أبي",
+   "أبيه",
+   "محمد بن عبد العزيز",
+   "محمد بن عبد العزيز بن عبد الرحمن",
+   "محمد بن عبد العزيز بن عبد الرحمن بن عوف",
+   "محمد بن عبد العزيز بن عبد الملك",
+   "محمد بن عبد العزيز بن عمر بن عبد الرحمن بن عوف",
+   "محمد بن عبد العزيز من ولد عبد الرحمن بن عوف",
+   "محمد بن عبد العزيز الزهري"
+  ],
+  "classical_sources": {
+   "jarh": {
+    "entry_id": 24,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "kamil": {
+    "entry_id": 1717,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   }
+  },
+  "teachers": [
+   569,
+   822,
+   2433,
+   2434,
+   6371,
+   11289,
+   13168,
+   13486,
+   14169
+  ],
+  "students": [
+   1026,
+   1427,
+   2793,
+   3568,
+   3921,
+   4307,
+   5831,
+   9979,
+   10860
+  ],
+  "id_score": 90,
+  "grade_score": 45,
+  "confidence": "A",
+  "id_flags": [
+   "deep_nasab",
+   "has_death",
+   "has_kunya",
+   "unique_name",
+   "has_source"
+  ],
+  "grade_flags": [
+   "source_graded"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "jarh",
+     "entry_id": 24,
+     "grade": "unknown"
+    },
+    {
+     "type": "kamil",
+     "entry_id": 1717,
+     "grade": "abandoned"
+    }
+   ],
+   "arsanad_id": 639,
+   "source_count": 2,
+   "introduced_via": {
+    "teacher_count": 9,
+    "student_count": 9
+   }
+  },
+  "unique_key": "محمد بن عبد العزيز بن عمر بن عبد الرحمن بن عوف",
+  "uniqueness": "name_unique",
+  "gk_id": 29601,
+  "gk_match_method": "exact_name"
+ },
+ "758": {
+  "id": 758,
+  "full_name": "يوسف بن أبي ذرة",
+  "kunya": "-",
+  "grade_en": "abandoned",
+  "grade_ar": "لا شيء",
+  "color": "#c0392b",
+  "death": "-",
+  "tabaqat": "-",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "الأنصاري",
+  "dhahabi": "-",
+  "namings": [
+   "يوسف بن أبي ذرة",
+   "يوسف بن أبي ذرة الأنصاري"
+  ],
+  "classical_sources": {
+   "mizan": {
+    "entry_id": 9873,
+    "grade_en": "abandoned",
+    "grade_ar": "لا شيء"
+   },
+   "lisan_mizan": {
+    "entry_id": 8685,
+    "grade_en": "abandoned",
+    "grade_ar": "لا شيء"
+   },
+   "mughni_ducafa": {
+    "entry_id": 7234,
+    "grade_en": "abandoned",
+    "grade_ar": "لا شيء"
+   }
+  },
+  "teachers": [
+   759
+  ],
+  "students": [
+   757
+  ],
+  "id_score": 60,
+  "grade_score": 45,
+  "confidence": "B",
+  "id_flags": [
+   "short_nasab",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "mizan",
+     "entry_id": 9873,
+     "grade": "abandoned"
+    },
+    {
+     "type": "lisan_mizan",
+     "entry_id": 8685,
+     "grade": "abandoned"
+    },
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 7234,
+     "grade": "abandoned"
+    }
+   ],
+   "arsanad_id": 758,
+   "source_count": 3,
+   "introduced_via": {
+    "teacher_count": 1,
+    "student_count": 1
+   }
+  },
+  "unique_key": "يوسف بن ابي ذرة",
+  "uniqueness": "name_unique",
+  "gk_id": 34318,
+  "gk_match_method": "exact_name"
+ },
+ "1235": {
+  "id": 1235,
+  "full_name": "علي بن الحزور ، ويقال : علي بن أبي فاطمة",
+  "kunya": "أبو الحسن",
+  "grade_en": "abandoned",
+  "grade_ar": "متروك",
+  "color": "#c0392b",
+  "death": "بعد 130 هـ",
+  "tabaqat": "السادسة",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "الكوفي ، الغنوي",
+  "dhahabi": "قال البخاري : فيه نظر",
+  "namings": [
+   "علي بن أبي فاطمة",
+   "علي بن الحزور",
+   "علي بن أبي فاطمة الغنوي"
+  ],
+  "classical_sources": {
+   "taqrib": {
+    "entry_id": 4703,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "mughni_ducafa": {
+    "entry_id": 4315,
+    "grade_en": "weak",
+    "grade_ar": "واه"
+   },
+   "tahdhib_tahdhib": {
+    "entry_id": 508,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "mizan": {
+    "entry_id": 5809,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "tahdhib_kamal": {
+    "entry_id": 4039,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   }
+  },
+  "teachers": [
+   1124,
+   1236,
+   2092,
+   2511,
+   3557,
+   4096,
+   4401,
+   5720,
+   14012,
+   15394,
+   16951,
+   18221,
+   73510,
+   94035
+  ],
+  "students": [
+   280,
+   626,
+   1169,
+   1234,
+   2509,
+   4453,
+   5058,
+   6187
+  ],
+  "global_id": 15383,
+  "id_score": 80,
+  "grade_score": 75,
+  "confidence": "A",
+  "id_flags": [
+   "short_nasab",
+   "has_death",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "taqrib_grade",
+   "source_graded"
+  ],
+  "provenance": {
+   "kaggle_id": 15383,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "taqrib",
+     "entry_id": 4703,
+     "grade": "abandoned"
+    },
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 4315,
+     "grade": "weak"
+    },
+    {
+     "type": "tahdhib_tahdhib",
+     "entry_id": 508,
+     "grade": "abandoned"
+    },
+    {
+     "type": "mizan",
+     "entry_id": 5809,
+     "grade": "abandoned"
+    },
+    {
+     "type": "tahdhib_kamal",
+     "entry_id": 4039,
+     "grade": "unknown"
+    }
+   ],
+   "arsanad_id": 1235,
+   "source_count": 5,
+   "kaggle_name": "'Ali bin al-Hazur/ 'Ali bin Abi Fatima علي بن الحزور/علي بن ",
+   "kaggle_grade": "Follower(Tabi') [6th generation]",
+   "introduced_via": {
+    "teacher_count": 4,
+    "student_count": 8
+   }
+  },
+  "unique_key": "علي بن الحزور",
+  "uniqueness": "name_unique",
+  "gk_id": 5731,
+  "gk_match_method": "exact_name"
+ },
+ "1308": {
+  "id": 1308,
+  "full_name": "المفضل بن محمد ، وسمى الخطيب جده يعلى",
+  "kunya": "-",
+  "grade_en": "abandoned",
+  "grade_ar": "متروك",
+  "color": "#c0392b",
+  "death": "168 هـ",
+  "tabaqat": "-",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "الضبي ، الكوفي ، المقرئ",
+  "dhahabi": "-",
+  "namings": [
+   "المفضل بن محمد",
+   "المفضل بن محمد الضبي",
+   "المفضل بن محمد الكوفي",
+   "المفضل بن محمد النحوي",
+   "مفضل بن محمد الضبي"
+  ],
+  "classical_sources": {
+   "mizan": {
+    "entry_id": 8741,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "mughni_ducafa": {
+    "entry_id": 6399,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "tarikh_islam": {
+    "entry_id": 3966,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "macrifa_qurra": {
+    "entry_id": 48,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   }
+  },
+  "teachers": [
+   467,
+   739,
+   1037,
+   2325,
+   4360
+  ],
+  "students": [
+   15,
+   3134
+  ],
+  "id_score": 80,
+  "grade_score": 45,
+  "confidence": "B",
+  "id_flags": [
+   "short_nasab",
+   "has_death",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "mizan",
+     "entry_id": 8741,
+     "grade": "abandoned"
+    },
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 6399,
+     "grade": "abandoned"
+    },
+    {
+     "type": "tarikh_islam",
+     "entry_id": 3966,
+     "grade": "unknown"
+    },
+    {
+     "type": "macrifa_qurra",
+     "entry_id": 48,
+     "grade": "abandoned"
+    }
+   ],
+   "arsanad_id": 1308,
+   "source_count": 4,
+   "introduced_via": {
+    "teacher_count": 5,
+    "student_count": 2
+   }
+  },
+  "unique_key": "المفضل بن محمد",
+  "uniqueness": "name_unique",
+  "gk_id": 32029,
+  "gk_match_method": "naming_variant"
+ },
+ "1320": {
+  "id": 1320,
+  "full_name": "القاسم بن محمد بن عبد الله بن محمد بن عقيل بن ابى طالب",
+  "kunya": "-",
+  "grade_en": "abandoned",
+  "grade_ar": "متروك",
+  "color": "#c0392b",
+  "death": "-",
+  "tabaqat": "-",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "الهاشمي ، الطالبي",
+  "dhahabi": "-",
+  "namings": [
+   "القاسم بن محمد العقيلي",
+   "القاسم بن محمد بن عبد الله بن عقيل",
+   "القاسم بن محمد بن عبد الله بن محمد بن عقيل"
+  ],
+  "classical_sources": {
+   "mughni_ducafa": {
+    "entry_id": 5011,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "diwan_ducafa": {
+    "entry_id": 3425,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   }
+  },
+  "teachers": [
+   1321,
+   1322
+  ],
+  "students": [
+   880,
+   1319,
+   3452
+  ],
+  "id_score": 70,
+  "grade_score": 45,
+  "confidence": "B",
+  "id_flags": [
+   "deep_nasab",
+   "has_kunya",
+   "unique_name",
+   "has_source"
+  ],
+  "grade_flags": [
+   "source_graded"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 5011,
+     "grade": "abandoned"
+    },
+    {
+     "type": "diwan_ducafa",
+     "entry_id": 3425,
+     "grade": "abandoned"
+    }
+   ],
+   "arsanad_id": 1320,
+   "source_count": 2,
+   "introduced_via": {
+    "teacher_count": 2,
+    "student_count": 3
+   }
+  },
+  "unique_key": "القاسم بن محمد بن عبد الله بن محمد بن عقيل بن ابى طالب",
+  "uniqueness": "name_unique"
+ },
+ "357": {
+  "id": 357,
+  "full_name": "مطهر بن الهيثم بن الحجاج",
+  "kunya": "-",
+  "grade_en": "fabricator",
+  "grade_ar": "متروك الحديث",
+  "color": "#c0392b",
+  "death": "بين 191 هـ و200 هـ",
+  "tabaqat": "التاسعة",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "الطائي ، البصري ، الغساني ، الدمشقي",
+  "dhahabi": "واه",
+  "namings": [
+   "مطهر بن الهيثم",
+   "مطهر بن الهيثم الطائي"
+  ],
+  "classical_sources": {
+   "jarh": {
+    "entry_id": 1815,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "mughni_ducafa": {
+    "entry_id": 6290,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "diwan_ducafa": {
+    "entry_id": 4152,
+    "grade_en": "abandoned",
+    "grade_ar": "تركوه"
+   },
+   "kashif": {
+    "entry_id": 5486,
+    "grade_en": "weak",
+    "grade_ar": "واه"
+   },
+   "tahdhib_tahdhib": {
+    "entry_id": 337,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "tahdhib_kamal": {
+    "entry_id": 6009,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "mizan": {
+    "entry_id": 8602,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   }
+  },
+  "teachers": [
+   231,
+   358,
+   1124,
+   2511,
+   3768,
+   5788,
+   7604,
+   14012,
+   15984,
+   18221,
+   94035
+  ],
+  "students": [
+   356,
+   491,
+   5091
+  ],
+  "id_score": 90,
+  "grade_score": 45,
+  "confidence": "A",
+  "id_flags": [
+   "good_nasab",
+   "has_death",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded",
+   "hokm_composite_abandoned"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "jarh",
+     "entry_id": 1815,
+     "grade": "unknown"
+    },
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 6290,
+     "grade": "abandoned"
+    },
+    {
+     "type": "diwan_ducafa",
+     "entry_id": 4152,
+     "grade": "abandoned"
+    },
+    {
+     "type": "kashif",
+     "entry_id": 5486,
+     "grade": "weak"
+    },
+    {
+     "type": "tahdhib_tahdhib",
+     "entry_id": 337,
+     "grade": "abandoned"
+    },
+    {
+     "type": "tahdhib_kamal",
+     "entry_id": 6009,
+     "grade": "unknown"
+    },
+    {
+     "type": "mizan",
+     "entry_id": 8602,
+     "grade": "abandoned"
+    }
+   ],
+   "arsanad_id": 357,
+   "source_count": 7,
+   "introduced_via": {
+    "teacher_count": 3,
+    "student_count": 3
+   }
+  },
+  "unique_key": "مطهر بن الهيثم بن الحجاج",
+  "uniqueness": "name_unique",
+  "gk_id": 7535,
+  "gk_match_method": "exact_name"
+ },
+ "470": {
+  "id": 470,
+  "full_name": "موسى بن زكريا",
+  "kunya": "-",
+  "grade_en": "fabricator",
+  "grade_ar": "متروك",
+  "color": "#c0392b",
+  "death": "-",
+  "tabaqat": "-",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "التستري",
+  "dhahabi": "-",
+  "namings": [
+   "أبو عمران التستري",
+   "موسى بن زكريا",
+   "موسى بن زكريا التستري",
+   "موسى بن زكريا التستري أبو عمران"
+  ],
+  "classical_sources": {
+   "mizan": {
+    "entry_id": 8871,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "lisan_mizan": {
+    "entry_id": 7997,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "mughni_ducafa": {
+    "entry_id": 6491,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   }
+  },
+  "teachers": [
+   223,
+   241,
+   471,
+   560,
+   726,
+   882,
+   1426,
+   1465,
+   1509,
+   1630,
+   1632,
+   1880,
+   2000,
+   2005,
+   2104,
+   2160,
+   2198,
+   2548,
+   2602,
+   2656,
+   2703,
+   2938,
+   3063,
+   3430,
+   3576,
+   3585,
+   3589,
+   3620,
+   4006,
+   4117,
+   4127,
+   4299,
+   4359,
+   4451,
+   4622,
+   4627,
+   5513,
+   6221,
+   6466,
+   6565,
+   6685,
+   6788,
+   6854,
+   7385,
+   8035,
+   8265,
+   8684,
+   11582,
+   12475,
+   12666
+  ],
+  "students": [
+   202,
+   326,
+   385,
+   469,
+   4504,
+   8659
+  ],
+  "id_score": 60,
+  "grade_score": 45,
+  "confidence": "B",
+  "id_flags": [
+   "short_nasab",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded",
+   "hokm_composite_abandoned"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "mizan",
+     "entry_id": 8871,
+     "grade": "abandoned"
+    },
+    {
+     "type": "lisan_mizan",
+     "entry_id": 7997,
+     "grade": "abandoned"
+    },
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 6491,
+     "grade": "abandoned"
+    }
+   ],
+   "arsanad_id": 470,
+   "source_count": 3,
+   "introduced_via": {
+    "teacher_count": 50,
+    "student_count": 6
+   }
+  },
+  "unique_key": "موسى بن زكريا",
+  "uniqueness": "name_unique",
+  "gk_id": 32343,
+  "gk_match_method": "exact_name"
+ },
+ "651": {
+  "id": 651,
+  "full_name": "خالد بن إلياس : ويقال : إياس بن صخر بن أبي الجهم : عبيد بن حذيفة بن غانم بن عامر بن عبد الله بن عبيد بن عويج بن عدي بن كعب بن لؤي بن غالب",
+  "kunya": "أبو الهيثم.",
+  "grade_en": "fabricator",
+  "grade_ar": "متروك الحديث",
+  "color": "#c0392b",
+  "death": "بين 161 هـ و170 هـ",
+  "tabaqat": "السابعة.",
+  "city": "المدينة",
+  "laqab": "-",
+  "nasab": "العدوي ، القرشي ، المدني.",
+  "dhahabi": "ضعفوه",
+  "namings": [
+   "خالد",
+   "خالد بن إلياس",
+   "خالد بن إلياس ويقال ابن إياس",
+   "خالد بن إياس",
+   "خالد بن إياس القرشي"
+  ],
+  "classical_sources": {
+   "taqrib": {
+    "entry_id": 1617,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "mizan": {
+    "entry_id": 2411,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "jarh": {
+    "entry_id": 1440,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "kamil": {
+    "entry_id": 571,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "mughni_ducafa": {
+    "entry_id": 1888,
+    "grade_en": "weak",
+    "grade_ar": ""
+   },
+   "diwan_ducafa": {
+    "entry_id": 1207,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "kashif": {
+    "entry_id": 1306,
+    "grade_en": "weak",
+    "grade_ar": "ضعفوه"
+   },
+   "isaba": {
+    "entry_id": 2147,
+    "grade_en": "companion",
+    "grade_ar": "ذكره ابن حجر في الإصابة"
+   },
+   "tahdhib_tahdhib": {
+    "entry_id": 152,
+    "grade_en": "fabricator",
+    "grade_ar": "يضع"
+   },
+   "tabaqat": {
+    "entry_id": 2172,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "tahdhib_kamal": {
+    "entry_id": 1556,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   }
+  },
+  "teachers": [
+   221,
+   288,
+   303,
+   566,
+   572,
+   652,
+   1434,
+   1439,
+   1936,
+   2433,
+   2434,
+   3521,
+   6044,
+   6655,
+   7681,
+   8326,
+   8436,
+   13379,
+   16407
+  ],
+  "students": [
+   26,
+   61,
+   157,
+   225,
+   431,
+   438,
+   1196,
+   1536,
+   1558,
+   1749,
+   2710,
+   3533,
+   4241,
+   6402,
+   6785,
+   8419
+  ],
+  "global_id": 22048,
+  "id_score": 45,
+  "grade_score": 75,
+  "confidence": "B",
+  "id_flags": [
+   "short_nasab",
+   "has_death",
+   "has_kunya",
+   "collision_small",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "taqrib_grade",
+   "source_graded",
+   "hokm_composite_abandoned"
+  ],
+  "provenance": {
+   "kaggle_id": 22048,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "taqrib",
+     "entry_id": 1617,
+     "grade": "abandoned"
+    },
+    {
+     "type": "mizan",
+     "entry_id": 2411,
+     "grade": "abandoned"
+    },
+    {
+     "type": "jarh",
+     "entry_id": 1440,
+     "grade": "abandoned"
+    },
+    {
+     "type": "kamil",
+     "entry_id": 571,
+     "grade": "abandoned"
+    },
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 1888,
+     "grade": "weak"
+    },
+    {
+     "type": "diwan_ducafa",
+     "entry_id": 1207,
+     "grade": "abandoned"
+    },
+    {
+     "type": "kashif",
+     "entry_id": 1306,
+     "grade": "weak"
+    },
+    {
+     "type": "isaba",
+     "entry_id": 2147,
+     "grade": "companion"
+    },
+    {
+     "type": "tahdhib_tahdhib",
+     "entry_id": 152,
+     "grade": "fabricator"
+    },
+    {
+     "type": "tabaqat",
+     "entry_id": 2172,
+     "grade": "unknown"
+    },
+    {
+     "type": "tahdhib_kamal",
+     "entry_id": 1556,
+     "grade": "unknown"
+    }
+   ],
+   "arsanad_id": 651,
+   "source_count": 11,
+   "kaggle_name": "Khalid bin Ilyas خالد بن إلياس",
+   "kaggle_grade": "Succ. (Taba' Tabi') [7th generation]",
+   "introduced_via": {
+    "teacher_count": 19,
+    "student_count": 16
+   }
+  },
+  "unique_key": "خالد بن الياس|d:161|k:ابو الهيثم.|t:محمد بن المنكدر بن ع|s:محمد بن خازم",
+  "uniqueness": "composite_unique"
+ },
+ "721": {
+  "id": 721,
+  "full_name": "ياسين بن معاذ",
+  "kunya": "أبو خلف",
+  "grade_en": "fabricator",
+  "grade_ar": "متروك",
+  "color": "#c0392b",
+  "death": "قريب من موت الثوري",
+  "tabaqat": "-",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "الزيات ، الكوفي ، اليمامي الأصل",
+  "dhahabi": "-",
+  "namings": [
+   "ياسين",
+   "ياسين أبو خلف",
+   "ياسين الزيات",
+   "ياسين الزيات أبي معاذ",
+   "ياسين بن أبي بسطام",
+   "ياسين بن معاذ",
+   "ياسين بن معاذ الزيات",
+   "ياسين بن معاذ الكوفي"
+  ],
+  "classical_sources": {
+   "mizan": {
+    "entry_id": 9451,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "lisan_mizan": {
+    "entry_id": 8405,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "jarh": {
+    "entry_id": 1350,
+    "grade_en": "weak",
+    "grade_ar": "منكر الحديث"
+   },
+   "kamil": {
+    "entry_id": 2094,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "mughni_ducafa": {
+    "entry_id": 6916,
+    "grade_en": "weak",
+    "grade_ar": ""
+   },
+   "diwan_ducafa": {
+    "entry_id": 4593,
+    "grade_en": "weak",
+    "grade_ar": ""
+   },
+   "tarikh_islam": {
+    "entry_id": 3993,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   }
+  },
+  "teachers": [
+   51,
+   104,
+   381,
+   467,
+   569,
+   602,
+   688,
+   885,
+   1070,
+   1314,
+   1457,
+   2325,
+   3198,
+   3405,
+   3556,
+   8809
+  ],
+  "students": [
+   44,
+   144,
+   147,
+   329,
+   592,
+   720,
+   1013,
+   1502,
+   1555,
+   2074,
+   2215,
+   3095,
+   3727,
+   4556,
+   4728,
+   6272,
+   6402,
+   7125,
+   8716
+  ],
+  "id_score": 60,
+  "grade_score": 45,
+  "confidence": "B",
+  "id_flags": [
+   "short_nasab",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded",
+   "hokm_prefix_upgrade_abandoned"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "mizan",
+     "entry_id": 9451,
+     "grade": "abandoned"
+    },
+    {
+     "type": "lisan_mizan",
+     "entry_id": 8405,
+     "grade": "abandoned"
+    },
+    {
+     "type": "jarh",
+     "entry_id": 1350,
+     "grade": "weak"
+    },
+    {
+     "type": "kamil",
+     "entry_id": 2094,
+     "grade": "abandoned"
+    },
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 6916,
+     "grade": "weak"
+    },
+    {
+     "type": "diwan_ducafa",
+     "entry_id": 4593,
+     "grade": "weak"
+    },
+    {
+     "type": "tarikh_islam",
+     "entry_id": 3993,
+     "grade": "abandoned"
+    }
+   ],
+   "arsanad_id": 721,
+   "source_count": 7,
+   "introduced_via": {
+    "teacher_count": 16,
+    "student_count": 19
+   }
+  },
+  "unique_key": "ياسين بن معاذ",
+  "uniqueness": "name_unique",
+  "gk_id": 33563,
+  "gk_match_method": "exact_name"
+ },
+ "1319": {
+  "id": 1319,
+  "full_name": "عبيد بن إسحاق بن الربيع",
+  "kunya": "أبو عبد الرحمن ، وقال علي بن مسلم : أبو إسحاق",
+  "grade_en": "fabricator",
+  "grade_ar": "متروك الحديث",
+  "color": "#c0392b",
+  "death": "214 هـ",
+  "tabaqat": "-",
+  "city": "-",
+  "laqab": "عطار المطلقات",
+  "nasab": "العطار ، الكوفي ، الضبي",
+  "dhahabi": "-",
+  "namings": [
+   "أبي",
+   "عبيد العطار",
+   "عبيد بن إسحاق",
+   "عبيد بن إسحاق العطار",
+   "عبيد بن إسحاق العطار الكوفي"
+  ],
+  "classical_sources": {
+   "mizan": {
+    "entry_id": 5416,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "lisan_mizan": {
+    "entry_id": 5048,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "jarh": {
+    "entry_id": 1859,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "thiqat": {
+    "entry_id": 14256,
+    "grade_en": "reliable",
+    "grade_ar": "ذكره ابن حبان في الثقات"
+   },
+   "kamil": {
+    "entry_id": 1505,
+    "grade_en": "weak",
+    "grade_ar": "منكر الحديث"
+   },
+   "mughni_ducafa": {
+    "entry_id": 3955,
+    "grade_en": "weak",
+    "grade_ar": "ضعفوه"
+   },
+   "diwan_ducafa": {
+    "entry_id": 2720,
+    "grade_en": "weak",
+    "grade_ar": "ضعفوه"
+   },
+   "tarikh_islam": {
+    "entry_id": 5901,
+    "grade_en": "mostly_reliable",
+    "grade_ar": "شيخ"
+   }
+  },
+  "teachers": [
+   379,
+   442,
+   493,
+   925,
+   1125,
+   1134,
+   1284,
+   1320,
+   1588,
+   1976,
+   3211,
+   3574,
+   4412,
+   10202,
+   13786,
+   14436
+  ],
+  "students": [
+   355,
+   702,
+   1109,
+   1358,
+   1919,
+   2098,
+   2460,
+   3227,
+   5774,
+   6367,
+   6422,
+   6645,
+   6675,
+   7092,
+   13994
+  ],
+  "global_id": 31104,
+  "id_score": 90,
+  "grade_score": 45,
+  "confidence": "A",
+  "id_flags": [
+   "good_nasab",
+   "has_death",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded",
+   "hokm_prefix_upgrade_abandoned"
+  ],
+  "provenance": {
+   "kaggle_id": 31104,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "mizan",
+     "entry_id": 5416,
+     "grade": "abandoned"
+    },
+    {
+     "type": "lisan_mizan",
+     "entry_id": 5048,
+     "grade": "abandoned"
+    },
+    {
+     "type": "jarh",
+     "entry_id": 1859,
+     "grade": "unknown"
+    },
+    {
+     "type": "thiqat",
+     "entry_id": 14256,
+     "grade": "reliable"
+    },
+    {
+     "type": "kamil",
+     "entry_id": 1505,
+     "grade": "weak"
+    },
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 3955,
+     "grade": "weak"
+    },
+    {
+     "type": "diwan_ducafa",
+     "entry_id": 2720,
+     "grade": "weak"
+    },
+    {
+     "type": "tarikh_islam",
+     "entry_id": 5901,
+     "grade": "mostly_reliable"
+    }
+   ],
+   "arsanad_id": 1319,
+   "source_count": 8,
+   "kaggle_name": "Ubaid bin Ishaq al-Tar Abu عبيد بن إسحاق العطار",
+   "kaggle_grade": "3rd Century AH",
+   "introduced_via": {
+    "teacher_count": 16,
+    "student_count": 15
+   }
+  },
+  "unique_key": "عبيد بن اسحاق بن الربيع",
+  "uniqueness": "name_unique",
+  "gk_id": 41023,
+  "gk_match_method": "prefix4_death_±0"
+ },
+ "1365": {
+  "id": 1365,
+  "full_name": "عباد بن صهيب",
+  "kunya": "أبو بكر",
+  "grade_en": "fabricator",
+  "grade_ar": "متروك",
+  "color": "#c0392b",
+  "death": "بعد 200 هـ ، أو : 212 هـ",
+  "tabaqat": "-",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "البصري ، الكليبي",
+  "dhahabi": "-",
+  "namings": [
+   "أبو بكر الكليبي",
+   "أبي",
+   "عباد",
+   "عباد بن صهيب",
+   "عبادة بن صهيب",
+   "عباد بن صهيب الكليبي"
+  ],
+  "classical_sources": {
+   "mizan": {
+    "entry_id": 4127,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك"
+   },
+   "jarh": {
+    "entry_id": 417,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "kamil": {
+    "entry_id": 1179,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "mughni_ducafa": {
+    "entry_id": 3037,
+    "grade_en": "mostly_reliable",
+    "grade_ar": "صدوق"
+   },
+   "tabaqat": {
+    "entry_id": 4172,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   }
+  },
+  "teachers": [
+   45,
+   346,
+   365,
+   380,
+   389,
+   412,
+   547,
+   732,
+   906,
+   1366,
+   1697,
+   2239,
+   3534,
+   3639,
+   3737,
+   4139,
+   4896,
+   6956
+  ],
+  "students": [
+   1364,
+   2183,
+   11456,
+   13209
+  ],
+  "id_score": 80,
+  "grade_score": 45,
+  "confidence": "B",
+  "id_flags": [
+   "short_nasab",
+   "has_death",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded",
+   "hokm_prefix_upgrade_abandoned"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "mizan",
+     "entry_id": 4127,
+     "grade": "abandoned"
+    },
+    {
+     "type": "jarh",
+     "entry_id": 417,
+     "grade": "unknown"
+    },
+    {
+     "type": "kamil",
+     "entry_id": 1179,
+     "grade": "abandoned"
+    },
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 3037,
+     "grade": "mostly_reliable"
+    },
+    {
+     "type": "tabaqat",
+     "entry_id": 4172,
+     "grade": "unknown"
+    }
+   ],
+   "arsanad_id": 1365,
+   "source_count": 5,
+   "introduced_via": {
+    "teacher_count": 18,
+    "student_count": 4
+   }
+  },
+  "unique_key": "عباد بن صهيب",
+  "uniqueness": "name_unique",
+  "gk_id": 20167,
+  "gk_match_method": "exact_name"
+ },
+ "1467": {
+  "id": 1467,
+  "full_name": "عبيد الله بن الوليد",
+  "kunya": "أبو إسماعيل",
+  "grade_en": "fabricator",
+  "grade_ar": "متروك الحديث",
+  "color": "#c0392b",
+  "death": "بين 141 هـ إلى 150 هـ",
+  "tabaqat": "السادسة",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "الوصافي ، الكوفي ، العجلي",
+  "dhahabi": "ضعفوه",
+  "namings": [
+   "أبيه",
+   "الوصافي",
+   "عبيد الله الوصافي",
+   "عبيد الله بن الوليد",
+   "عبيد الله بن الوليد العجلي",
+   "عبيد الله بن الوليد الوصافي"
+  ],
+  "classical_sources": {
+   "kamil": {
+    "entry_id": 1156,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "tahdhib_kamal": {
+    "entry_id": 3694,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   }
+  },
+  "teachers": [
+   42,
+   43,
+   247,
+   405,
+   781,
+   1708,
+   1990,
+   2144,
+   3304,
+   5200,
+   5852,
+   7559,
+   9173,
+   11133,
+   12471,
+   12607,
+   12751,
+   15020,
+   15394,
+   17669,
+   29451,
+   70404
+  ],
+  "students": [
+   26,
+   51,
+   61,
+   147,
+   180,
+   280,
+   434,
+   438,
+   493,
+   797,
+   1134,
+   1207,
+   1466,
+   1836,
+   1863,
+   2271,
+   2496,
+   2889,
+   3095,
+   3368,
+   4639,
+   8203
+  ],
+  "id_score": 70,
+  "grade_score": 45,
+  "confidence": "B",
+  "id_flags": [
+   "short_nasab",
+   "has_death",
+   "has_kunya",
+   "unique_name",
+   "has_source"
+  ],
+  "grade_flags": [
+   "source_graded",
+   "hokm_composite_abandoned"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "kamil",
+     "entry_id": 1156,
+     "grade": "abandoned"
+    },
+    {
+     "type": "tahdhib_kamal",
+     "entry_id": 3694,
+     "grade": "unknown"
+    }
+   ],
+   "arsanad_id": 1467,
+   "source_count": 2,
+   "introduced_via": {
+    "teacher_count": 11,
+    "student_count": 22
+   }
+  },
+  "unique_key": "عبيد الله بن الوليد",
+  "uniqueness": "name_unique",
+  "gk_id": 5378,
+  "gk_match_method": "exact_name",
+  "additional_info": {
+   "muslim_note": "Fabricator/abandoned narrator in Muslim. GK also grades negatively. Possibly in Muslim's muqaddimah (introduction) rather than main text, or used as supporting evidence. Grade remains fabricator."
+  }
+ },
+ "1554": {
+  "id": 1554,
+  "full_name": "إبراهيم بن إسحاق",
+  "kunya": "أبو إسحاق",
+  "grade_en": "fabricator",
+  "grade_ar": "متروك الحديث",
+  "color": "#c0392b",
+  "death": "230 هـ ، أو 232هـ",
+  "tabaqat": "-",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "الصيني ، الجعفي مولاهم ، الكوفي",
+  "dhahabi": "-",
+  "namings": [
+   "إبراهيم بن إسحاق الجعفي",
+   "إبراهيم بن إسحاق الصيني",
+   "إبراهيم بن إسحاق الأنصاري"
+  ],
+  "classical_sources": {
+   "mizan": {
+    "entry_id": 31,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   },
+   "jarh": {
+    "entry_id": 203,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "thiqat": {
+    "entry_id": 12321,
+    "grade_en": "reliable",
+    "grade_ar": "ذكره ابن حبان في الثقات"
+   },
+   "mughni_ducafa": {
+    "entry_id": 29,
+    "grade_en": "abandoned",
+    "grade_ar": "متروك الحديث"
+   }
+  },
+  "teachers": [
+   466,
+   777,
+   1284,
+   1555,
+   1585,
+   1655,
+   2917,
+   3117,
+   9845
+  ],
+  "students": [
+   167,
+   327,
+   1088,
+   1429,
+   1660,
+   2244,
+   6547,
+   9942,
+   14263
+  ],
+  "global_id": 31745,
+  "id_score": 35,
+  "grade_score": 45,
+  "confidence": "C",
+  "id_flags": [
+   "short_nasab",
+   "has_death",
+   "has_kunya",
+   "collision_large",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded",
+   "hokm_composite_abandoned"
+  ],
+  "provenance": {
+   "kaggle_id": 31745,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "mizan",
+     "entry_id": 31,
+     "grade": "abandoned"
+    },
+    {
+     "type": "jarh",
+     "entry_id": 203,
+     "grade": "unknown"
+    },
+    {
+     "type": "thiqat",
+     "entry_id": 12321,
+     "grade": "reliable"
+    },
+    {
+     "type": "mughni_ducafa",
+     "entry_id": 29,
+     "grade": "abandoned"
+    }
+   ],
+   "arsanad_id": 1554,
+   "source_count": 4,
+   "kaggle_name": "Ibrahim bin Ishaq al-Syna إبراهيم بن إسحاق الصيني",
+   "kaggle_grade": "3rd Century AH",
+   "introduced_via": {
+    "teacher_count": 9,
+    "student_count": 9
+   }
+  },
+  "unique_key": "ابراهيم بن اسحاق|d:230|k:ابو اسحاق|t:علي بن هاشم بن البري|s:محمد بن عبد الله بن ",
+  "uniqueness": "composite_unique",
+  "gk_id": 11346,
+  "gk_match_method": "name_kunya"
+ },
+ "18": {
+  "id": 18,
+  "full_name": "علقمة بن وقاص بن محصن بن كلدة بن عبد ياليل بن طريف بن عتوارة بن عامر بن مالك بن ليث بن بكر بن عبد مناة بن كنانة",
+  "kunya": "أبو يحيى ، وقيل : أبو واقد",
+  "grade_en": "companion",
+  "grade_ar": "له صحبة",
+  "color": "#9b59b6",
+  "death": "في خلافة عبد الملك بن مروان",
+  "tabaqat": "الثانية",
+  "city": "المدينة",
+  "laqab": "-",
+  "nasab": "الليثي ، العتواري ، المدني",
+  "dhahabi": "ثقة",
+  "namings": [
+   "أبيه",
+   "جده",
+   "جده علقمة بن وقاص",
+   "جدي",
+   "علقمة",
+   "علقمة بن أبي وقاص",
+   "علقمة بن وقاص",
+   "علقمة بن وقاص الليثي",
+   "علقمة بن وقاص العتواري"
+  ],
+  "classical_sources": {
+   "taqrib": {
+    "entry_id": 4685,
+    "grade_en": "companion",
+    "grade_ar": "له صحبة"
+   },
+   "jarh": {
+    "entry_id": 2259,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "thiqat": {
+    "entry_id": 4560,
+    "grade_en": "reliable",
+    "grade_ar": "ذكره ابن حبان في الثقات"
+   },
+   "kashif": {
+    "entry_id": 3877,
+    "grade_en": "reliable",
+    "grade_ar": "ثقة"
+   },
+   "isaba": {
+    "entry_id": 5684,
+    "grade_en": "companion",
+    "grade_ar": "ذكره ابن حجر في الإصابة"
+   },
+   "siyar": {
+    "entry_id": 15,
+    "grade_en": "reliable",
+    "grade_ar": "ثقه"
+   },
+   "tahdhib_tahdhib": {
+    "entry_id": 489,
+    "grade_en": "reliable",
+    "grade_ar": "ثقة"
+   },
+   "tabaqat": {
+    "entry_id": 1457,
+    "grade_en": "reliable",
+    "grade_ar": "ثقة"
+   },
+   "tadhkirat_huffaz": {
+    "entry_id": 35,
+    "grade_en": "reliable",
+    "grade_ar": "ثقة"
+   },
+   "mucin_tabaqat": {
+    "entry_id": 222,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "tahdhib_kamal": {
+    "entry_id": 4021,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   }
+  },
+  "teachers": [
+   19,
+   48,
+   165,
+   181,
+   231,
+   342,
+   356,
+   397,
+   567,
+   603,
+   623,
+   683,
+   828,
+   1122,
+   2139,
+   4258,
+   5241,
+   6011,
+   6336,
+   8621,
+   9839,
+   10179,
+   12471,
+   13783,
+   13944,
+   17523,
+   29451,
+   33950,
+   56335,
+   56357
+  ],
+  "students": [
+   17,
+   399,
+   569,
+   685,
+   1314,
+   1921,
+   2073,
+   8655,
+   13318
+  ],
+  "global_id": 11042,
+  "generation": 2,
+  "id_score": 80,
+  "grade_score": 75,
+  "confidence": "A",
+  "id_flags": [
+   "deep_nasab",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "taqrib_grade",
+   "source_graded"
+  ],
+  "provenance": {
+   "kaggle_id": 11042,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "taqrib",
+     "entry_id": 4685,
+     "grade": "companion"
+    },
+    {
+     "type": "jarh",
+     "entry_id": 2259,
+     "grade": "unknown"
+    },
+    {
+     "type": "thiqat",
+     "entry_id": 4560,
+     "grade": "reliable"
+    },
+    {
+     "type": "kashif",
+     "entry_id": 3877,
+     "grade": "reliable"
+    },
+    {
+     "type": "isaba",
+     "entry_id": 5684,
+     "grade": "companion"
+    },
+    {
+     "type": "siyar",
+     "entry_id": 15,
+     "grade": "reliable"
+    },
+    {
+     "type": "tahdhib_tahdhib",
+     "entry_id": 489,
+     "grade": "reliable"
+    },
+    {
+     "type": "tabaqat",
+     "entry_id": 1457,
+     "grade": "reliable"
+    },
+    {
+     "type": "tadhkirat_huffaz",
+     "entry_id": 35,
+     "grade": "reliable"
+    },
+    {
+     "type": "mucin_tabaqat",
+     "entry_id": 222,
+     "grade": "unknown"
+    },
+    {
+     "type": "tahdhib_kamal",
+     "entry_id": 4021,
+     "grade": "unknown"
+    }
+   ],
+   "arsanad_id": 18,
+   "source_count": 11,
+   "kaggle_name": "'Alqama bin Waqqas علقمة بن وقاص",
+   "kaggle_grade": "Follower(Tabi') [2nd Generation]",
+   "introduced_via": {
+    "teacher_count": 13,
+    "student_count": 9
+   }
+  },
+  "unique_key": "علقمة بن وقاص بن محصن بن كلدة بن عبد ياليل بن طريف بن عتوارة بن عامر بن مالك بن ليث",
+  "uniqueness": "name_unique",
+  "gk_id": 5719,
+  "gk_match_method": "prefix3_unique"
+ },
+ "32": {
+  "id": 32,
+  "full_name": "جوثة بن أبي جوثة ، ويقال : ابن عبيد",
+  "kunya": "أبو عبيد",
+  "grade_en": "companion",
+  "grade_ar": "من الصحابة",
+  "color": "#9b59b6",
+  "death": "127 هـ",
+  "tabaqat": "-",
+  "city": "-",
+  "laqab": "-",
+  "nasab": "المدني ، الديلي",
+  "dhahabi": "-",
+  "namings": [
+   "جوثة بن عبيد الديلي"
+  ],
+  "classical_sources": {
+   "thiqat": {
+    "entry_id": 2091,
+    "grade_en": "companion",
+    "grade_ar": "من الصحابة"
+   },
+   "tabaqat": {
+    "entry_id": 1978,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   }
+  },
+  "teachers": [
+   8,
+   5852,
+   70580
+  ],
+  "students": [
+   31
+  ],
+  "id_score": 70,
+  "grade_score": 45,
+  "confidence": "B",
+  "id_flags": [
+   "short_nasab",
+   "has_death",
+   "has_kunya",
+   "unique_name",
+   "has_source"
+  ],
+  "grade_flags": [
+   "source_graded"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "thiqat",
+     "entry_id": 2091,
+     "grade": "companion"
+    },
+    {
+     "type": "tabaqat",
+     "entry_id": 1978,
+     "grade": "unknown"
+    }
+   ],
+   "arsanad_id": 32,
+   "source_count": 2,
+   "introduced_via": {
+    "teacher_count": 1,
+    "student_count": 1
+   }
+  },
+  "unique_key": "جوثة بن ابي جوثة",
+  "uniqueness": "name_unique",
+  "gk_id": 14076,
+  "gk_match_method": "naming_variant"
+ },
+ "58": {
+  "id": 58,
+  "full_name": "سلمان بن مر",
+  "kunya": "أبو عبد الله",
+  "grade_en": "companion",
+  "grade_ar": "صحابي",
+  "color": "#9b59b6",
+  "death": "34 هـ  أو قبلها  ، أو 35 هـ أو 36 هـ أو 37 هـ",
+  "tabaqat": "صحابي",
+  "city": "المدائن، الكوفة",
+  "laqab": "سابق الفرس",
+  "nasab": "الفارسي ، الأصبهاني الأصل ، وقيل : الرامهرمزي الأصل ، مولى بني هاشم",
+  "dhahabi": "من نجباء الصحابة",
+  "namings": [
+   "أبو عبد الله",
+   "الفارسي يعني سلمان",
+   "سلمان",
+   "سلمان الخير",
+   "سلمان الفارسي",
+   "سلمان بن الإسلام",
+   "سليمان"
+  ],
+  "classical_sources": {
+   "tabaqat": {
+    "entry_id": 380,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "tarikh": {
+    "entry_id": 10,
+    "grade_en": "companion",
+    "grade_ar": "صحابي"
+   },
+   "mucin_tabaqat": {
+    "entry_id": 49,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   }
+  },
+  "teachers": [
+   165,
+   187,
+   231,
+   405,
+   747,
+   1244,
+   2816,
+   4310,
+   5241,
+   9193,
+   9839,
+   11133,
+   12471,
+   13783,
+   16970,
+   18221,
+   18382,
+   56381,
+   112346
+  ],
+  "students": [
+   8,
+   23,
+   24,
+   42,
+   48,
+   57,
+   106,
+   110,
+   112,
+   148,
+   160,
+   181,
+   199,
+   209,
+   212,
+   221,
+   245,
+   250,
+   251,
+   301,
+   348,
+   369,
+   370,
+   375,
+   391,
+   479,
+   511,
+   536,
+   602,
+   690,
+   698,
+   710,
+   712,
+   736,
+   774,
+   781,
+   845,
+   888,
+   897,
+   973,
+   1074,
+   1085,
+   1136,
+   1256,
+   1280,
+   1309,
+   1314,
+   1533,
+   1763,
+   1816,
+   1818,
+   1998,
+   2052,
+   2057,
+   2076,
+   2088,
+   2107,
+   2146,
+   2177,
+   2233,
+   2379,
+   2424,
+   2456,
+   2513,
+   2605,
+   2864,
+   2868,
+   2971,
+   3480,
+   3675,
+   3700,
+   3749,
+   3793,
+   3795,
+   4228,
+   4265,
+   4496,
+   4707,
+   4711,
+   4909,
+   4923,
+   5018,
+   5299,
+   5329,
+   5427,
+   5448,
+   5623,
+   5639,
+   5655,
+   5736,
+   5773,
+   6210,
+   6292,
+   6315,
+   6375,
+   6494,
+   6649,
+   6666,
+   6758,
+   6862,
+   7349,
+   7351,
+   7475,
+   7525,
+   8775,
+   8823,
+   8861,
+   8947,
+   9299,
+   9525,
+   9557,
+   9633,
+   9779,
+   10111,
+   10229,
+   10648,
+   10855,
+   11130,
+   12318,
+   12363,
+   12525,
+   12905,
+   13487,
+   13949,
+   14015,
+   14495,
+   15624,
+   17495,
+   17517,
+   17710
+  ],
+  "global_id": 16355,
+  "id_score": 25,
+  "grade_score": 45,
+  "confidence": "C",
+  "id_flags": [
+   "no_nasab",
+   "has_death",
+   "has_kunya",
+   "collision_large",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded"
+  ],
+  "provenance": {
+   "kaggle_id": 16355,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "tabaqat",
+     "entry_id": 380,
+     "grade": "unknown"
+    },
+    {
+     "type": "tarikh",
+     "entry_id": 10,
+     "grade": "companion"
+    },
+    {
+     "type": "mucin_tabaqat",
+     "entry_id": 49,
+     "grade": "unknown"
+    }
+   ],
+   "arsanad_id": 58,
+   "source_count": 3,
+   "kaggle_name": "Salman Shykh سلمان",
+   "kaggle_grade": "Follower(Tabi')",
+   "introduced_via": {
+    "teacher_count": 2,
+    "student_count": 130
+   }
+  },
+  "unique_key": "سلمان|d:34|k:ابو عبد الله|t:عمر بن الخطاب بن نفي|s:انس بن مالك بن النضر",
+  "uniqueness": "composite_unique",
+  "gk_id": 3476,
+  "gk_match_method": "naming_variant"
+ },
+ "98": {
+  "id": 98,
+  "full_name": "صهيب بن سنان بن خالد بن عمرو ، وقال ابن سعد : صهيب بن سنان بن مالك بن عبد عمرو بن عقيل بن عامر بن جندلة بن جذيمة بن كعب بن سعد بن أسلم بن أوس مناة بن النمر بن قاسط",
+  "kunya": "أبو يحيى ،  وقيل : أبو غسان",
+  "grade_en": "companion",
+  "grade_ar": "صحابي",
+  "color": "#9b59b6",
+  "death": "قال ابن سعد : 38 هـ ، وفي كتاب ابن الأثير : 39 هـ",
+  "tabaqat": "صحابي",
+  "city": "الروم ، نينوى ، مكة",
+  "laqab": "صهيب ، سابق الروم",
+  "nasab": "الرومي ، النمري الأصل ، من تيم الله بن النضر بن قاسط ، وقال ابن حبان : أصله من الجزيرة",
+  "dhahabi": "بدري من السابقين",
+  "namings": [
+   "أبيه",
+   "جده",
+   "صهيب",
+   "صهيب الحبر",
+   "صهيب الخير",
+   "صهيب بن سنان",
+   "صهيب صاحب النبي",
+   "صهيب مولى بني جدعان",
+   "صهيب الرومي"
+  ],
+  "classical_sources": {
+   "taqrib": {
+    "entry_id": 2954,
+    "grade_en": "companion",
+    "grade_ar": "صحابي"
+   },
+   "jarh": {
+    "entry_id": 1950,
+    "grade_en": "companion",
+    "grade_ar": "له صحبة"
+   },
+   "thiqat": {
+    "entry_id": 656,
+    "grade_en": "reliable",
+    "grade_ar": "ذكره ابن حبان في الثقات"
+   },
+   "kashif": {
+    "entry_id": 2416,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "isaba": {
+    "entry_id": 4108,
+    "grade_en": "companion",
+    "grade_ar": "صحابي"
+   },
+   "siyar": {
+    "entry_id": 4,
+    "grade_en": "mostly_reliable",
+    "grade_ar": "إمام"
+   },
+   "tahdhib_kamal": {
+    "entry_id": 2904,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "tahdhib_tahdhib": {
+    "entry_id": 769,
+    "grade_en": "companion",
+    "grade_ar": "أدرك النبي"
+   },
+   "tabaqat": {
+    "entry_id": 70,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "mucin_tabaqat": {
+    "entry_id": 61,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   }
+  },
+  "teachers": [
+   187,
+   1244,
+   3100,
+   5847,
+   7019,
+   7822,
+   9839,
+   12751,
+   12787,
+   12845,
+   17671,
+   29451,
+   41555,
+   70404
+  ],
+  "students": [
+   42,
+   97,
+   120,
+   224,
+   569,
+   606,
+   661,
+   725,
+   874,
+   932,
+   1998,
+   2575,
+   2862,
+   3099,
+   3455,
+   4109,
+   4163,
+   5623,
+   5790,
+   6166,
+   6563,
+   7861,
+   8404,
+   8609,
+   9986,
+   11073,
+   11151,
+   12986,
+   13323,
+   13999,
+   14612
+  ],
+  "global_id": 182,
+  "id_score": 100,
+  "grade_score": 75,
+  "confidence": "A",
+  "id_flags": [
+   "deep_nasab",
+   "has_death",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "taqrib_grade",
+   "source_graded"
+  ],
+  "provenance": {
+   "kaggle_id": 182,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "taqrib",
+     "entry_id": 2954,
+     "grade": "companion"
+    },
+    {
+     "type": "jarh",
+     "entry_id": 1950,
+     "grade": "companion"
+    },
+    {
+     "type": "thiqat",
+     "entry_id": 656,
+     "grade": "reliable"
+    },
+    {
+     "type": "kashif",
+     "entry_id": 2416,
+     "grade": "unknown"
+    },
+    {
+     "type": "isaba",
+     "entry_id": 4108,
+     "grade": "companion"
+    },
+    {
+     "type": "siyar",
+     "entry_id": 4,
+     "grade": "mostly_reliable"
+    },
+    {
+     "type": "tahdhib_kamal",
+     "entry_id": 2904,
+     "grade": "unknown"
+    },
+    {
+     "type": "tahdhib_tahdhib",
+     "entry_id": 769,
+     "grade": "companion"
+    },
+    {
+     "type": "tabaqat",
+     "entry_id": 70,
+     "grade": "unknown"
+    },
+    {
+     "type": "mucin_tabaqat",
+     "entry_id": 61,
+     "grade": "unknown"
+    }
+   ],
+   "arsanad_id": 98,
+   "source_count": 10,
+   "kaggle_name": "Suhayb bin Sinan ar-Rumi ( صهيب بن سنان بن مالك الرومي ( رضي",
+   "kaggle_grade": "Comp.(RA) [1st Generation]",
+   "introduced_via": {
+    "teacher_count": 2,
+    "student_count": 31
+   }
+  },
+  "unique_key": "صهيب بن سنان بن خالد بن عمرو",
+  "uniqueness": "name_unique",
+  "gk_id": 3964,
+  "gk_match_method": "exact_name"
+ },
+ "106": {
+  "id": 106,
+  "full_name": "عبد الرحمن بن صخر ، وقيل : عبد الرحمن بن غنم ، وقيل : عبد الله بن عائذ ، وقيل : عبد الله بن عامر ، وقيل : عبد الله بن عمرو ، وقيل : سكين بن وذمة ، وقيل : سكين بن هانئ ، وقيل : سكين بن مل ، وقيل : سكين بن صخر ، وقيل : عامر بن عبد شمس ، وقيل : عامر بن عمير ، وقيل : برير بن عشرقة ، وقيل : عبد نهم ، وقيل : عبد شمس ،  وقيل : غنم ، وقيل : عبيد بن غنم ، وقيل : عمرو بن غنم ،  وقيل : عمرو بن عامر ، وقيل : سعيد بن الحارث ، وقيل غير ذلك ، وقال هشام بن محمد الكلبي اسمه : عمير بن عامر بن ذي الشري بن طريف بن عيان بن أبي صعب بن هنية بن سعد بن ثعلبة بن سليم بن فهم بن غنم بن دوس بن عدثان بن عبد الله بن زهران بن كعب بن الحارث بن كعب بن عبد الله بن مالك بن نصر بن الأزد ، وهكذا قال خليفة بن خياط في نسبه إلا أنه قال عتاب بدل عيان ، ويقال: كان اسمه في الجاهلية عبد شمس فسماه رسول الله صلى الله عليه وسلم عبد الله",
+  "kunya": "أبو هريرة ، ويقال كانت كنيته في الجاهلية :  أبو الأسود",
+  "grade_en": "companion",
+  "grade_ar": "صحابي",
+  "color": "#9b59b6",
+  "death": "57 هـ ، أو : 58 هـ ، أو : 59 هـ",
+  "tabaqat": "الصحابي الجليل",
+  "city": "المدينة ، ذو الحليفة ، البحرين",
+  "laqab": "-",
+  "nasab": "الدوسي ، اليماني",
+  "dhahabi": "كان حافظا متثبتا ذكيا مفتيا ، صاحب صيام وقيام ، قال عكرمة : كان يسبح في اليوم اثني عشر ألف تسبيحة",
+  "namings": [
+   "أبو هريرة",
+   "أبو هريرة الدوسي",
+   "أبي",
+   "أبيه",
+   "اليماني"
+  ],
+  "classical_sources": {
+   "taqrib": {
+    "entry_id": 8426,
+    "grade_en": "companion",
+    "grade_ar": "صحابي"
+   },
+   "thiqat": {
+    "entry_id": 924,
+    "grade_en": "reliable",
+    "grade_ar": "ذكره ابن حبان في الثقات"
+   },
+   "siyar": {
+    "entry_id": 126,
+    "grade_en": "mostly_reliable",
+    "grade_ar": "إمام"
+   },
+   "tahdhib_tahdhib": {
+    "entry_id": 1216,
+    "grade_en": "companion",
+    "grade_ar": "من الصحابة"
+   },
+   "tadhkirat_huffaz": {
+    "entry_id": 16,
+    "grade_en": "weak",
+    "grade_ar": "لين"
+   },
+   "tahdhib_kamal": {
+    "entry_id": 7681,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   }
+  },
+  "teachers": [
+   8,
+   58,
+   107,
+   120,
+   164,
+   165,
+   181,
+   182,
+   187,
+   238,
+   275,
+   276,
+   342,
+   368,
+   406,
+   456,
+   487,
+   498,
+   529,
+   559,
+   567,
+   603,
+   623,
+   638,
+   662,
+   725,
+   811,
+   974,
+   1213,
+   1347,
+   1599,
+   1754,
+   2200,
+   2248,
+   2513,
+   2748,
+   2814,
+   4043,
+   4328,
+   4401,
+   4934,
+   5054,
+   5393,
+   5852,
+   6895,
+   6959,
+   7981,
+   8760,
+   10732,
+   11596,
+   12751,
+   13684,
+   13783,
+   15394,
+   16872
+  ],
+  "students": [
+   4,
+   7,
+   8,
+   23,
+   29,
+   40,
+   42,
+   47,
+   48,
+   52,
+   57,
+   93,
+   97,
+   105,
+   110,
+   120,
+   126,
+   160,
+   182,
+   184,
+   185,
+   192,
+   195,
+   199,
+   208,
+   209,
+   212,
+   221,
+   233,
+   240,
+   245,
+   247,
+   250,
+   252,
+   274,
+   281,
+   288,
+   301,
+   302,
+   303,
+   342,
+   348,
+   368,
+   369,
+   375,
+   391,
+   394,
+   395,
+   396,
+   399,
+   400,
+   416,
+   448,
+   467,
+   490,
+   497,
+   523,
+   528,
+   536,
+   548,
+   555,
+   566,
+   569,
+   572,
+   573,
+   602,
+   606,
+   611,
+   622,
+   637,
+   649,
+   652,
+   657,
+   661,
+   664,
+   685,
+   688,
+   690,
+   699,
+   713,
+   729,
+   736,
+   749,
+   762,
+   781,
+   788,
+   792,
+   796,
+   799,
+   801,
+   810,
+   822,
+   827,
+   836,
+   845,
+   864,
+   871,
+   872,
+   873,
+   874,
+   888,
+   895,
+   928,
+   939,
+   950,
+   972,
+   1016,
+   1018,
+   1019,
+   1038,
+   1060,
+   1074,
+   1085,
+   1092,
+   1111,
+   1117,
+   1131,
+   1139,
+   1167,
+   1171,
+   1179,
+   1198,
+   1271,
+   1274,
+   1297,
+   1302,
+   1314,
+   1353,
+   1380,
+   1384,
+   1385,
+   1387,
+   1397,
+   1401,
+   1407,
+   1420,
+   1490,
+   1504,
+   1530,
+   1550,
+   1581,
+   1591,
+   1637,
+   1639,
+   1693,
+   1700,
+   1704,
+   1719,
+   1723,
+   1730,
+   1753,
+   1782,
+   1788,
+   1801,
+   1806,
+   1815,
+   1818,
+   1853,
+   1867,
+   1872,
+   1916,
+   1929,
+   1936,
+   1951,
+   1958,
+   1962,
+   1989,
+   1990,
+   1996,
+   2022,
+   2026,
+   2029,
+   2052,
+   2057,
+   2073,
+   2096,
+   2107,
+   2115,
+   2131,
+   2135,
+   2137,
+   2146,
+   2174,
+   2177,
+   2207,
+   2222,
+   2225,
+   2242,
+   2307,
+   2308,
+   2320,
+   2328,
+   2338,
+   2361,
+   2370,
+   2379,
+   2384,
+   2390,
+   2428,
+   2433,
+   2434,
+   2444,
+   2456,
+   2478,
+   2511,
+   2516,
+   2520,
+   2539,
+   2543,
+   2568,
+   2572,
+   2604,
+   2644,
+   2662,
+   2663,
+   2676,
+   2688,
+   2698,
+   2713,
+   2734,
+   2750,
+   2794,
+   2805,
+   2807,
+   2811,
+   2813,
+   2843,
+   2845,
+   2859,
+   2863,
+   2906,
+   2978,
+   2994,
+   3047,
+   3058,
+   3072,
+   3094,
+   3096,
+   3098,
+   3198,
+   3205,
+   3251,
+   3258,
+   3271,
+   3304,
+   3307,
+   3320,
+   3338,
+   3349,
+   3353,
+   3357,
+   3369,
+   3396,
+   3406,
+   3434,
+   3439,
+   3455,
+   3472,
+   3486,
+   3487,
+   3491,
+   3496,
+   3517,
+   3520,
+   3521,
+   3539,
+   3542,
+   3549,
+   3555,
+   3557,
+   3618,
+   3625,
+   3637,
+   3641,
+   3714,
+   3734,
+   3741,
+   3793,
+   3803,
+   3832,
+   3833,
+   3841,
+   3875,
+   3879,
+   3911,
+   3939,
+   4017,
+   4018,
+   4042,
+   4107,
+   4110,
+   4148,
+   4158,
+   4162,
+   4163,
+   4183,
+   4193,
+   4199,
+   4202,
+   4226,
+   4249,
+   4265,
+   4284,
+   4315,
+   4327,
+   4330,
+   4333,
+   4365,
+   4400,
+   4418,
+   4432,
+   4470,
+   4484,
+   4498,
+   4550,
+   4559,
+   4610,
+   4663,
+   4678,
+   4719,
+   4763,
+   4780,
+   4782,
+   4784,
+   4831,
+   4834,
+   4886,
+   4977,
+   5012,
+   5053,
+   5086,
+   5094,
+   5101,
+   5114,
+   5118,
+   5120,
+   5152,
+   5162,
+   5167,
+   5170,
+   5173,
+   5199,
+   5256,
+   5320,
+   5331,
+   5334,
+   5340,
+   5360,
+   5393,
+   5412,
+   5422,
+   5423,
+   5450,
+   5459,
+   5484,
+   5522,
+   5619,
+   5623,
+   5631,
+   5783,
+   5790,
+   5791,
+   5821,
+   5828,
+   5842,
+   5889,
+   5952,
+   5955,
+   5956,
+   5969,
+   6012,
+   6081,
+   6087,
+   6098,
+   6132,
+   6163,
+   6172,
+   6206,
+   6232,
+   6245,
+   6254,
+   6261,
+   6291,
+   6292,
+   6346,
+   6350,
+   6353,
+   6366,
+   6370,
+   6395,
+   6411,
+   6478,
+   6480,
+   6503,
+   6527,
+   6541,
+   6560,
+   6564,
+   6577,
+   6618,
+   6624,
+   6694,
+   6768,
+   6770,
+   6782,
+   6802,
+   6811,
+   6896,
+   6941,
+   6994,
+   7026,
+   7037,
+   7105,
+   7123,
+   7178,
+   7185,
+   7229,
+   7241,
+   7269,
+   7350,
+   7411,
+   7459,
+   7516,
+   7531,
+   7542,
+   7561,
+   7589,
+   7626,
+   7679,
+   7687,
+   7697,
+   7728,
+   7770,
+   7787,
+   7788,
+   7790,
+   7848,
+   7871,
+   7878,
+   7917,
+   7925,
+   7936,
+   7949,
+   7954,
+   8003,
+   8016,
+   8054,
+   8066,
+   8155,
+   8196,
+   8207,
+   8231,
+   8235,
+   8279,
+   8311,
+   8379,
+   8380,
+   8409,
+   8458,
+   8564,
+   8569,
+   8582,
+   8598,
+   8679,
+   8685,
+   8726,
+   8739,
+   8772,
+   8780,
+   8813,
+   8817,
+   8843,
+   8881,
+   8890,
+   8892,
+   8947,
+   8951,
+   9101,
+   9110,
+   9135,
+   9137,
+   9142,
+   9191,
+   9222,
+   9229,
+   9230,
+   9283,
+   9284,
+   9287,
+   9336,
+   9346,
+   9378,
+   9405,
+   9442,
+   9447,
+   9494,
+   9507,
+   9519,
+   9557,
+   9632,
+   9698,
+   9756,
+   9793,
+   9853,
+   9857,
+   9895,
+   9897,
+   9955,
+   9975,
+   9977,
+   10107,
+   10122,
+   10135,
+   10148,
+   10151,
+   10197,
+   10209,
+   10212,
+   10244,
+   10246,
+   10247,
+   10272,
+   10317,
+   10366,
+   10379,
+   10380,
+   10386,
+   10387,
+   10393,
+   10395,
+   10397,
+   10480,
+   10490,
+   10508,
+   10515,
+   10542,
+   10575,
+   10640,
+   10660,
+   10694,
+   10774,
+   10826,
+   10829,
+   10938,
+   10968,
+   10978,
+   11010,
+   11179,
+   11209,
+   11214,
+   11243,
+   11264,
+   11348,
+   11370,
+   11457,
+   11506,
+   11534,
+   11565,
+   11581,
+   11627,
+   11646,
+   11747,
+   11764,
+   12005,
+   12032,
+   12036,
+   12037,
+   12049,
+   12068,
+   12071,
+   12084,
+   12095,
+   12109,
+   12184,
+   12203,
+   12228,
+   12247,
+   12268,
+   12295,
+   12319,
+   12335,
+   12338,
+   12359,
+   12369,
+   12387,
+   12388,
+   12469,
+   12485,
+   12491,
+   12507,
+   12527,
+   12569,
+   12596,
+   12632,
+   12651,
+   12679,
+   12726,
+   12748,
+   12821,
+   12824,
+   12879,
+   12882,
+   12923,
+   12949,
+   12977,
+   13009,
+   13051,
+   13054,
+   13084,
+   13128,
+   13132,
+   13135,
+   13169,
+   13247,
+   13298,
+   13333,
+   13334,
+   13362,
+   13375,
+   13480,
+   13576,
+   13626,
+   13702,
+   13758,
+   13776,
+   13850,
+   13856,
+   13907,
+   13943,
+   14091,
+   14151,
+   14157,
+   14176,
+   14294,
+   14295,
+   14301,
+   14339,
+   14357,
+   14384,
+   14391,
+   14419,
+   14422,
+   14433,
+   14463,
+   14494,
+   14599,
+   14631,
+   14645,
+   14651,
+   14702,
+   14750,
+   14851,
+   14881,
+   14906,
+   14907,
+   14943,
+   15016,
+   15023,
+   15048,
+   15121,
+   15187,
+   15190,
+   15369,
+   15384,
+   15407,
+   15443,
+   15463,
+   15464,
+   15495,
+   15557,
+   15585,
+   15600,
+   15629,
+   15684,
+   15702,
+   15812,
+   15826,
+   15834,
+   15863,
+   15868,
+   15905,
+   15916,
+   15959,
+   16005,
+   16117,
+   16137,
+   16149,
+   16187,
+   16223,
+   16289,
+   16302,
+   16401,
+   16441,
+   16459,
+   16460,
+   16481,
+   16493,
+   16499,
+   16567,
+   16585,
+   16780,
+   16794,
+   16796,
+   16822,
+   16830,
+   16887,
+   16992,
+   17020,
+   17026,
+   17031,
+   17045,
+   17077,
+   17165,
+   17241,
+   17433,
+   17562,
+   17688,
+   17722,
+   17724,
+   17747,
+   17778,
+   17875,
+   17894,
+   17973,
+   17995,
+   18051,
+   18086
+  ],
+  "global_id": 28331,
+  "id_score": 80,
+  "grade_score": 75,
+  "confidence": "A",
+  "id_flags": [
+   "short_nasab",
+   "has_death",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "taqrib_grade",
+   "source_graded"
+  ],
+  "provenance": {
+   "kaggle_id": 28331,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "taqrib",
+     "entry_id": 8426,
+     "grade": "companion"
+    },
+    {
+     "type": "thiqat",
+     "entry_id": 924,
+     "grade": "reliable"
+    },
+    {
+     "type": "siyar",
+     "entry_id": 126,
+     "grade": "mostly_reliable"
+    },
+    {
+     "type": "tahdhib_tahdhib",
+     "entry_id": 1216,
+     "grade": "companion"
+    },
+    {
+     "type": "tadhkirat_huffaz",
+     "entry_id": 16,
+     "grade": "weak"
+    },
+    {
+     "type": "tahdhib_kamal",
+     "entry_id": 7681,
+     "grade": "unknown"
+    }
+   ],
+   "arsanad_id": 106,
+   "source_count": 6,
+   "kaggle_name": "'Abdur Rahman bin Skhr عبد الرحمن بن صخر",
+   "kaggle_grade": "Succ. (Taba' Tabi') [9th generation]",
+   "introduced_via": {
+    "teacher_count": 43,
+    "student_count": 734
+   }
+  },
+  "unique_key": "عبد الرحمن بن صخر",
+  "uniqueness": "name_unique",
+  "gk_id": 4396,
+  "gk_match_method": "exact_name"
+ },
+ "121": {
+  "id": 121,
+  "full_name": "رافع بن خديج بن رافع بن عدي بن تزيد بن جشم بن حارثة بن الحارث بن الخزرج بن عمرو بن مالك بن الأوس",
+  "kunya": "أبو عبد الله ، ويقال : أبو رافع ، ويقال : أبو خديج",
+  "grade_en": "companion",
+  "grade_ar": "له صحبة",
+  "color": "#9b59b6",
+  "death": "73 هـ ، أو 74 هـ ، وقيل : 59 هـ ، وقيل :  بعد 50 هـ إلى 60 هـ",
+  "tabaqat": "صحابي جليل",
+  "city": "المدينة ، والكوفة",
+  "laqab": "-",
+  "nasab": "الحارثي ، الأوسي ، الأنصاري ، المدني",
+  "dhahabi": "أحدي",
+  "namings": [
+   "أبي",
+   "أبيه",
+   "ابن خديج",
+   "جده",
+   "جده رافع بن خديج",
+   "رافع",
+   "رافع بن خديج",
+   "رافع بن خديج الأنصاري",
+   "رافع بن خديج بن رافع",
+   "رافع هو ابن خديج"
+  ],
+  "classical_sources": {
+   "taqrib": {
+    "entry_id": 1861,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "jarh": {
+    "entry_id": 2150,
+    "grade_en": "companion",
+    "grade_ar": "له صحبة"
+   },
+   "thiqat": {
+    "entry_id": 407,
+    "grade_en": "reliable",
+    "grade_ar": "ذكره ابن حبان في الثقات"
+   },
+   "kashif": {
+    "entry_id": 1505,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "isaba": {
+    "entry_id": 2528,
+    "grade_en": "weak",
+    "grade_ar": "واه"
+   },
+   "siyar": {
+    "entry_id": 34,
+    "grade_en": "reliable",
+    "grade_ar": "ثقة"
+   },
+   "tahdhib_tahdhib": {
+    "entry_id": 440,
+    "grade_en": "mostly_reliable",
+    "grade_ar": "وسط"
+   },
+   "mucin_tabaqat": {
+    "entry_id": 39,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "tahdhib_kamal": {
+    "entry_id": 1833,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   }
+  },
+  "teachers": [
+   122,
+   165,
+   231,
+   353,
+   405,
+   1198,
+   2284,
+   4382,
+   4401,
+   7050,
+   7591,
+   7646,
+   9839,
+   11104,
+   12257,
+   12283,
+   12751,
+   12787,
+   14475,
+   18203,
+   21950,
+   22788,
+   29451,
+   41555,
+   45826,
+   54057,
+   74877
+  ],
+  "students": [
+   42,
+   51,
+   93,
+   97,
+   120,
+   160,
+   181,
+   247,
+   288,
+   303,
+   375,
+   396,
+   569,
+   579,
+   602,
+   690,
+   713,
+   716,
+   749,
+   788,
+   799,
+   864,
+   888,
+   1074,
+   1118,
+   1122,
+   1167,
+   1302,
+   1380,
+   1990,
+   2071,
+   2174,
+   2385,
+   4202,
+   4381,
+   4510,
+   4646,
+   4909,
+   5559,
+   5688,
+   5737,
+   6078,
+   6232,
+   6359,
+   6406,
+   6480,
+   6864,
+   6929,
+   6985,
+   7267,
+   7636,
+   7672,
+   7774,
+   9142,
+   9226,
+   9227,
+   10129,
+   10286,
+   10564,
+   10565,
+   11783,
+   12833,
+   13384,
+   14394,
+   14523,
+   15339,
+   15901,
+   16908,
+   17179,
+   18159
+  ],
+  "global_id": 1986,
+  "id_score": 100,
+  "grade_score": 75,
+  "confidence": "A",
+  "id_flags": [
+   "deep_nasab",
+   "has_death",
+   "has_kunya",
+   "unique_name",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "taqrib_grade",
+   "source_graded"
+  ],
+  "provenance": {
+   "kaggle_id": 1986,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "taqrib",
+     "entry_id": 1861,
+     "grade": "unknown"
+    },
+    {
+     "type": "jarh",
+     "entry_id": 2150,
+     "grade": "companion"
+    },
+    {
+     "type": "thiqat",
+     "entry_id": 407,
+     "grade": "reliable"
+    },
+    {
+     "type": "kashif",
+     "entry_id": 1505,
+     "grade": "unknown"
+    },
+    {
+     "type": "isaba",
+     "entry_id": 2528,
+     "grade": "weak"
+    },
+    {
+     "type": "siyar",
+     "entry_id": 34,
+     "grade": "reliable"
+    },
+    {
+     "type": "tahdhib_tahdhib",
+     "entry_id": 440,
+     "grade": "mostly_reliable"
+    },
+    {
+     "type": "mucin_tabaqat",
+     "entry_id": 39,
+     "grade": "unknown"
+    },
+    {
+     "type": "tahdhib_kamal",
+     "entry_id": 1833,
+     "grade": "unknown"
+    }
+   ],
+   "arsanad_id": 121,
+   "source_count": 9,
+   "kaggle_name": "Rafi' bin Khadij bin Rafi' ( رافع بن خديج بن رافع الأنصاري (",
+   "kaggle_grade": "Comp.(RA) [1st Generation]",
+   "introduced_via": {
+    "teacher_count": 5,
+    "student_count": 70
+   }
+  },
+  "unique_key": "رافع بن خديج بن رافع بن عدي بن تزيد بن جشم بن حارثة بن الحارث بن الخزرج بن عمرو",
+  "uniqueness": "name_unique",
+  "gk_id": 2865,
+  "gk_match_method": "prefix4_death_±1"
+ },
+ "148": {
+  "id": 148,
+  "full_name": "خالد بن عبد الله بن عبد الرحمن بن يزيد.",
+  "kunya": "أبو الهيثم ، ويقال: أبو محمد.",
+  "grade_en": "companion",
+  "grade_ar": "له صحبة",
+  "color": "#9b59b6",
+  "death": "179 هـ ، أو 182 هـ ، وقيل : 183 هـ.",
+  "tabaqat": "الثامنة.",
+  "city": "-",
+  "laqab": "الحافظ ، الطحان",
+  "nasab": "الحافظ ، الطحان ، المزني مولاهم ، الواسطي.",
+  "dhahabi": "أحد العلماء ، ثقة ، عابد.",
+  "namings": [
+   "أبو الهيثم",
+   "أبي",
+   "خالد",
+   "خالد أظنه الواسطي",
+   "خالد الطحان",
+   "خالد الواسطي",
+   "خالد بن أبي نضرة",
+   "خالد بن عبد",
+   "خالد بن عبد الله",
+   "خالد بن عبد الله الطحان",
+   "خالد بن عبد الله الطحان المزني",
+   "خالد بن عبد الله المزني",
+   "خالد بن عبد الله الواسطي",
+   "خالد بن عبد الله بن خالد الواسطي",
+   "خالد بن عبد الله هو الطحان",
+   "خالد بن عبيد الله",
+   "خالد هو ابن عبد الله",
+   "خالد هو ابن عبد الله الطحان",
+   "خالد هو ابن عبد الله الواسطي",
+   "خالد هو ابن عبد الله الواسطي الطحان",
+   "خالد هو الطحان",
+   "خالد وهو ابن عبد الله الواسطي",
+   "خالد يعني ابن عبد الله",
+   "خالد يعني ابن عبد الله الطحان",
+   "خالد يعني ابن عبد الله الطحان الواسطي",
+   "خالد يعني ابن عبد الله الواسطي",
+   "خالد يعني ابن عبد الله الواسطي الطحان",
+   "خالد يعني الطحان",
+   "خالد يعني الواسطي",
+   "خالد يعني الواسطي الطحان",
+   "خلف"
+  ],
+  "classical_sources": {
+   "jarh": {
+    "entry_id": 1524,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "isaba": {
+    "entry_id": 2181,
+    "grade_en": "companion",
+    "grade_ar": "له صحبة"
+   },
+   "tabaqat": {
+    "entry_id": 4252,
+    "grade_en": "reliable",
+    "grade_ar": "ثقة"
+   }
+  },
+  "teachers": [
+   17,
+   23,
+   45,
+   58,
+   103,
+   149,
+   154,
+   172,
+   252,
+   346,
+   347,
+   365,
+   380,
+   394,
+   412,
+   435,
+   537,
+   542,
+   569,
+   593,
+   607,
+   610,
+   611,
+   626,
+   664,
+   678,
+   685,
+   739,
+   853,
+   888,
+   964,
+   983,
+   1066,
+   1074,
+   1146,
+   1210,
+   1245,
+   1313,
+   1367,
+   1393,
+   1445,
+   1655,
+   1712,
+   1961,
+   2115,
+   2209,
+   2233,
+   2252,
+   2276,
+   2277,
+   2391,
+   2487,
+   2609,
+   2796,
+   2837,
+   2918,
+   2925,
+   2988,
+   3000,
+   3597,
+   3822,
+   3837,
+   3850,
+   4132,
+   4364,
+   4441,
+   4532,
+   4558,
+   4640,
+   4783,
+   6038,
+   6134,
+   6329,
+   6708,
+   6973,
+   7497,
+   7901,
+   7999,
+   8040,
+   9585,
+   12451,
+   12880,
+   13854
+  ],
+  "students": [
+   15,
+   54,
+   84,
+   143,
+   147,
+   157,
+   171,
+   205,
+   410,
+   414,
+   441,
+   550,
+   591,
+   670,
+   679,
+   695,
+   983,
+   1002,
+   1007,
+   1008,
+   1076,
+   1165,
+   1261,
+   1287,
+   1619,
+   1635,
+   1821,
+   1946,
+   1959,
+   1978,
+   2004,
+   2087,
+   2092,
+   2547,
+   2628,
+   2734,
+   2912,
+   2950,
+   3147,
+   3208,
+   3317,
+   3582,
+   3596,
+   3600,
+   4127,
+   4140,
+   4261,
+   4339,
+   4393,
+   4442,
+   4685,
+   4689,
+   5455,
+   5859,
+   6123,
+   7385,
+   7793,
+   7856,
+   7968,
+   9317,
+   9900,
+   15705,
+   17290
+  ],
+  "id_score": 65,
+  "grade_score": 45,
+  "confidence": "B",
+  "id_flags": [
+   "deep_nasab",
+   "has_death",
+   "has_kunya",
+   "collision_small",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded"
+  ],
+  "provenance": {
+   "origin": "classical",
+   "sources": [
+    {
+     "type": "jarh",
+     "entry_id": 1524,
+     "grade": "unknown"
+    },
+    {
+     "type": "isaba",
+     "entry_id": 2181,
+     "grade": "companion"
+    },
+    {
+     "type": "tabaqat",
+     "entry_id": 4252,
+     "grade": "reliable"
+    }
+   ],
+   "arsanad_id": 148,
+   "source_count": 3,
+   "introduced_via": {
+    "teacher_count": 83,
+    "student_count": 63
+   }
+  },
+  "unique_key": "خالد بن عبد الله بن عبد الرحمن بن يزيد|d:179|k:ابو الهيثم ، ويقال: ابو محمد.|t:محمد بن عمرو بن علقم|s:فضيل بن حسين بن طلحة",
+  "uniqueness": "composite_unique",
+  "gk_id": 41258,
+  "gk_match_method": "naming_variant"
+ },
+ "151": {
+  "id": 151,
+  "full_name": "عبد الله بن قيس بن سليم بن حضار بن حرب بن عامر بن عنز بن بكر بن عامر بن عذر بن وائل بن ناجية بن الجماهر بن الأشعر",
+  "kunya": "أبو موسى",
+  "grade_en": "companion",
+  "grade_ar": "له صحبة",
+  "color": "#9b59b6",
+  "death": "42 هـ ، أو 44 هـ ، أو 50 هـ ، أو 52 هـ ، أو 53 هـ ، ويقال 49 هـ ، ويقال 51 هـ",
+  "tabaqat": "صحابي مشهور",
+  "city": "مكة ، الحبشة ، زبيد ، عدن ، البصرة ، الكوفة ، المدينة",
+  "laqab": "-",
+  "nasab": "الأشعري ، المدني ، التميمي ، المقرئ ، اليماني",
+  "dhahabi": "صحابى",
+  "namings": [
+   "أبو موسى",
+   "أبو موسى الأشعري",
+   "أبو موسى الأشعري عبد الله بن قيس",
+   "أبو موسى يعني الأشعري",
+   "أبوك",
+   "أبوه",
+   "أبوهما",
+   "أبي",
+   "أبيه",
+   "الأشعري",
+   "الأشعري أبو موسى",
+   "الأشعري يعني أبا موسى",
+   "جدك",
+   "جده",
+   "عبد الله بن قيس",
+   "عبد الله بن قيس أبو موسى الأشعري",
+   "عبد الله بن قيس الأشعري"
+  ],
+  "classical_sources": {
+   "jarh": {
+    "entry_id": 642,
+    "grade_en": "companion",
+    "grade_ar": "له صحبة"
+   },
+   "isaba": {
+    "entry_id": 10584,
+    "grade_en": "companion",
+    "grade_ar": "ذكره ابن حجر في الإصابة"
+   },
+   "siyar": {
+    "entry_id": 82,
+    "grade_en": "weak",
+    "grade_ar": "واه"
+   },
+   "tahdhib_tahdhib": {
+    "entry_id": 1152,
+    "grade_en": "unknown",
+    "grade_ar": ""
+   },
+   "tabaqat": {
+    "entry_id": 388,
+    "grade_en": "companion",
+    "grade_ar": "صحابي"
+   },
+   "tadhkirat_huffaz": {
+    "entry_id": 10,
+    "grade_en": "reliable",
+    "grade_ar": "حجة"
+   },
+   "macrifa_qurra": {
+    "entry_id": 6,
+    "grade_en": "companion",
+    "grade_ar": "صحابي"
+   }
+  },
+  "teachers": [
+   48,
+   164,
+   165,
+   182,
+   187,
+   275,
+   342,
+   397,
+   487,
+   529,
+   559,
+   601,
+   700,
+   828,
+   3371,
+   11309
+  ],
+  "students": [
+   8,
+   40,
+   42,
+   45,
+   48,
+   51,
+   57,
+   93,
+   120,
+   126,
+   150,
+   154,
+   181,
+   184,
+   199,
+   209,
+   212,
+   213,
+   245,
+   250,
+   254,
+   301,
+   303,
+   369,
+   375,
+   394,
+   422,
+   448,
+   529,
+   536,
+   543,
+   544,
+   548,
+   558,
+   569,
+   637,
+   657,
+   661,
+   686,
+   690,
+   799,
+   820,
+   845,
+   873,
+   888,
+   1053,
+   1066,
+   1074,
+   1085,
+   1136,
+   1179,
+   1256,
+   1297,
+   1314,
+   1407,
+   1474,
+   1507,
+   1543,
+   1565,
+   1637,
+   1815,
+   1818,
+   1853,
+   1925,
+   1958,
+   1960,
+   1998,
+   2022,
+   2049,
+   2076,
+   2107,
+   2131,
+   2208,
+   2273,
+   2304,
+   2328,
+   2361,
+   2486,
+   2525,
+   2544,
+   2572,
+   2605,
+   2676,
+   2692,
+   2835,
+   2862,
+   2868,
+   3020,
+   3258,
+   3396,
+   3472,
+   3473,
+   3501,
+   3523,
+   3547,
+   3664,
+   3700,
+   3749,
+   3793,
+   3841,
+   3929,
+   4163,
+   4550,
+   4637,
+   4739,
+   4840,
+   5299,
+   5322,
+   5333,
+   5446,
+   5459,
+   5490,
+   5619,
+   5623,
+   5631,
+   5773,
+   5823,
+   5842,
+   5993,
+   6142,
+   6374,
+   6553,
+   6666,
+   6959,
+   7080,
+   7453,
+   7504,
+   7643,
+   7702,
+   7842,
+   7927,
+   8057,
+   8061,
+   8584,
+   8599,
+   8707,
+   8772,
+   9517,
+   10229,
+   10275,
+   10593,
+   10637,
+   11074,
+   11123,
+   11134,
+   11136,
+   11660,
+   11765,
+   12044,
+   12699,
+   12877,
+   12880,
+   12963,
+   13126,
+   13712,
+   13955,
+   14044,
+   14362,
+   14746,
+   14894,
+   15164,
+   16308,
+   16629,
+   16863,
+   17193,
+   17303,
+   17922,
+   18148
+  ],
+  "global_id": 41,
+  "generation": 1,
+  "id_score": 65,
+  "grade_score": 45,
+  "confidence": "B",
+  "id_flags": [
+   "deep_nasab",
+   "has_death",
+   "has_kunya",
+   "collision_small",
+   "multi_source"
+  ],
+  "grade_flags": [
+   "source_graded"
+  ],
+  "provenance": {
+   "kaggle_id": 41,
+   "origin": "merged",
+   "sources": [
+    {
+     "type": "jarh",
+     "entry_id": 642,
+     "grade": "companion"
+    },
+    {
+     "type": "isaba",
+     "entry_id": 10584,
+     "grade": "companion"
+    },
+    {
+     "type": "siyar",
+     "entry_id": 82,
+     "grade": "weak"
+    },
+    {
+     "type": "tahdhib_tahdhib",
+     "entry_id": 1152,
+     "grade": "unknown"
+    },
+    {
+     "type": "tabaqat",
+     "entry_id": 388,
+     "grade": "companion"
+    },
+    {
+     "type": "tadhkirat_huffaz",
+     "entry_id": 10,
+     "grade": "reliable"
+    },
+    {
+     "type": "macrifa_qurra",
+     "entry_id": 6,
+     "grade": "companion"
+    }
+   ],
+   "arsanad_id": 151,
+   "source_count": 7,
+   "kaggle_name": "Abu Musa al-Asha'ari ( أبو موسى الأشعري ( رضي الله عنه",
+   "kaggle_grade": "Comp.(RA) [1st Generation]",
+   "introduced_via": {
+    "teacher_count": 16,
+    "student_count": 168
+   }
+  },
+  "unique_key": "عبد الله بن قيس بن سليم بن حضار بن حرب بن عامر بن عنز بن بكر بن عامر بن عذر بن وائل|d:42|k:ابو موسى|t:عبد الله بن عباس بن |s:انس بن مالك بن النضر",
+  "uniqueness": "composite_unique"
+ }
+}

--- a/tests/test_parse/test_itqan_parser.py
+++ b/tests/test_parse/test_itqan_parser.py
@@ -1,0 +1,152 @@
+"""Tests for the Itqan rijal narrator-bio parser (da#92a)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+from src.parse import itqan
+from src.parse.itqan import (
+    _GRADE_TO_TRUST,
+    _clean,
+    _extract_death_year,
+    _generation,
+    _parse_profile,
+)
+from src.parse.schemas import NARRATOR_BIO_SCHEMA
+
+FIXTURE = Path(__file__).parent / "fixtures" / "itqan_rijal_sample.json"
+
+
+@pytest.fixture
+def raw_dir(tmp_path: Path) -> Path:
+    """A raw/itqan dir holding the sample profiles as a profiles_*.json bucket."""
+    d = tmp_path / "raw" / "itqan"
+    d.mkdir(parents=True)
+    shutil.copy(FIXTURE, d / "profiles_sample.json")
+    return tmp_path / "raw"
+
+
+class TestPureMappings:
+    def test_every_grade_bucket_maps_to_a_trust_tier(self) -> None:
+        # All seven Itqan grade buckets must have a trustworthiness mapping.
+        for grade in (
+            "reliable",
+            "mostly_reliable",
+            "weak",
+            "abandoned",
+            "fabricator",
+            "companion",
+            "unknown",
+        ):
+            assert grade in _GRADE_TO_TRUST
+
+    def test_jarh_tiers(self) -> None:
+        assert _GRADE_TO_TRUST["reliable"] == "thiqa"
+        assert _GRADE_TO_TRUST["mostly_reliable"] == "saduq"
+        assert _GRADE_TO_TRUST["weak"] == "daif"
+        assert _GRADE_TO_TRUST["abandoned"] == "matruk"
+        assert _GRADE_TO_TRUST["fabricator"] == "kadhdhab"
+        assert _GRADE_TO_TRUST["unknown"] == "unknown"
+
+    def test_clean_treats_dash_as_null(self) -> None:
+        assert _clean("-") is None
+        assert _clean("  ") is None
+        assert _clean(None) is None
+        assert _clean("البصرة") == "البصرة"
+
+    def test_extract_death_year_single(self) -> None:
+        assert _extract_death_year("168 هـ") == 168
+
+    def test_extract_death_year_range_takes_first(self) -> None:
+        assert _extract_death_year("بين 161 هـ إلى 170 هـ") == 161
+
+    def test_extract_death_year_missing(self) -> None:
+        assert _extract_death_year("-") is None
+        assert _extract_death_year("بعد عصر التابعين") is None
+
+    def test_extract_death_year_rejects_absurd(self) -> None:
+        assert _extract_death_year("3200") is None
+
+    def test_generation_companion_is_sahabi(self) -> None:
+        assert _generation({"tabaqat": "-"}, "companion") == "sahabi"
+
+    def test_generation_from_tabaqat(self) -> None:
+        assert _generation({"tabaqat": "السادسة"}, "weak") == "taba_tabii"
+        assert _generation({"tabaqat": "الثالثة"}, "reliable") == "tabii"
+
+    def test_generation_unknown_tabaqat_is_none(self) -> None:
+        assert _generation({"tabaqat": "-"}, "weak") is None
+
+
+class TestParseProfile:
+    def test_row_shape_and_tagging(self) -> None:
+        profile = {
+            "id": 320,
+            "full_name": "سعيد بن سماك بن حرب",
+            "kunya": "أبي خزامة",
+            "grade_en": "abandoned",
+            "grade_ar": "متروك الحديث",
+            "death": "168 هـ",
+            "tabaqat": "-",
+            "city": "البصرة",
+            "nasab": "الذهلي",
+            "laqab": "-",
+        }
+        row = _parse_profile("320", profile)
+        assert row is not None
+        assert row["bio_id"] == "itqan:320"
+        assert row["source"] == "itqan"
+        assert row["external_id"] == "320"
+        assert row["name_ar"] == "سعيد بن سماك بن حرب"
+        assert row["name_ar_normalized"]  # normalized, non-empty
+        assert row["trustworthiness"] == "matruk"
+        assert row["death_year_ah"] == 168
+        assert row["birth_location"] == "البصرة"
+        assert row["nisba"] == "الذهلي"
+        assert row["laqab"] is None  # dash placeholder
+        assert row["bio_text"] == "متروك الحديث"
+
+    def test_profile_without_name_is_dropped(self) -> None:
+        assert _parse_profile("1", {"id": 1, "full_name": "-", "grade_en": "weak"}) is None
+
+
+class TestRunOverFixture:
+    def test_produces_schema_conformant_parquet(self, raw_dir: Path, tmp_path: Path) -> None:
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        out = itqan.run(raw_dir, staging)
+        assert out.name == "narrators_bio_itqan.parquet"
+
+        table = pq.read_table(out)
+        assert table.schema.equals(NARRATOR_BIO_SCHEMA)
+
+        with FIXTURE.open(encoding="utf-8") as f:
+            expected = len(json.load(f))
+        assert table.num_rows == expected
+
+        rows = table.to_pylist()
+        # Every row tagged to the itqan source with a namespaced, unique bio_id.
+        assert {r["source"] for r in rows} == {"itqan"}
+        bio_ids = [r["bio_id"] for r in rows]
+        assert all(b.startswith("itqan:") for b in bio_ids)
+        assert len(set(bio_ids)) == len(bio_ids)
+
+        # The three real grade buckets in the fixture exercise three jarh tiers.
+        trust = {r["trustworthiness"] for r in rows}
+        assert {"matruk", "kadhdhab", "thiqa"} <= trust
+
+    def test_idempotent_dedup_on_repeated_bucket(self, raw_dir: Path, tmp_path: Path) -> None:
+        # A second bucket file with overlapping ids must not double-count.
+        shutil.copy(FIXTURE, raw_dir / "itqan" / "profiles_dup.json")
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        out = itqan.run(raw_dir, staging)
+        table = pq.read_table(out)
+        with FIXTURE.open(encoding="utf-8") as f:
+            expected = len(json.load(f))
+        assert table.num_rows == expected

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -1,0 +1,154 @@
+"""Tests for the bio-direct canonical promoter (da#92a)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from src.parse.identity import make_canonical_id
+from src.parse.schemas import NARRATOR_BIO_SCHEMA
+from src.resolve.bio_promote import promote_bios_to_canonical
+from src.utils.arabic import normalize_arabic
+
+
+def _write_bios(staging: Path, suffix: str, rows: list[dict[str, Any]]) -> Path:
+    """Write a narrators_bio_<suffix>.parquet with schema defaults filled in."""
+    full = []
+    for r in rows:
+        base = {f.name: None for f in NARRATOR_BIO_SCHEMA}
+        base.update(r)
+        full.append(base)
+    arrays = {f.name: [r[f.name] for r in full] for f in NARRATOR_BIO_SCHEMA}
+    table = pa.table(arrays, schema=NARRATOR_BIO_SCHEMA)
+    path = staging / f"narrators_bio_{suffix}.parquet"
+    pq.write_table(table, path)
+    return path
+
+
+def test_promotes_bios_to_canonical_with_nar_ids(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    name = "سعيد بن سماك"
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:320",
+                "source": "itqan",
+                "name_ar": name,
+                "name_ar_normalized": normalize_arabic(name),
+                "trustworthiness": "matruk",
+                "external_id": "320",
+            }
+        ],
+    )
+
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    table = pq.read_table(path)
+    rows = table.to_pylist()
+    assert len(rows) == 1
+    rec = rows[0]
+    assert rec["canonical_id"].startswith("nar:")
+    assert rec["canonical_id"] == make_canonical_id(normalize_arabic(name))
+    assert rec["trustworthiness"] == "matruk"
+    assert rec["external_id"] == "320"
+    assert rec["source_ids"] == ["itqan:320"]
+    assert rec["mention_count"] == 0
+
+
+def test_same_name_dedups_to_one_canonical(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    name = "عمر بن حفص"
+    norm = normalize_arabic(name)
+    # The second bio carries an int death year; back-fill must keep it an int
+    # (regression: it was previously stringified, breaking the int32 column).
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {"bio_id": "itqan:1", "source": "itqan", "name_ar": name, "name_ar_normalized": norm},
+            {
+                "bio_id": "itqan:2",
+                "source": "itqan",
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                "death_year_ah": 231,
+            },
+        ],
+    )
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    rows = pq.read_table(path).to_pylist()
+    assert len(rows) == 1
+    assert sorted(rows[0]["source_ids"]) == ["itqan:1", "itqan:2"]
+    assert rows[0]["death_year_ah"] == 231
+
+
+def test_source_filter(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    _write_bios(
+        staging,
+        "itqan",
+        [{"bio_id": "itqan:1", "source": "itqan", "name_ar": "أ", "name_ar_normalized": "ا"}],
+    )
+    _write_bios(
+        staging,
+        "muhaddithat",
+        [{"bio_id": "m:1", "source": "muhaddithat", "name_ar": "ب", "name_ar_normalized": "ب"}],
+    )
+    path = promote_bios_to_canonical(staging, out_dir, sources={"itqan"})
+    assert path is not None
+    rows = pq.read_table(path).to_pylist()
+    assert len(rows) == 1
+    assert rows[0]["source_ids"] == ["itqan:1"]
+
+
+def test_merges_into_existing_canonical(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    # Pre-existing canonical (as if from the disambiguator) with a different id.
+    from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+
+    existing = {f.name: [None] for f in NARRATORS_CANONICAL_SCHEMA}
+    existing["canonical_id"] = ["nar:preexisting"]
+    existing["source_ids"] = [["sanadset:9"]]
+    existing["aliases"] = [[]]
+    existing["mention_count"] = [5]
+    pq.write_table(
+        pa.table(existing, schema=NARRATORS_CANONICAL_SCHEMA),
+        out_dir / "narrators_canonical.parquet",
+    )
+
+    _write_bios(
+        staging,
+        "itqan",
+        [{"bio_id": "itqan:1", "source": "itqan", "name_ar": "ج", "name_ar_normalized": "ج"}],
+    )
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    ids = {r["canonical_id"] for r in pq.read_table(path).to_pylist()}
+    assert "nar:preexisting" in ids  # not clobbered
+    assert len(ids) == 2  # plus the new itqan-derived narrator
+
+
+def test_no_bio_files_returns_none(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    assert promote_bios_to_canonical(staging, out_dir) is None

--- a/tests/test_resolve/test_disambiguate.py
+++ b/tests/test_resolve/test_disambiguate.py
@@ -6,8 +6,8 @@ import uuid
 
 import pytest
 
+from src.parse.identity import CANONICAL_NAMESPACE
 from src.resolve.disambiguate import (
-    _CANONICAL_NAMESPACE,
     Candidate,
     ChainContext,
     Match,
@@ -227,7 +227,7 @@ class TestCanonicalId:
         assert parsed.version == 5
 
     def test_uses_fixed_namespace(self) -> None:
-        expected = f"nar:{uuid.uuid5(_CANONICAL_NAMESPACE, 'test_input')}"
+        expected = f"nar:{uuid.uuid5(CANONICAL_NAMESPACE, 'test_input')}"
         assert _make_canonical_id("test_input") == expected
 
 


### PR DESCRIPTION
## da#92a (N1a) — NEW Itqan adapter, narrators only

New **Itqan** rijal source ([github R3GENESI5/Itqan](https://github.com/R3GENESI5/Itqan)) — the largest open-source narrator DB: **115,735 profiles** from 22 classical texts, **72.6 % graded** (jarh-wa-ta'dil). This is the **narrators-only** slice (PR 1 of 3 in the owner's pre-split). Keystone source for isnad-graph narrator search (ig#963 / #965).

Out of scope (separate Itqan PRs): isnad chains `teachers`/`students` → **#93**; name variants `namings`/`by_name` → **#94**.

### What's here
- **`src/acquire/itqan.py`** — downloads the 7 per-grade profile buckets via the rijal `manifest.json` (HTTPS, no auth; skips `by_name` and the isnad lists).
- **`src/parse/itqan.py`** — emits `narrators_bio_itqan.parquet` (`NARRATOR_BIO_SCHEMA`): `grade_en` → trustworthiness (jarh tier), `grade_ar` → `bio_text`, approximate Hijri death year from free Arabic text, companion/tabaqat → generation, `city` → location, kunya/nasab/laqab. `bio_id = itqan:{globally-unique id}`.
- **`SourceCorpus.ITQAN`** added; registered in the acquire/parse `run_all` registries; `validate` baseline `narrators_bio_itqan = 115735`.

### Profile-only sources need a bio-direct canonical path
The mention-driven disambiguator only mints a canonical `Narrator` when an **isnad mention** resolves to a bio candidate — so a bios-only source would load **zero** Narrator nodes. **`src/resolve/bio_promote.py`** promotes each bio to a canonical narrator keyed by the **same** `nar:<uuid5(normalized-name)>` identity the disambiguator uses, so the two paths converge (a later mention run dedups onto the same node) and the graph loader ingests it unchanged. Merge-safe — unions an existing `narrators_canonical.parquet` rather than clobbering it.

To remove uuid5-scheme drift, the canonical-id minting is centralized in `identity.make_canonical_id` + `CANONICAL_NAMESPACE` (single source of truth, da#82); `disambiguate._make_canonical_id` now delegates (byte-identical output, namespace pinned).

### Acceptance — LIVE `neo4j:5` ✅
- `tests/integration/test_itqan_load.py` runs the real slice (parse → promote → `load_all_nodes`) into a live `neo4j:5` container against a committed 24-profile **real** sample (abandoned + fabricator + companion), asserting `nar:` ids, `external_id` provenance, and the three jarh trust tiers. Skip-guarded when Docker is unreachable.
- **Scale proof (local):** 3 real buckets → 14,360 bios → **12,820 canonical narrators** → **12,820 `Narrator` nodes loaded into `neo4j:5`, 0 errors** (thiqa 9,922 · kadhdhab 1,639 · matruk 1,259).
- `docs/itqan-narrators.md` — field mapping, **full-load runbook** (all 115,735), reachability + **licensing** note.

> ⚠ **Licensing:** the upstream repo ships **no LICENSE** → all-rights-reserved by default. Acquisition is for research; redistribution/production publication needs an explicit grant from the author — **flagged for owner; not cleared for redistribution.**

### Checks
- ruff check + format clean · mypy clean (66 files) · 365 unit tests pass (3 ml-skips) · 2 live integration tests pass.

Closes #92 · Refs #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
