### PR TITLE
da#99 (X1): cross-source narrator-identity resolution

### DIFF
--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -635,6 +635,75 @@ _MERGE_LOG_SCHEMA = pa.schema(
 )
 
 
+def _upsert_canonical(
+    canonical_map: dict[str, dict[str, str | int | list[str] | None]],
+    canonical_id: str,
+    *,
+    norm_name: str,
+    name_ar: str | None,
+    name_en: str | None,
+    alias: str | None,
+    candidate: Candidate | None,
+) -> None:
+    """Create or merge the canonical narrator record for *canonical_id*.
+
+    ``canonical_id`` is a pure function of ``norm_name`` (:func:`_make_canonical_id`),
+    so a bio-matched mention and a bio-less mention of the *same* normalized name
+    — from any number of sources — converge on **one** record. This is the
+    cross-source collapse for da#99.
+
+    A biographical *candidate*, when supplied, enriches the record by filling any
+    still-empty biographical field, so resolution order never loses bio metadata
+    (a bio-less mention seen first leaves a minimal record that a later
+    bio-matched mention of the same name upgrades in place).
+    """
+    rec = canonical_map.get(canonical_id)
+    if rec is None:
+        rec = {
+            "canonical_id": canonical_id,
+            "name_ar": name_ar,
+            "name_en": name_en,
+            "name_ar_normalized": norm_name,
+            "aliases": [],
+            "birth_year_ah": None,
+            "death_year_ah": None,
+            "generation": None,
+            "gender": None,
+            "trustworthiness": None,
+            "source_ids": [],
+            "external_id": None,
+            "mention_count": 0,
+        }
+        canonical_map[canonical_id] = rec
+
+    raw_count = rec.get("mention_count")
+    rec["mention_count"] = (int(raw_count) if isinstance(raw_count, int | str) else 0) + 1
+
+    if candidate is not None:
+        if not rec.get("name_ar") and candidate.name_ar:
+            rec["name_ar"] = candidate.name_ar
+        if not rec.get("name_en") and candidate.name_en:
+            rec["name_en"] = candidate.name_en
+        for field_name, value in (
+            ("birth_year_ah", candidate.birth_year_ah),
+            ("death_year_ah", candidate.death_year_ah),
+            ("generation", candidate.generation),
+            ("gender", candidate.gender),
+            ("trustworthiness", candidate.trustworthiness),
+            ("external_id", candidate.external_id),
+        ):
+            if rec.get(field_name) is None and value is not None:
+                rec[field_name] = value
+        src_ids = rec.get("source_ids")
+        if isinstance(src_ids, list) and candidate.bio_id and candidate.bio_id not in src_ids:
+            src_ids.append(candidate.bio_id)
+
+    if alias and alias != norm_name:
+        aliases = rec.get("aliases")
+        if isinstance(aliases, list) and alias not in aliases:
+            aliases.append(alias)
+
+
 # ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
@@ -680,6 +749,11 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
     merge_log_rows: list[dict[str, str | float | None]] = []
     ambiguous_rows: list[dict[str, str | float | None]] = []
 
+    # Cross-source collapse measurement (da#99): the naive baseline keeps one
+    # node per (source, canonical) pair; the collapsed count is distinct
+    # canonicals. naive > collapsed exactly when a narrator spans >1 source.
+    naive_identity_pairs: set[tuple[str, str]] = set()
+
     # Per-source counters.
     source_resolved: dict[str, int] = {}
     source_total: dict[str, int] = {}
@@ -697,7 +771,7 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
             mention_text = str(mention.get("name_normalized") or mention.get("name_raw") or "")
 
             if best and best.score >= _CONFIDENCE_THRESHOLD:
-                # Resolved.
+                # Resolved to a biographical candidate.
                 source_resolved[corpus] = source_resolved.get(corpus, 0) + 1
                 c = best.candidate
                 norm_name = c.name_ar_normalized or normalize_arabic(c.name_ar or "")
@@ -708,37 +782,16 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
                 position = int(mention.get("position_in_chain") or 0)
                 death_year_index[f"{hadith_id}:{position}"] = c.death_year_ah
 
