### PR TITLE
tech-debt(ci): static guard for generate_source_id call-site corpus (#113)

### DIFF
--- a/scripts/check_source_id_corpus.py
+++ b/scripts/check_source_id_corpus.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Static guard for ``generate_source_id`` call-site corpus arguments.
+
+``src.parse.base.generate_source_id(corpus, collection, *parts)`` fails fast
+(raises ``ValueError``) when *corpus* is not a known :class:`SourceCorpus`
+value. That check only fires **at runtime**, when the real acquisition dir is
+present — so a caller that passes a non-corpus first arg (e.g. a free-text bio
+``source`` label like ``"kaggle_narrators"``) aborts the whole parse and is
+masked in unit tests that build no raw dir. That was the da#89 sanadset crash.
+
+This guard catches the same class of bug **at CI time**: it AST-scans every
+``generate_source_id`` call-site and asserts the first positional argument
+statically resolves to a :class:`SourceCorpus` value. Free-text provenance keys
+(bio ``source`` values, etc.) must build their ids via the direct
+``ID_DELIMITER.join(...)`` path instead — see ``sanadset.py`` ``bio_id``.
+
+Run standalone (defaults to scanning ``src/parse``)::
+
+    python scripts/check_source_id_corpus.py
+    python scripts/check_source_id_corpus.py src/parse/sanadset.py
+
+Exit code is 1 if any violation is found, 0 otherwise. The same scan functions
+are exercised by ``tests/test_parse/test_source_id_corpus_guard.py``, which runs
+in CI's existing pytest job (so no new CI job / pre-commit ⇄ CI sync entry is
+required — the gate rides the ``Test`` workflow already mirrored in
+``.pre-commit-config.yaml``).
+
+Access forms covered (per the lint-gate-cover-all-syntactic-forms lesson):
+
+* bare call after ``from src.parse.base import generate_source_id`` —
+  ``generate_source_id(...)``
+* dotted/attribute call — ``base.generate_source_id(...)`` / any
+  ``<module>.generate_source_id(...)``
+
+First-arg forms accepted as valid:
+
+* a string literal whose value is a ``SourceCorpus`` value (``"lk"``)
+* a *module-level* string constant that resolves to one (``SOURCE_CORPUS = "fawaz"``)
+* an enum member access ``SourceCorpus.LK`` or ``SourceCorpus.LK.value``
+
+Anything else (an unknown literal/constant, an unknown enum member, or a
+non-static runtime expression such as a bare parameter) is a violation:
+it cannot be statically proven corpus-safe, which is exactly the reintroduction
+risk this guard exists to block.
+
+Form deliberately **not** chased: a corpus value rebound through a local
+(non-module-level) variable or imported from another module under an alias.
+Current call-sites never do this, and resolving arbitrary dataflow is out of
+scope for a line-of-defence static gate; such a first arg simply reads as a
+non-static expression and is flagged, which is the safe default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.models.enums import SourceCorpus  # noqa: E402  (after sys.path bootstrap)
+
+FUNC_NAME = "generate_source_id"
+ENUM_NAME = "SourceCorpus"
+
+#: Valid first-arg string values (the ``SourceCorpus`` *values*, e.g. ``"lk"``).
+VALID_CORPORA: frozenset[str] = frozenset(c.value for c in SourceCorpus)
+#: Valid enum *member* names (e.g. ``LK`` in ``SourceCorpus.LK``).
+VALID_MEMBERS: frozenset[str] = frozenset(c.name for c in SourceCorpus)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A ``generate_source_id`` call-site whose corpus arg is not provably valid."""
+
+    file: str
+    line: int
+    col: int
+    arg: str
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}:{self.col}: corpus={self.arg} — {self.reason}"
+
+
+def _is_target_call(node: ast.Call) -> bool:
+    """True for both ``generate_source_id(...)`` and ``x.generate_source_id(...)``."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == FUNC_NAME
+    if isinstance(func, ast.Attribute):
+        return func.attr == FUNC_NAME
+    return False
+
+
+def _module_str_consts(tree: ast.Module) -> dict[str, str]:
+    """Map module-level ``NAME = "literal"`` assignments to their string value."""
+    consts: dict[str, str] = {}
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign):
+            targets: list[ast.expr] = stmt.targets
+            value: ast.expr | None = stmt.value
+        elif isinstance(stmt, ast.AnnAssign):
+            targets = [stmt.target]
+            value = stmt.value
+        else:
+            continue
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    consts[target.id] = value.value
+    return consts
+
+
+def _enum_member_attr(arg: ast.expr) -> ast.Attribute | None:
+    """Return the ``SourceCorpus.MEMBER`` attribute node, unwrapping a trailing ``.value``.
+
+    Handles both ``SourceCorpus.LK`` and ``SourceCorpus.LK.value``; returns None
+    if *arg* is not an access on the ``SourceCorpus`` name.
+    """
+    node = arg
+    if isinstance(node, ast.Attribute) and node.attr == "value":
+        node = node.value
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == ENUM_NAME
+    ):
+        return node
+    return None
+
+
+def _check_first_arg(arg: ast.expr, consts: dict[str, str]) -> tuple[bool, str, str]:
+    """Return ``(ok, rendered_arg, reason)`` for a call's first positional arg."""
+    rendered = ast.unparse(arg)
+
+    # 1. String literal — must be a SourceCorpus value.
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        if arg.value in VALID_CORPORA:
+            return True, rendered, ""
+        return False, rendered, f"string literal {arg.value!r} is not a SourceCorpus value"
+
+    # 2. Module-level string constant (e.g. SOURCE_CORPUS = "fawaz").
+    if isinstance(arg, ast.Name):
+        if arg.id in consts:
+            resolved = consts[arg.id]
+            if resolved in VALID_CORPORA:
+                return True, f"{arg.id} (= {resolved!r})", ""
+            return (
+                False,
+                f"{arg.id} (= {resolved!r})",
+                f"module constant {arg.id} = {resolved!r} is not a SourceCorpus value",
+            )
+        return (
+            False,
+            rendered,
+            f"name {arg.id!r} does not resolve to a module-level SourceCorpus string constant",
+        )
+
+    # 3. Enum member access: SourceCorpus.LK / SourceCorpus.LK.value
+    member = _enum_member_attr(arg)
+    if member is not None:
+        if member.attr in VALID_MEMBERS:
+            return True, rendered, ""
+        return False, rendered, f"{ENUM_NAME} has no member {member.attr!r}"
+
+    # 4. Anything else — not statically provable as corpus-safe.
+    return (
+        False,
+        rendered,
+        "first arg is not a statically-verifiable SourceCorpus literal, "
+        "module constant, or enum member",
+    )
+
+
+def scan_source(source: str, filename: str) -> list[Violation]:
+    """Scan one module's source text for unsafe ``generate_source_id`` call-sites."""
+    tree = ast.parse(source, filename=filename)
+    consts = _module_str_consts(tree)
+    violations: list[Violation] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and _is_target_call(node)):
+            continue
+        if not node.args:
+            violations.append(
+                Violation(
+                    filename,
+                    node.lineno,
+                    node.col_offset,
+                    "<no positional args>",
+                    "call has no positional corpus argument to verify",
+                )
+            )
+            continue
+        first = node.args[0]
+        ok, rendered, reason = _check_first_arg(first, consts)
+        if not ok:
+            violations.append(Violation(filename, first.lineno, first.col_offset, rendered, reason))
+    return violations
+
+
+def scan_path(path: Path) -> list[Violation]:
+    """Scan a single ``.py`` file."""
+    return scan_source(path.read_text(encoding="utf-8"), str(path))
+
+
+def scan_tree(root: Path) -> list[Violation]:
+    """Recursively scan every ``.py`` file under *root* (sorted for stable output)."""
+    violations: list[Violation] = []
+    for path in sorted(root.rglob("*.py")):
+        violations.extend(scan_path(path))
+    return violations
+
+
+def collect(paths: list[Path]) -> list[Violation]:
+    """Scan a mix of files and directories."""
+    violations: list[Violation] = []
+    for path in paths:
+        if path.is_dir():
+            violations.extend(scan_tree(path))
+        else:
+            violations.extend(scan_path(path))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["src/parse"],
+        help="files or directories to scan (default: src/parse)",
+    )
+    args = parser.parse_args(argv)
+    paths = [Path(p) for p in (args.paths or ["src/parse"])]
+
+    violations = collect(paths)
+    scanned = ", ".join(str(p) for p in paths)
+    if violations:
+        print("generate_source_id call-site corpus guard: FAIL", file=sys.stderr)
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        print(
+            f"\n{len(violations)} violation(s) under [{scanned}]. "
+            "Pass a SourceCorpus value as the first arg, or — for a free-text "
+            "provenance key (a bio `source` label, not a hadith corpus) — build "
+            "the id via ID_DELIMITER.join(...) directly instead of "
+            "generate_source_id().",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"generate_source_id call-site corpus guard: OK ([{scanned}] clean)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/parse/identity.py
+++ b/src/parse/identity.py
@@ -40,6 +40,21 @@ Two historical identity hazards this module designs out
    ``APPEARS_IN.hadith_number_in_book`` is the staging ``hadith_number`` column —
    **not** the collection-wide reference number (sunnah.com exposes both). See
    ``HADITH_SCHEMA`` and ``src/graph/load_edges.py`` ``_APPEARS_IN_QUERY``.
+
+Free-text provenance keys are NOT corpus ids (da#89)
+----------------------------------------------------
+:func:`base.generate_source_id` is for hadith ``source_id``\\ s only: its first
+argument MUST be a :data:`SOURCE_CORPORA` value and it fails fast otherwise. A
+bio/narrator provenance key is namespaced by its *bio source* (a free-text label
+like ``"kaggle_narrators"``), which is **not** a hadith ``SourceCorpus`` — so
+build it with ``ID_DELIMITER.join([...])`` directly, never with
+``generate_source_id`` (see ``sanadset.py`` ``bio_id``). Passing a non-corpus
+first arg to ``generate_source_id`` aborted the whole parse at runtime and was
+masked by unit tests with no raw dir (the da#89 crash). ``scripts/
+check_source_id_corpus.py`` (test: ``tests/test_parse/
+test_source_id_corpus_guard.py``) is a CI static guard that asserts every
+``generate_source_id`` call-site passes a statically-provable ``SourceCorpus``
+first arg, blocking reintroduction.
 """
 
 from __future__ import annotations

--- a/tests/test_parse/test_source_id_corpus_guard.py
+++ b/tests/test_parse/test_source_id_corpus_guard.py
@@ -1,0 +1,159 @@
+"""Tests for the ``generate_source_id`` call-site corpus static guard.
+
+The guard (``scripts/check_source_id_corpus.py``) AST-scans call-sites and fails
+if a first ("corpus") argument cannot be statically proven to be a
+``SourceCorpus`` value. This catches the da#89-class crash (a free-text bio
+``source`` label passed where a corpus is required) at CI time instead of at
+runtime parse.
+
+The real-tree test below is the actual regression gate: it asserts the live
+``src/parse`` package is clean. The synthetic cases lock in the discrimination
+logic across both access forms (bare + dotted) and every accepted first-arg
+shape.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_GUARD_PATH = REPO_ROOT / "scripts" / "check_source_id_corpus.py"
+
+_spec = importlib.util.spec_from_file_location("check_source_id_corpus", _GUARD_PATH)
+assert _spec is not None and _spec.loader is not None
+guard = importlib.util.module_from_spec(_spec)
+# Register before exec: the module's frozen dataclass resolves its annotations
+# via sys.modules[__module__] at class-creation time (Python 3.14).
+sys.modules[_spec.name] = guard
+_spec.loader.exec_module(guard)
+
+
+def _scan(code: str) -> list:
+    return guard.scan_source(code, "<test>")
+
+
+# --- Real-tree regression gate ------------------------------------------------
+
+
+def test_live_parse_package_is_clean() -> None:
+    """Every current generate_source_id call-site in src/parse passes the guard."""
+    violations = guard.scan_tree(REPO_ROOT / "src" / "parse")
+    assert violations == [], "\n".join(str(v) for v in violations)
+
+
+def test_guard_actually_finds_the_call_sites() -> None:
+    """Sanity: the live scan is exercising real calls, not silently matching none.
+
+    Guards against a vacuous green (e.g. a refactor that renames the function and
+    makes the scan match nothing — which would also report zero violations).
+    """
+    found = False
+    for path in (REPO_ROOT / "src" / "parse").rglob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        if f"{guard.FUNC_NAME}(" in source and "def " + guard.FUNC_NAME not in source:
+            found = True
+            break
+    assert found, "expected at least one generate_source_id call-site in src/parse"
+
+
+# --- Accepted first-arg forms (no violation) ----------------------------------
+
+
+def test_valid_string_literal() -> None:
+    assert _scan('generate_source_id("lk", "bukhari", 1)') == []
+
+
+def test_valid_module_constant() -> None:
+    code = 'SOURCE_CORPUS = "fawaz"\ngenerate_source_id(SOURCE_CORPUS, "coll", 1)'
+    assert _scan(code) == []
+
+
+def test_valid_underscore_module_constant() -> None:
+    # sanadset.py uses a leading-underscore constant name.
+    code = '_SOURCE_CORPUS = "sanadset"\ngenerate_source_id(_SOURCE_CORPUS, "m", 1)'
+    assert _scan(code) == []
+
+
+def test_valid_enum_member_access() -> None:
+    assert _scan('generate_source_id(SourceCorpus.LK, "bukhari")') == []
+
+
+def test_valid_enum_member_value_access() -> None:
+    assert _scan('generate_source_id(SourceCorpus.SUNNAH.value, "muslim")') == []
+
+
+def test_valid_dotted_access_form() -> None:
+    # `base.generate_source_id(...)` — the dotted/attribute call form.
+    assert _scan('base.generate_source_id("thaqalayn", "kafi")') == []
+
+
+# --- Rejected first-arg forms (violation) -------------------------------------
+
+
+def test_invalid_string_literal_is_flagged() -> None:
+    # The exact da#89 shape: a bio source label, not a corpus.
+    violations = _scan('generate_source_id("kaggle_narrators", "x", 1)')
+    assert len(violations) == 1
+    assert "kaggle_narrators" in violations[0].reason
+
+
+def test_invalid_module_constant_is_flagged() -> None:
+    code = 'BIO_SOURCE = "kaggle_narrators"\ngenerate_source_id(BIO_SOURCE, "x")'
+    violations = _scan(code)
+    assert len(violations) == 1
+    assert "BIO_SOURCE" in violations[0].arg
+
+
+def test_unknown_enum_member_is_flagged() -> None:
+    violations = _scan('generate_source_id(SourceCorpus.BOGUS, "x")')
+    assert len(violations) == 1
+    assert "BOGUS" in violations[0].reason
+
+
+def test_dotted_access_form_invalid_corpus_is_flagged() -> None:
+    # The dotted form must be policed too, not only the bare form.
+    violations = _scan('base.generate_source_id("not_a_corpus", "x")')
+    assert len(violations) == 1
+
+
+def test_non_static_runtime_expression_is_flagged() -> None:
+    # A runtime expression (function call) cannot be statically proven corpus-safe.
+    code = "generate_source_id(pick_corpus(), 'x', 1)"
+    violations = _scan(code)
+    assert len(violations) == 1
+    assert "statically-verifiable" in violations[0].reason
+
+
+def test_undeclared_name_is_flagged() -> None:
+    # A Name with no module-level string-constant assignment.
+    violations = _scan('generate_source_id(MYSTERY, "x")')
+    assert len(violations) == 1
+    assert "does not resolve" in violations[0].reason
+
+
+def test_local_constant_does_not_count_as_module_constant() -> None:
+    # Deliberately not chased: a corpus rebound through a local (function-scope)
+    # variable reads as a non-static expression and is flagged (safe default).
+    code = "def f():\n    c = 'lk'\n    return generate_source_id(c, 'x')"
+    violations = _scan(code)
+    assert len(violations) == 1
+
+
+# --- CLI entry point ----------------------------------------------------------
+
+
+def test_main_returns_zero_on_clean_tree(capsys) -> None:
+    rc = guard.main(["src/parse"])
+    capsys.readouterr()
+    assert rc == 0
+
+
+def test_main_returns_one_on_dirty_file(tmp_path, capsys) -> None:
+    bad = tmp_path / "bad.py"
+    bad.write_text('generate_source_id("kaggle_narrators", "x")\n', encoding="utf-8")
+    rc = guard.main([str(bad)])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "FAIL" in err


### PR DESCRIPTION
Closes #113.

## What this catches

`generate_source_id()` fails fast on an unknown corpus, but only **at runtime** (when the real acquisition dir is present). A caller passing a non-corpus first arg — e.g. a free-text bio `source` label like `"kaggle_narrators"` — aborts the whole parse and is masked by unit tests that build no raw dir. That was the **da#89** sanadset crash. An AST sweep confirms the live blast radius is currently zero call-sites, but nothing prevented reintroduction.

This adds a static guard that asserts every `generate_source_id` call-site passes a statically-provable `SourceCorpus` first arg, catching the bug at **CI time** instead of at runtime parse.

## Changes

- **`scripts/check_source_id_corpus.py`** — standalone, importable AST guard + CLI (exit 1 on violation; defaults to scanning `src/parse`). The authoritative valid set is `SourceCorpus` itself (imported, not re-listed).
- **`tests/test_parse/test_source_id_corpus_guard.py`** — runs in CI's existing `Test` pytest job, so **no new CI job and no pre-commit ⇄ CI sync-drift entry is needed** (the gate rides a workflow already mirrored in `.pre-commit-config.yaml`; sync-drift gate verified green locally). Asserts the live `src/parse` tree is clean (with a non-vacuous-green sanity check) + positive/negative discrimination cases.
- **`src/parse/identity.py`** — doc note only (the canonical `source_id`-grammar home, per `base.py`'s docstring pointer): bio/`source` free-text keys build via `ID_DELIMITER.join(...)`, never `generate_source_id`. **Acceptance criterion #2.**

## Accepted first-arg forms
- string literal that is a `SourceCorpus` value (`"lk"`)
- module-level string constant resolving to one (`SOURCE_CORPUS = "fawaz"`, `_SOURCE_CORPUS = "sanadset"`)
- enum-member access `SourceCorpus.LK` / `SourceCorpus.LK.value`

Everything else (unknown literal/constant, unknown enum member, or a non-static runtime expression) is a violation.

## Access forms covered (lint-gate-cover-all-syntactic-forms)
- bare `generate_source_id(...)` after `from src.parse.base import generate_source_id`
- dotted `<module>.generate_source_id(...)` (e.g. `base.generate_source_id(...)`)

**Form deliberately not chased** (documented in the script): a corpus value rebound through a local (function-scope) variable or imported under an alias — it reads as a non-static expression and is flagged, which is the safe default.

## #81 sequencing note
This guard **reads** `src/parse/base.py` and `src/models/enums.py` via call-site analysis but does **not** edit either. The only `src/` change is a docstring note in `src/parse/identity.py`. If #81 changes `generate_source_id`'s signature or location, the guard's `FUNC_NAME`/scan may need a trivial rebase — but there is no code-line conflict with `base.py`/`enums.py`.

## Test Plan
- `python scripts/check_source_id_corpus.py` → `OK ([src/parse] clean)`, rc=0
- `ENVIRONMENT=test uv run pytest tests/test_parse/test_source_id_corpus_guard.py -q` → 17 passed
- `uv run ruff format --check` + `uv run ruff check src/ tests/` → clean
- `uv run mypy src/` → Success, no issues in 68 files
- `python3 .claude/lib/pre_commit_ci_sync.py . --ci .github/workflows/ci.yml` → OK (mirror intact)

Reviewers: @Jean-Claude Habimana (architect, primary) + @Oyunbileg Batbayar (QA, secondary).