-                # Upsert canonical record.
-                if canonical_id not in canonical_map:
-                    canonical_map[canonical_id] = {
-                        "canonical_id": canonical_id,
-                        "name_ar": c.name_ar,
-                        "name_en": c.name_en,
-                        "name_ar_normalized": norm_name,
-                        "aliases": [],
-                        "birth_year_ah": c.birth_year_ah,
-                        "death_year_ah": c.death_year_ah,
-                        "generation": c.generation,
-                        "gender": c.gender,
-                        "trustworthiness": c.trustworthiness,
-                        "source_ids": [c.bio_id],
-                        "external_id": c.external_id,
-                        "mention_count": 1,
-                    }
-                else:
-                    rec = canonical_map[canonical_id]
-                    raw_count = rec.get("mention_count")
-                    prev = int(raw_count) if isinstance(raw_count, int | str) else 0
-                    rec["mention_count"] = prev + 1
-                    # Merge source IDs.
-                    src_ids = rec.get("source_ids")
-                    if isinstance(src_ids, list) and c.bio_id not in src_ids:
-                        src_ids.append(c.bio_id)
-                    # Add alias if different from primary.
-                    if mention_text and mention_text != norm_name:
-                        aliases = rec.get("aliases")
-                        if isinstance(aliases, list) and mention_text not in aliases:
-                            aliases.append(mention_text)
+                _upsert_canonical(
+                    canonical_map,
+                    canonical_id,
+                    norm_name=norm_name,
+                    name_ar=c.name_ar,
+                    name_en=c.name_en,
+                    alias=mention_text,
+                    candidate=c,
+                )
+                naive_identity_pairs.add((corpus, canonical_id))
 
                 # Merge log entry.
                 merge_log_rows.append(
@@ -751,7 +804,31 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
                     }
                 )
             else:
-                # Ambiguous — collect top-3 candidates.
+                # No confident biographical match. Cross-source identity
+                # resolution (da#99) still canonicalizes the mention by its OWN
+                # normalized name, so the same narrator appearing across sources
+                # collapses to a single Narrator node even without a rijal bio —
+                # the canonical id is a pure function of the normalized name.
+                # Exact-name only (high precision); fuzzy mention-to-mention
+                # clustering of spelling variants is deferred (see #109 / future).
+                fallback_name = str(mention.get("name_normalized") or "") or normalize_arabic(
+                    str(mention.get("name_raw") or "")
+                )
+                if fallback_name:
+                    fallback_id = _make_canonical_id(fallback_name)
+                    _upsert_canonical(
+                        canonical_map,
+                        fallback_id,
+                        norm_name=fallback_name,
+                        name_ar=(str(mention.get("name_raw") or "") or None),
+                        name_en=None,
+                        alias=None,
+                        candidate=None,
+                    )
+                    naive_identity_pairs.add((corpus, fallback_id))
+
+                # Record the top-3 bio candidates for the ambiguous-audit report
+                # (a fallback canonical node was still created above when named).
                 top3 = sorted(all_matches, key=lambda m: m.score, reverse=True)[:3]
                 row: dict[str, str | float | None] = {
                     "mention_id": mention_id,
@@ -810,6 +887,11 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
     matched_bios = {r["canonical_id"] for r in merge_log_rows if r.get("canonical_id")}
     bio_coverage = round(len(matched_bios) / max(len(candidates), 1) * 100, 1)
 
+    # Cross-source collapse (da#99): how many per-source identities merged into a
+    # shared canonical narrator. naive = one node per (source, canonical) pair.
+    naive_identity_count = len(naive_identity_pairs)
+    cross_source_merged = naive_identity_count - total_canonical
+
     logger.info(
         "disambiguate_summary",
         total_mentions=total_mentions,
@@ -818,6 +900,8 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
         total_ambiguous=total_ambiguous,
         resolution_rate_pct=round(total_resolved / max(total_mentions, 1) * 100, 1),
         bio_coverage_pct=bio_coverage,
+        naive_identity_count=naive_identity_count,
+        cross_source_merged=cross_source_merged,
     )
 
     # ---------------------------------------------------------------------------

--- a/src/resolve/quality.py
+++ b/src/resolve/quality.py
@@ -1,0 +1,85 @@
+"""Cluster-quality metrics for narrator-identity resolution (da#99).
+
+Pairwise precision / recall / F1 over predicted vs. gold narrator clusters — the
+standard entity-resolution dedup-quality measure. Each mention is assigned a
+cluster label (its canonical narrator id for the prediction; the true narrator
+identity for the gold). We compare the set of *same-cluster mention pairs*:
+
+* **precision** — of all mention pairs the resolver placed together, the
+  fraction that truly are the same narrator (over-merging lowers this).
+* **recall** — of all truly-same mention pairs, the fraction the resolver caught
+  (under-merging / missed variants lowers this).
+
+Pure Python, no ML dependencies, so it runs in unit tests and CI. Only mentions
+present in BOTH the predicted and gold maps are scored, so a labelled *sample*
+can be evaluated against a full prediction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from itertools import combinations
+
+__all__ = ["ClusterQuality", "pairwise_quality"]
+
+
+@dataclass(frozen=True)
+class ClusterQuality:
+    """Pairwise precision/recall/F1 of a clustering against a gold standard."""
+
+    precision: float
+    recall: float
+    f1: float
+    true_positive_pairs: int
+    predicted_pairs: int
+    gold_pairs: int
+
+    def summary(self) -> str:
+        """One-line human-readable summary."""
+        return (
+            f"precision={self.precision:.3f} recall={self.recall:.3f} f1={self.f1:.3f} "
+            f"(tp={self.true_positive_pairs}, pred={self.predicted_pairs}, "
+            f"gold={self.gold_pairs})"
+        )
+
+
+def _same_cluster_pairs(assignment: Mapping[str, str]) -> set[tuple[str, str]]:
+    """Set of unordered (a, b) mention-id pairs sharing a cluster label."""
+    groups: dict[str, list[str]] = {}
+    for key, label in assignment.items():
+        groups.setdefault(label, []).append(key)
+    pairs: set[tuple[str, str]] = set()
+    for members in groups.values():
+        for a, b in combinations(sorted(members), 2):
+            pairs.add((a, b))
+    return pairs
+
+
+def pairwise_quality(
+    predicted: Mapping[str, str],
+    gold: Mapping[str, str],
+) -> ClusterQuality:
+    """Compute pairwise precision/recall/F1 of *predicted* against *gold*.
+
+    *predicted* and *gold* both map ``mention_id -> cluster_label`` (any hashable
+    label). Only mention ids present in both are scored. With no positive pairs on
+    a side the corresponding rate is defined as 1.0 (vacuously perfect).
+    """
+    keys = set(predicted) & set(gold)
+    pred_pairs = _same_cluster_pairs({k: predicted[k] for k in keys})
+    gold_pairs = _same_cluster_pairs({k: gold[k] for k in keys})
+
+    tp = len(pred_pairs & gold_pairs)
+    precision = tp / len(pred_pairs) if pred_pairs else 1.0
+    recall = tp / len(gold_pairs) if gold_pairs else 1.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+
+    return ClusterQuality(
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        true_positive_pairs=tp,
+        predicted_pairs=len(pred_pairs),
+        gold_pairs=len(gold_pairs),
+    )

--- a/tests/integration/test_cross_source_resolution.py
+++ b/tests/integration/test_cross_source_resolution.py
@@ -1,0 +1,140 @@
+"""Live-Neo4j cross-source narrator-identity resolution (da#99).
+
+Proves the X1 keystone: the SAME narrator appearing across ≥2 sources collapses
+to ONE canonical ``Narrator`` node, instead of one node per source.
+
+Pipeline exercised: a consolidated ``narrator_mentions_resolved.parquet`` (the
+NER output) spanning two corpora (``sanadset`` + ``thaqalayn``) → the REAL
+``disambiguate.run`` (bio-matched AND bio-less exact-name canonicalization) →
+the REAL ``load_all_nodes`` into a live ``neo4j:5``. Asserts the collapsed
+canonical narrator count is strictly less than the naive per-source union, that a
+shared narrator is a single node, and reports pairwise precision/recall of the
+collapse against a labelled gold sample.
+
+Requires Docker; ``neo4j_client`` ``pytest.skip``s when Docker is unreachable.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.graph.load_nodes import load_all_nodes
+from src.parse.schemas import NARRATOR_BIO_SCHEMA
+from src.resolve import disambiguate
+from src.resolve.disambiguate import _make_canonical_id
+from src.resolve.quality import pairwise_quality
+from src.utils.arabic import normalize_arabic
+from tests.test_graph.conftest import write_narrator_mentions_resolved
+
+# Narrator names (gold entity label → the surface name used in mentions).
+_MALIK = "مالك بن أنس"  # has a bio → bio-matched, appears in both sources
+_JAFAR = "جعفر بن محمد"  # no bio → fallback-canonicalized, appears in both sources
+_ZAYD = "زيد بن ثابت"  # sanadset only
+_AMMAR = "عمار بن ياسر"  # thaqalayn only
+
+# (mention_id, source_corpus, name, gold_entity)
+_MENTIONS = [
+    ("m1", "sanadset", _MALIK, "malik"),
+    ("m2", "thaqalayn", _MALIK, "malik"),
+    ("m3", "sanadset", _JAFAR, "jafar"),
+    ("m4", "thaqalayn", _JAFAR, "jafar"),
+    ("m5", "sanadset", _ZAYD, "zayd"),
+    ("m6", "thaqalayn", _AMMAR, "ammar"),
+]
+_EXPECTED_CANONICAL = 4  # malik, jafar, zayd, ammar
+_NAIVE_UNION = 6  # one node per (source, narrator)
+
+
+def _write_bios(staging: Path, rows: list[dict[str, object]]) -> Path:
+    """Write a narrators_bio_*.parquet conforming to NARRATOR_BIO_SCHEMA."""
+    arrays = {
+        f.name: pa.array([r.get(f.name) for r in rows], type=f.type) for f in NARRATOR_BIO_SCHEMA
+    }
+    table = pa.table(arrays, schema=NARRATOR_BIO_SCHEMA)
+    path = staging / "narrators_bio_test.parquet"
+    pq.write_table(table, path)
+    return path
+
+
+@pytest.mark.integration
+class TestCrossSourceResolutionLive:
+    def test_same_narrator_across_sources_collapses_to_one_node(
+        self, neo4j_client, tmp_path: Path
+    ) -> None:
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        curated = tmp_path / "curated"
+        curated.mkdir()
+        resolve_out = tmp_path / "resolve"
+        resolve_out.mkdir()
+
+        # Consolidated NER output spanning two corpora.
+        write_narrator_mentions_resolved(
+            resolve_out,
+            [
+                {
+                    "mention_id": mid,
+                    "hadith_id": f"hdt:{corpus}:c:1:{i}",
+                    "source_corpus": corpus,
+                    "position_in_chain": 0,
+                    "name_raw": name,
+                    "name_normalized": normalize_arabic(name),
+                }
+                for i, (mid, corpus, name, _gold) in enumerate(_MENTIONS)
+            ],
+        )
+
+        # A single rijal bio for Malik (the others resolve bio-less by name).
+        _write_bios(
+            staging,
+            [{"bio_id": "bio-malik", "source": "test", "name_ar": _MALIK, "death_year_ah": 179}],
+        )
+
+        # REAL disambiguation across both sources.
+        disambiguate.run(staging, resolve_out)
+        canonical_path = resolve_out / "narrators_canonical.parquet"
+        assert canonical_path.exists()
+
+        canonical_tbl = pq.read_table(canonical_path)
+        # Cross-source collapse: distinct canonicals < naive per-source union.
+        assert canonical_tbl.num_rows == _EXPECTED_CANONICAL
+        assert canonical_tbl.num_rows < _NAIVE_UNION
+
+        # Load the canonical narrators into the live graph.
+        shutil.copy(canonical_path, staging / "narrators_canonical.parquet")
+        results = load_all_nodes(neo4j_client, staging, curated, strict=False)
+        narrator_result = next(r for r in results if r.node_type == "Narrator")
+        assert narrator_result.created == _EXPECTED_CANONICAL
+
+        rows = neo4j_client.execute_read("MATCH (n:Narrator) RETURN n.id AS id")
+        ids = {r["id"] for r in rows}
+        assert len(ids) == _EXPECTED_CANONICAL
+        assert all(i.startswith("nar:") for i in ids)
+
+        # The shared narrators (Malik, Jafar) are each ONE node spanning both
+        # sources, not one-per-source.
+        malik_id = _make_canonical_id(normalize_arabic(_MALIK))
+        jafar_id = _make_canonical_id(normalize_arabic(_JAFAR))
+        assert malik_id in ids
+        assert jafar_id in ids
+        # Malik carries the bio metadata; the bio-less Jafar does not.
+        malik = neo4j_client.execute_read(
+            "MATCH (n:Narrator {id: $id}) RETURN n.death_year_ah AS dy", {"id": malik_id}
+        )
+        assert malik[0]["dy"] == 179
+
+        # Reported dedup quality on the labelled sample: the resolver's identity
+        # function (canonical id keyed on normalized name) vs the gold entities.
+        predicted = {
+            mid: _make_canonical_id(normalize_arabic(name)) for mid, _c, name, _g in _MENTIONS
+        }
+        gold = {mid: gold_entity for mid, _c, _name, gold_entity in _MENTIONS}
+        quality = pairwise_quality(predicted, gold)
+        # Clean exact-match sample → perfect collapse.
+        assert quality.precision == 1.0
+        assert quality.recall == 1.0

--- a/tests/integration/test_cross_source_resolution.py
+++ b/tests/integration/test_cross_source_resolution.py
@@ -26,6 +26,7 @@ import pytest
 from src.graph.load_nodes import load_all_nodes
 from src.parse.schemas import NARRATOR_BIO_SCHEMA
 from src.resolve import disambiguate
+from src.resolve.bio_promote import promote_bios_to_canonical
 from src.resolve.disambiguate import _make_canonical_id
 from src.resolve.quality import pairwise_quality
 from src.utils.arabic import normalize_arabic
@@ -50,13 +51,13 @@ _EXPECTED_CANONICAL = 4  # malik, jafar, zayd, ammar
 _NAIVE_UNION = 6  # one node per (source, narrator)
 
 
-def _write_bios(staging: Path, rows: list[dict[str, object]]) -> Path:
-    """Write a narrators_bio_*.parquet conforming to NARRATOR_BIO_SCHEMA."""
+def _write_bios(staging: Path, rows: list[dict[str, object]], *, suffix: str = "test") -> Path:
+    """Write a narrators_bio_<suffix>.parquet conforming to NARRATOR_BIO_SCHEMA."""
     arrays = {
         f.name: pa.array([r.get(f.name) for r in rows], type=f.type) for f in NARRATOR_BIO_SCHEMA
     }
     table = pa.table(arrays, schema=NARRATOR_BIO_SCHEMA)
-    path = staging / "narrators_bio_test.parquet"
+    path = staging / f"narrators_bio_{suffix}.parquet"
     pq.write_table(table, path)
     return path
 
@@ -138,3 +139,150 @@ class TestCrossSourceResolutionLive:
         # Clean exact-match sample → perfect collapse.
         assert quality.precision == 1.0
         assert quality.recall == 1.0
+
+    def test_three_sources_including_itqan_converge_on_one_canonical(
+        self, neo4j_client, tmp_path: Path
+    ) -> None:
+        """Three sources — two mention-driven + the bio-direct Itqan rijal source.
+
+        da#110 added Itqan as a profile-only narrator corpus: it contributes
+        biographies but no isnad mentions, so its narrators reach the graph via
+        ``bio_promote`` (the bio-direct path), not the mention-driven
+        disambiguator. This proves all THREE present sources resolve into one
+        identity space — the same narrator seen in ``sanadset`` + ``thaqalayn``
+        mentions AND in an Itqan bio collapses to ONE ``nar:`` node, while
+        distinct narrators (incl. an Itqan-only one) stay distinct.
+
+        It also locks the producer-ordering invariant: ``disambiguate``
+        (OVERWRITES ``narrators_canonical.parquet``) must run BEFORE
+        ``bio_promote`` (MERGES), or the Itqan-only narrator would be clobbered.
+        Both producers key on the same ``identity.make_canonical_id``, so they
+        converge instead of duplicating.
+        """
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        curated = tmp_path / "curated"
+        curated.mkdir()
+        resolve_out = tmp_path / "resolve"
+        resolve_out.mkdir()
+
+        shuba = "شعبة بن الحجاج"  # Itqan bio ONLY — no mention in any corpus.
+
+        # Mention-driven sources: Malik spans sanadset + thaqalayn; Zayd is
+        # sanadset-only; Ammar is thaqalayn-only.
+        mentions = [
+            ("m1", "sanadset", _MALIK, 0),
+            ("m2", "thaqalayn", _MALIK, 1),
+            ("m3", "sanadset", _ZAYD, 0),
+            ("m4", "thaqalayn", _AMMAR, 0),
+        ]
+        write_narrator_mentions_resolved(
+            resolve_out,
+            [
+                {
+                    "mention_id": mid,
+                    "hadith_id": f"hdt:{corpus}:c:1:{i}",
+                    "source_corpus": corpus,
+                    "position_in_chain": 0,
+                    "name_raw": name,
+                    "name_normalized": normalize_arabic(name),
+                }
+                for i, (mid, corpus, name, _pos) in enumerate(mentions)
+            ],
+        )
+
+        # The Itqan rijal slice (the THIRD source): a bio for Malik (who is also
+        # mentioned in the two isnad corpora) and a bio for Shuba (mentioned
+        # nowhere — a profile-only narrator). Present at disambiguation time so
+        # Malik's mentions bio-match the Itqan record; Shuba, lacking any
+        # mention, is materialised only later by bio_promote.
+        _write_bios(
+            staging,
+            [
+                {
+                    "bio_id": "itqan:malik",
+                    "source": "itqan",
+                    "name_ar": _MALIK,
+                    "name_ar_normalized": normalize_arabic(_MALIK),
+                    "death_year_ah": 179,
+                    "trustworthiness": "thiqa",
+                    "external_id": "malik",
+                },
+                {
+                    "bio_id": "itqan:shuba",
+                    "source": "itqan",
+                    "name_ar": shuba,
+                    "name_ar_normalized": normalize_arabic(shuba),
+                    "death_year_ah": 160,
+                    "trustworthiness": "thiqa",
+                    "external_id": "shuba",
+                },
+            ],
+            suffix="itqan",
+        )
+
+        # Step 1 — REAL disambiguation over the two mention corpora. Emits a
+        # canonical node per mentioned narrator only (Shuba, mention-less, is
+        # absent here): Malik (collapsed across both corpora), Zayd, Ammar.
+        disambiguate.run(staging, resolve_out)
+        canonical_path = resolve_out / "narrators_canonical.parquet"
+        assert canonical_path.exists()
+        after_disambig = {r["canonical_id"] for r in pq.read_table(canonical_path).to_pylist()}
+        assert len(after_disambig) == 3  # malik, zayd, ammar — NOT yet shuba.
+
+        # Step 2 — bio-direct promotion of the Itqan source. MERGES into the
+        # disambiguator output (must run second): Malik's record gains the Itqan
+        # provenance, Shuba becomes a new canonical node. Source-filtered to
+        # itqan so the ordering invariant is what is under test.
+        promoted_path = promote_bios_to_canonical(staging, resolve_out, sources={"itqan"})
+        assert promoted_path == canonical_path
+
+        records = {r["canonical_id"]: r for r in pq.read_table(canonical_path).to_pylist()}
+        malik_id = _make_canonical_id(normalize_arabic(_MALIK))
+        zayd_id = _make_canonical_id(normalize_arabic(_ZAYD))
+        ammar_id = _make_canonical_id(normalize_arabic(_AMMAR))
+        shuba_id = _make_canonical_id(normalize_arabic(shuba))
+
+        # Four distinct canonical narrators across the three sources.
+        assert set(records) == {malik_id, zayd_id, ammar_id, shuba_id}
+        assert all(cid.startswith("nar:") for cid in records)
+
+        # Malik is ONE node spanning sanadset + thaqalayn mentions AND the Itqan
+        # bio: the two mention contributions survive the merge (mention_count
+        # preserved, NOT reset by bio_promote) and the Itqan provenance is on it.
+        malik = records[malik_id]
+        assert malik["mention_count"] == 2
+        assert "itqan:malik" in malik["source_ids"]
+        assert malik["death_year_ah"] == 179
+
+        # The Itqan-only narrator survived the disambiguate→bio_promote ordering
+        # (would have been clobbered had bio_promote run first) and stays
+        # distinct: a bio-direct node with no mentions.
+        shuba_rec = records[shuba_id]
+        assert shuba_rec["mention_count"] == 0
+        assert shuba_rec["source_ids"] == ["itqan:shuba"]
+
+        # The mention-only narrators stay distinct and carry no Itqan provenance.
+        for cid in (zayd_id, ammar_id):
+            assert "itqan:shuba" not in records[cid]["source_ids"]
+            assert "itqan:malik" not in records[cid]["source_ids"]
+
+        # End-to-end: the merged canonical loads as exactly four Narrator nodes,
+        # all nar:-prefixed, into the live graph.
+        shutil.copy(canonical_path, staging / "narrators_canonical.parquet")
+        results = load_all_nodes(neo4j_client, staging, curated, strict=False)
+        narrator_result = next(r for r in results if r.node_type == "Narrator")
+        assert narrator_result.created == 4
+
+        rows = neo4j_client.execute_read("MATCH (n:Narrator) RETURN n.id AS id")
+        ids = {r["id"] for r in rows}
+        assert ids == {malik_id, zayd_id, ammar_id, shuba_id}
+
+        # The Itqan provenance is queryable on the graph (owner's removability
+        # guarantee for the unlicensed Itqan corpus rides on source_ids).
+        malik_node = neo4j_client.execute_read(
+            "MATCH (n:Narrator {id: $id}) RETURN n.source_ids AS sids, n.death_year_ah AS dy",
+            {"id": malik_id},
+        )
+        assert "itqan:malik" in malik_node[0]["sids"]
+        assert malik_node[0]["dy"] == 179

--- a/tests/test_resolve/test_quality.py
+++ b/tests/test_resolve/test_quality.py
@@ -1,0 +1,57 @@
+"""Tests for cross-source resolution quality metrics (da#99)."""
+
+from __future__ import annotations
+
+from src.resolve.quality import pairwise_quality
+
+
+class TestPairwiseQuality:
+    def test_perfect_clustering(self) -> None:
+        """Identical predicted and gold clusters → precision = recall = 1."""
+        gold = {"m1": "A", "m2": "A", "m3": "B"}
+        pred = {"m1": "x", "m2": "x", "m3": "y"}  # labels differ, partition matches
+        q = pairwise_quality(pred, gold)
+        assert q.precision == 1.0
+        assert q.recall == 1.0
+        assert q.f1 == 1.0
+        assert q.true_positive_pairs == 1  # (m1, m2)
+
+    def test_over_merge_lowers_precision(self) -> None:
+        """Merging two distinct narrators → precision < 1, recall = 1."""
+        gold = {"m1": "A", "m2": "A", "m3": "B"}
+        pred = {"m1": "x", "m2": "x", "m3": "x"}  # all one cluster (over-merge)
+        q = pairwise_quality(pred, gold)
+        assert q.recall == 1.0  # the true (m1,m2) pair is still together
+        assert q.precision < 1.0  # but (m1,m3)/(m2,m3) are wrong
+        assert q.true_positive_pairs == 1
+        assert q.predicted_pairs == 3
+
+    def test_under_merge_lowers_recall(self) -> None:
+        """Splitting one narrator across clusters → recall < 1, precision = 1."""
+        gold = {"m1": "A", "m2": "A", "m3": "A"}
+        pred = {"m1": "x", "m2": "x", "m3": "y"}  # m3 split off (under-merge)
+        q = pairwise_quality(pred, gold)
+        assert q.precision == 1.0
+        assert q.recall < 1.0
+        assert q.true_positive_pairs == 1
+        assert q.gold_pairs == 3
+
+    def test_all_singletons(self) -> None:
+        """No same-cluster pairs on either side → vacuously perfect."""
+        gold = {"m1": "A", "m2": "B"}
+        pred = {"m1": "x", "m2": "y"}
+        q = pairwise_quality(pred, gold)
+        assert q.precision == 1.0
+        assert q.recall == 1.0
+        assert q.predicted_pairs == 0
+        assert q.gold_pairs == 0
+
+    def test_only_overlapping_keys_scored(self) -> None:
+        """Mentions absent from the gold sample are ignored, not penalized."""
+        gold = {"m1": "A", "m2": "A"}  # labelled sample of 2
+        pred = {"m1": "x", "m2": "x", "m3": "x", "m4": "z"}  # full prediction
+        q = pairwise_quality(pred, gold)
+        assert q.precision == 1.0
+        assert q.recall == 1.0
+        assert q.gold_pairs == 1
+        assert q.predicted_pairs == 1  # only (m1, m2) among scored keys


### PR DESCRIPTION
## da#99 (X1): cross-source narrator-identity resolution

Makes the SAME narrator appearing across multiple sources collapse to **one**
canonical `Narrator` node instead of one node per source — the X1 keystone that
makes narrator search (isnad-graph#963) return unified people, not per-source
duplicates.

### The gap
The disambiguation pipeline already ran, but only **bio-matched** mentions became
canonical narrators — a mention that matched a rijal biography. Narrators with no
biography entry were dropped (logged ambiguous, no node), so they were never
canonicalized and never deduped across sources. Cross-source collapse therefore
only worked for the bio-covered subset.

### Change
- **`src/resolve/disambiguate.py`**
  - **Bio-less exact-name fallback**: a mention with no confident bio match is now
    canonicalized by its own normalized name. The canonical id is a pure function
    of the normalized name (`_make_canonical_id`), so the same narrator across
    sources collapses to one node **whether or not** it has a biography.
  - **`_upsert_canonical` helper** centralizes the canonical-record merge so
    bio-matched and bio-less mentions of the same name converge on one record, and
    a bio candidate enriches it regardless of resolution order (no lost metadata).
  - **Cross-source collapse metric** in the summary log: naive per-`(source,
    canonical)` union vs. distinct canonicals (`cross_source_merged`).
  - Exact-name only (high precision). Fuzzy mention-to-mention clustering of
    spelling variants is explicitly **deferred**.
- **`src/resolve/quality.py`** — pairwise precision/recall/F1 dedup-quality metric
  (pure Python, no ML dependency) to measure collapse against a labelled sample.

### Acceptance — LIVE local neo4j:5
`tests/integration/test_cross_source_resolution.py` feeds a consolidated
`narrator_mentions_resolved` spanning **sanadset + thaqalayn** through the REAL
`disambiguate.run` → REAL `load_all_nodes` into a live `neo4j:5`:
- Distinct canonical narrators = **4** < naive per-source union = **6** — the two
  shared narrators (one bio-matched, one bio-less) each collapse to a single
  `nar:` node spanning both sources.
- The bio-matched narrator carries its bio metadata (`death_year_ah`); the
  bio-less one is minimal.
- **Reported dedup quality** on the labelled 6-mention sample: precision **1.000**,
  recall **1.000** (clean exact-match collapse).

```
tests/integration/test_cross_source_resolution.py::...collapses_to_one_node PASSED  [15.0s, real neo4j:5-community]
```
Off-Docker it degrades to a clean SKIP.

Local: `tests/test_resolve` 95 passed / 3 skipped; broad suites
(resolve+graph+parse+acquire) 383 passed / 3 skipped; `ruff check`,
`ruff format --check`, `mypy src/` clean. Unit tests (`test_quality.py`) confirm
the metric detects over-merge (precision↓) and under-merge (recall↓).

### Quality / precision-recall note
Exact normalized-name collapse is high-precision but will **under-merge** true
variants that survive normalization differently (e.g. a kunya-only spelling) —
that shows up as recall loss, which the new metric is built to quantify. Fuzzy
cross-source mention clustering is the natural next increment.

### Coordination with #109 (narrator→hadith edges)
Kept as a **clean follow-on**, not folded. Every mention now resolves to a
deterministic canonical id, so #109's backfill of `canonical_narrator_id` onto
`narrator_mentions_resolved` (which wires `NARRATED` edges + non-empty `Chain`s)
is mechanical — bio-matched ids come from the existing `merge_log`, bio-less ids
are `_make_canonical_id(name_normalized)`. This PR deliberately stops at producing
the collapsed `narrators_canonical`; the edge backfill is #109.

### Update — rebased onto post-#110 wave tip + 3rd source (Itqan)

Rebased onto `deployments/phase-4/wave-3` @ 9b8fe55 (includes the merged **da#110**
Itqan narrator adapter). `disambiguate._make_canonical_id` now delegates to the
centralized `src.parse.identity.make_canonical_id` introduced by #110 — both the
mention-driven and the bio-direct (`bio_promote`) paths share one
`nar:<uuid5(normalized-name)>` scheme, so they converge instead of duplicating.
Clean rebase (my `run()` edits and #110's import/`_make_canonical_id` edits touch
disjoint regions of the file).

**New test — `test_three_sources_including_itqan_converge_on_one_canonical`**
(live `neo4j:5`). Itqan is a *profile-only* corpus (bios, no isnad mentions), so it
reaches the graph via `bio_promote`, not the disambiguator. The test proves all
**three** present sources resolve into one identity space:
- **Malik** — `sanadset` + `thaqalayn` mentions **and** an Itqan bio → ONE `nar:`
  node; both mention contributions survive the merge (`mention_count==2`) and the
  Itqan provenance (`source_ids`, `death_year_ah`) is folded in.
- **Shuba** — Itqan-bio-only (no mention) → a distinct bio-direct node that only
  materializes through `bio_promote`.
- **Zayd / Ammar** — stay distinct, no Itqan provenance.

It also locks the **producer-ordering invariant**: `disambiguate` (OVERWRITES
`narrators_canonical.parquet`) must run **before** `bio_promote` (MERGES), or the
Itqan-only narrator would be clobbered. Verified E2E: 4 Narrator nodes, all
`nar:`-prefixed, Itqan `source_id` queryable on the graph.

Out of scope (flagged, not folded): **wiring `bio_promote` into `resolve.run_all`**
(it is still test-only; `run_all` orders NER→disambiguate→dedup). That ordering
needs disambiguate-before-bio_promote when wired — tracked separately.

Local green: `ruff@0.15.11 check` + `format --check`, `mypy src/` (68 files), non-
integration `test_resolve`+`test_graph` 186 passed / 3 skipped, and both
`test_cross_source_resolution` integration tests pass against live `neo4j:5`.

### Reviewers
- **Jean-Claude Habimana** (Data Architect — owns `parallels.py` cross-sect
  matching / cross-source identity) — **primary**
- **Ivana Horvat** (ML/NLP — owns the Itqan adapter + `bio_promote`, #110) —
  **secondary**

Closes #99
Refs #81 #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

