### PR TITLE
feat: multi-source ingestion framework + SourceCorpus registry (#81)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -115,6 +115,9 @@ muhaddithat
 thaqalayn
 riyadussalihin
 firstlight
+Shatha
+fawazahmed
+mhashim
 
 # --- Itqan rijal narrator source + jarh-wa-ta'dil vocabulary (da#92a — docs/itqan-narrators.md) ---
 itqan

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,0 +1,59 @@
+# Source adapters — data dictionary
+
+The set of hadith ingest sources is the single registry `SOURCE_REGISTRY` in
+[`src/adapters.py`](../src/adapters.py). This document is the human-readable view of
+that registry; the registry itself is authoritative (and `tests/test_adapters.py`
+fails CI if the two below ever disagree with the code). See
+[ADR-002](adr/002-multi-source-adapter-registry.md) for the design rationale.
+
+## The registry contract
+
+Every ingest source is one frozen `SourceAdapter` row declaring:
+
+| Field            | Meaning |
+|------------------|---------|
+| `slug`           | The adapter key. **Not always the corpus** — see `sunnah` vs `sunnah_scraped` below. |
+| `corpus`         | The `SourceCorpus` enum value that namespaces this source's `source_id` (collision-safe across sources — see [`src/parse/identity.py`](../src/parse/identity.py)). Several adapters MAY share one corpus. |
+| `sect`           | The declared `Sect` (`sunni` / `shia`), or **`None`** for a multi-sect source that tags `sect` per record in its parser. |
+| `acquire_module` / `acquire_fn` | Where the downloader lives under `src/acquire/`. Default fn `run(raw_dir) -> Path \| None`. |
+| `parse_module` / `parse_fn`     | Where the parser lives under `src/parse/`. Default fn `run(raw_dir, staging_dir) -> Path \| tuple \| list`. |
+| `raw_subdir`     | Per-source raw subdirectory passed to acquire/parse (only `sanadset` uses it). |
+| `reachable`      | Whether the source is fetchable in CI today (a `False` source is documented but not currently loadable — e.g. needs an API key). |
+| `license_note`   | Licensing / provenance note for the source. |
+| `description`    | One-line human description. |
+
+## Registered sources
+
+| slug | corpus | sect | reachable | source |
+|------|--------|------|-----------|--------|
+| `lk` | `lk` | sunni | yes | LK-Hadith-Corpus (ShathaTm) — 6 Sunni books, open GitHub CSV |
+| `sanadset` | `sanadset` | sunni | yes | Sanadset 650K (Mendeley) — 650,986 narrator records / 926 books |
+| `thaqalayn` | `thaqalayn` | **shia** | yes | ThaqalaynAPI (MohammedArab1) — the Four Books and more |
+| `fawaz` | `fawaz` | multi (`None`) | yes | fawazahmed0/hadith-api — multi-collection, sect per collection |
+| `sunnah` | `sunnah` | sunni | **no** | Sunnah.com REST API — gated on an API key (403 keyless, da#71) |
+| `sunnah_scraped` | `sunnah` | sunni | yes | Sunnah.com web scraper — keyless; shares the `sunnah` corpus with the API |
+| `open_hadith` | `open_hadith` | sunni | yes | Open-Hadith-Data (mhashim6) — 9 Sunni books incl. the Six Books |
+| `muhaddithat` | `muhaddithat` | multi (`None`) | yes | muhaddithat/isnad-datasets — female narrators across both traditions |
+| `itqan` | `itqan` | multi (`None`) | yes | Itqan rijal DB — 115,735 narrator profiles, 22 classical texts (no upstream license; owner-approved, da#92a) |
+
+Notes:
+
+- **`sunnah` + `sunnah_scraped` share `SourceCorpus.SUNNAH`** on purpose: the API
+  and the scraper describe the same collections, so a shared corpus namespace lets
+  the same hadith dedup to one graph node.
+- **Multi-sect sources (`sect = None`)** — `fawaz`, `muhaddithat`, `itqan` — span
+  both traditions; their parsers set `sect` per record rather than uniformly. They
+  contribute to *both* Sunni and Shia coverage in `adapters_for_sect`.
+
+## Adding a source
+
+1. Add a distinct value to `SourceCorpus` in [`src/models/enums.py`](../src/models/enums.py)
+   — the one shared registration surface, one non-overlapping value per source.
+2. Write `src/acquire/<slug>.py` (`run(raw_dir) -> Path | None`) and
+   `src/parse/<slug>.py` (`run(raw_dir, staging_dir) -> ...`), normalizing to the
+   canonical staging schemas in [`src/parse/schemas.py`](../src/parse/schemas.py)
+   and tagging `source_corpus` + `sect`.
+3. Add ONE `SourceAdapter` row to `SOURCE_REGISTRY` in `src/adapters.py`.
+
+The coverage invariant in `tests/test_adapters.py` fails CI if step 1 happens
+without step 3 (or vice versa), so the enum and the registry cannot drift.

--- a/docs/adr/002-multi-source-adapter-registry.md
+++ b/docs/adr/002-multi-source-adapter-registry.md
@@ -1,0 +1,101 @@
+# ADR-002: Multi-source adapter registry — one declared contract for ingest sources
+
+## Status: Accepted (P4W4, epic da#81)
+
+## Context
+
+`noorinalabs-data-acquisition` ingests hadith data from nine sources spanning two
+traditions (Sunni + Shia). Each source is implemented as a pair of modules — a
+downloader in `src/acquire/<slug>.py` (`run(raw_dir) -> Path | None`) and a parser
+in `src/parse/<slug>.py` (`run(raw_dir, staging_dir) -> Path | tuple | list`) —
+that normalize a disparate source schema into the canonical staging schemas
+(`src/parse/schemas.py`), tagged with `source_corpus` and `sect`. The shared
+acquisition/parse utilities (`src/acquire/base.py`, `src/parse/base.py`), the
+canonical identity grammar (`src/parse/identity.py`, da#82), and the provenance
+conformance gate (da#83) were each delivered in their own per-source light-up PRs.
+
+What was missing was a **single source of truth for the set of sources itself.**
+Two facts were spread across the codebase and could silently drift:
+
+1. **The source list was duplicated.** `src/acquire/__init__.py` and
+   `src/parse/__init__.py` each hand-maintained a parallel `SOURCES` / `PARSERS`
+   list of `(name, module)` tuples that had to be kept in lockstep — add a source
+   and you had to remember to edit both, in the same order, or the acquire and
+   parse phases would disagree on which sources exist.
+2. **`sect` was an undeclared, scattered literal.** Each parser hardcoded its sect
+   (`SECT = "sunni"`, an inline `"sect": "sunni"`, or — for multi-sect sources —
+   tagged it per record). There was no one place that declared *this source is
+   Sunni / Shia / multi-sect*, nor a machine-checkable link between that fact and
+   the `SourceCorpus` enum that namespaces its ids.
+
+The `SourceCorpus` enum (`src/models/enums.py`) is the one shared registration
+surface — every source adds exactly one non-overlapping value — but nothing
+enforced that a new enum value actually had a working adapter behind it, or that an
+adapter named a real corpus.
+
+## Decision
+
+Introduce **`src/adapters.py`**: a single registry, `SOURCE_REGISTRY`, of frozen
+`SourceAdapter` rows. Each row is pure data — it declares the source's `slug`,
+`corpus` (`SourceCorpus`), `sect` (`Sect`, or `None` for a multi-sect source that
+tags `sect` per record), where its acquire/parse code lives (`acquire_module` /
+`parse_module` and the function names), its `reachable` flag, and a `license_note`
++ `description`. The acquire/parse entry points are resolved **lazily** on call
+(deferred `import_module`), because `src/adapters.py` is imported *by*
+`src/acquire/__init__.py` and `src/parse/__init__.py` and importing their
+submodules eagerly would form a package-init cycle.
+
+Consequences of the decision:
+
+- **The two orchestrators derive from the registry.** `src.acquire.run_all` and
+  `src.parse.run_all` iterate `SOURCE_REGISTRY` instead of a private list. The
+  duplicated `SOURCES` / `PARSERS` lists are deleted. `run_all` signatures are
+  unchanged, so `src/cli.py` and every existing test are unaffected.
+- **`slug` is the key, not `corpus`.** `sunnah` (the REST API) and `sunnah_scraped`
+  (the web scraper) deliberately share `SourceCorpus.SUNNAH` so the same hadith
+  dedups to one graph node (`src/parse/identity.py`); the registry therefore keys
+  by slug and lets several adapters map to one corpus.
+- **A coverage invariant enforces the enum ⇄ registry link.**
+  `tests/test_adapters.py` asserts `covered_corpora() == set(SourceCorpus)` — CI
+  fails if a `SourceCorpus` value is added without an adapter, or an adapter names
+  an unknown corpus. A second test asserts the registry's declared `sect` agrees
+  with any parser-level `SECT` constant, so the two cannot diverge.
+- **Adding a source is a three-step, mechanically-checked pattern** (see the
+  `src/adapters.py` module docstring and `docs/adapters.md`): add the
+  `SourceCorpus` value, write the two modules, add one `SourceAdapter` row.
+
+This ADR does **not** re-implement any acquire/parse/identity/schema code that the
+per-source PRs already delivered; it ratifies the framework by giving it a single,
+declared, enforced registration contract — the capstone of epic da#81.
+
+## Consequences
+
+**Positive**
+
+- One edit site to add/remove a source; acquire and parse can no longer drift.
+- `sect`, reachability, and licensing provenance become queryable data
+  (`adapters_for_sect`, `get_adapter`, `covered_corpora`) rather than tribal
+  knowledge — directly serving da#81's "tag every record with `source_corpus` +
+  `sect` consistently" requirement.
+- A new `SourceCorpus` value without a working adapter is now a red build, not a
+  silent runtime gap.
+
+**Negative / trade-offs**
+
+- The acquire/parse entry points are resolved by string module names rather than
+  direct references, so a typo in `acquire_module` surfaces at call time (mitigated
+  by `tests/test_adapters.py::TestEntryPoints`, which imports and arity-checks every
+  declared entry point without invoking it).
+- Parsers still carry their own `SECT` constants for now; the registry is the new
+  source of truth and the agreement test guards drift, but a follow-up could have
+  the parsers import their sect from the registry to remove the remaining
+  duplication entirely.
+
+## Related
+
+- Epic da#81 — multi-source hadith ingestion (Sunni + Shia) with cross-source
+  transform/normalization.
+- da#82 — canonical `source_id` / identity grammar (`src/parse/identity.py`).
+- da#83 — provenance conformance gate (`src/parse/base.py::provenance_violations`).
+- `docs/adapters.md` — the per-source data dictionary generated from this registry's
+  shape.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,3 +4,4 @@ We use Michael Nygard's ADR format. Each decision gets a numbered file.
 
 ## Index
 - [ADR-001](001-local-hook-policy-dispatcher-style.md) — Local hook policy: data-acquisition stays dispatcher-style
+- [ADR-002](002-multi-source-adapter-registry.md) — Multi-source adapter registry: one declared contract for ingest sources

--- a/src/acquire/__init__.py
+++ b/src/acquire/__init__.py
@@ -3,58 +3,30 @@
 This package contains source-specific downloaders that fetch raw data from
 CSV files, JSON APIs, Kaggle datasets, and Git repositories into ``data/raw/``.
 Shared HTTP/download/clone utilities live in ``base.py``.
+
+The set of sources and their run order is the single registry in
+:mod:`src.adapters` (epic da#81); :func:`run_all` just iterates it, so this module
+and :mod:`src.parse` can no longer drift on which sources exist.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from types import ModuleType
 
-from src.acquire import (
-    fawaz,
-    itqan,
-    lk_corpus,
-    muhaddithat,
-    open_hadith,
-    sunnah_api,
-    sunnah_scraper,
-    thaqalayn,
-)
-from src.acquire.sanadset import download_sanadset
+from src.adapters import SOURCE_REGISTRY
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
-
-# Each entry is (name, module_or_none).
-# Most modules expose ``run(raw_dir)``; sanadset (None) is handled separately.
-SOURCES: list[tuple[str, ModuleType | None]] = [
-    ("lk", lk_corpus),
-    ("sanadset", None),
-    ("thaqalayn", thaqalayn),
-    ("fawaz", fawaz),
-    ("sunnah", sunnah_api),
-    ("sunnah_scraped", sunnah_scraper),
-    ("open_hadith", open_hadith),
-    ("muhaddithat", muhaddithat),
-    ("itqan", itqan),
-]
-
-
-def _acquire_one(name: str, module: ModuleType | None, raw_dir: Path) -> Path | None:
-    """Run a single downloader, returning its output path."""
-    if name == "sanadset":
-        return download_sanadset(raw_dir / "sanadset")
-    assert module is not None
-    return module.run(raw_dir)  # type: ignore[no-any-return]
 
 
 def run_all(raw_dir: Path) -> dict[str, Path | None]:
     """Run all downloaders. Continue on failure. Return dict of source -> path."""
     results: dict[str, Path | None] = {}
-    for name, module in SOURCES:
+    for adapter in SOURCE_REGISTRY:
+        name = adapter.slug
         try:
             logger.info("acquiring", source=name)
-            path = _acquire_one(name, module, raw_dir)
+            path = adapter.acquire(raw_dir)
             results[name] = path
             logger.info("acquired", source=name, path=str(path) if path else "skipped")
         except Exception as exc:  # noqa: BLE001

--- a/src/adapters.py
+++ b/src/adapters.py
@@ -1,0 +1,270 @@
+"""Multi-source adapter registry — the single source of truth for ingest sources.
+
+This module is the capstone of epic da#81 (multi-source hadith ingestion, Sunni +
+Shia). The per-source acquire/parse modules, the shared base utilities
+(:mod:`src.acquire.base` / :mod:`src.parse.base`), the staging schemas
+(:mod:`src.parse.schemas`) and the canonical identity contract
+(:mod:`src.parse.identity`) were each delivered in their own per-source light-up
+PRs. What was missing — and what this module provides — is the *registry* that
+binds them into one declared, enforceable contract:
+
+* every ingest source is one :class:`SourceAdapter` row in :data:`SOURCE_REGISTRY`;
+* each row declares its ``corpus`` (the :class:`~src.models.enums.SourceCorpus`
+  namespace that keeps ``source_id`` collision-safe — see
+  :mod:`src.parse.identity`), its ``sect`` (a :class:`~src.models.enums.Sect`, or
+  ``None`` for a multi-sect source that tags ``sect`` per record), where its
+  acquire/parse code lives, and its reachability + licensing provenance;
+* the package orchestrators (:func:`src.acquire.run_all` / :func:`src.parse.run_all`)
+  DERIVE their run order from this one list instead of each hand-maintaining a
+  parallel ``SOURCES`` / ``PARSERS`` copy that had to be kept in lockstep.
+
+Adding a source (the pattern every per-source PR follows)::
+
+    1. add a distinct value to ``SourceCorpus`` in ``src.models.enums`` — the ONE
+       shared registration surface, one non-overlapping value per source;
+    2. write ``src/acquire/<slug>.py`` (``run(raw_dir) -> Path | None``) and
+       ``src/parse/<slug>.py`` (``run(raw_dir, staging_dir) -> Path | tuple | list``);
+    3. add ONE ``SourceAdapter`` row here.
+
+The coverage invariant in ``tests/test_adapters.py`` fails CI if a ``SourceCorpus``
+value has no adapter, so step 1 cannot silently drift from step 3.
+
+The registry is pure data: a ``SourceAdapter`` stores *where* its code lives
+(``acquire_module`` / ``parse_module`` / fn names) and resolves it lazily on call.
+The deferred import is deliberate — this module is imported BY ``src.acquire`` and
+``src.parse`` ``__init__``, so importing their submodules at module load would form
+a package-init cycle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from pathlib import Path
+
+from src.models.enums import Sect, SourceCorpus
+
+__all__ = [
+    "ParseOutput",
+    "SourceAdapter",
+    "SOURCE_REGISTRY",
+    "adapter_slugs",
+    "get_adapter",
+    "iter_adapters",
+    "adapters_for_corpus",
+    "adapters_for_sect",
+    "covered_corpora",
+]
+
+# A parser's ``run`` may return a single Path, a tuple/list of Paths, or a dict of
+# them; ``src.parse.run_all`` flattens this via ``_normalize_output``.
+ParseOutput = Path | tuple[Path, ...] | list[Path] | dict[str, Path]
+
+
+@dataclass(frozen=True)
+class SourceAdapter:
+    """One ingest source: its corpus namespace, declared sect, code location, and
+    reachability + licensing provenance.
+
+    ``slug`` is the adapter key (e.g. ``"sunnah_scraped"``), and is NOT always the
+    corpus: ``sunnah`` (the REST API) and ``sunnah_scraped`` (the web scraper)
+    deliberately share :attr:`SourceCorpus.SUNNAH` so the same hadith dedups to one
+    graph node (see :mod:`src.parse.identity`). The registry is therefore keyed by
+    slug and carries ``corpus`` as a field — several adapters MAY map to one corpus.
+
+    ``sect`` is the source's declared sect, or ``None`` for a multi-sect source
+    (``fawaz`` spans collections, ``muhaddithat`` + ``itqan`` cover both traditions)
+    whose parser tags ``sect`` per record rather than uniformly.
+
+    The acquire/parse entry points are addressed by module + function name and
+    resolved lazily in :meth:`acquire` / :meth:`parse`. ``raw_subdir`` handles the
+    one source (sanadset) whose downloader/parser are invoked on a per-source
+    subdirectory of ``raw_dir`` rather than ``raw_dir`` itself.
+    """
+
+    slug: str
+    corpus: SourceCorpus
+    sect: Sect | None
+    acquire_module: str
+    parse_module: str
+    reachable: bool
+    license_note: str
+    description: str
+    acquire_fn: str = "run"
+    parse_fn: str = "run"
+    raw_subdir: str | None = None
+
+    def acquire(self, raw_dir: Path) -> Path | None:
+        """Download this source's raw data, returning its output path (or ``None``)."""
+        target = raw_dir / self.raw_subdir if self.raw_subdir else raw_dir
+        fn = getattr(import_module(f"src.acquire.{self.acquire_module}"), self.acquire_fn)
+        result: Path | None = fn(target)
+        return result
+
+    def parse(self, raw_dir: Path, staging_dir: Path) -> ParseOutput:
+        """Parse this source's raw data into staging Parquet under *staging_dir*."""
+        source = raw_dir / self.raw_subdir if self.raw_subdir else raw_dir
+        fn = getattr(import_module(f"src.parse.{self.parse_module}"), self.parse_fn)
+        result: ParseOutput = fn(source, staging_dir)
+        return result
+
+
+# The canonical run order. Keep this list and ``SourceCorpus`` mutually exhaustive
+# (the coverage invariant in tests/test_adapters.py enforces it).
+SOURCE_REGISTRY: tuple[SourceAdapter, ...] = (
+    SourceAdapter(
+        slug="lk",
+        corpus=SourceCorpus.LK,
+        sect=Sect.SUNNI,
+        acquire_module="lk_corpus",
+        parse_module="lk_corpus",
+        reachable=True,
+        license_note="LK-Hadith-Corpus (ShathaTm) — open GitHub CSV, 6 books.",
+        description="LK-Hadith-Corpus — 6 Sunni books, English + Arabic.",
+    ),
+    SourceAdapter(
+        slug="sanadset",
+        corpus=SourceCorpus.SANADSET,
+        sect=Sect.SUNNI,
+        acquire_module="sanadset",
+        parse_module="sanadset",
+        acquire_fn="download_sanadset",
+        parse_fn="parse_sanadset",
+        raw_subdir="sanadset",
+        reachable=True,
+        license_note="Sanadset 650K (Mendeley 5xth87zwb5) — open dataset.",
+        description="Sanadset 650K — 650,986 narrator records / 926 books (Sunni-heavy).",
+    ),
+    SourceAdapter(
+        slug="thaqalayn",
+        corpus=SourceCorpus.THAQALAYN,
+        sect=Sect.SHIA,
+        acquire_module="thaqalayn",
+        parse_module="thaqalayn",
+        reachable=True,
+        license_note="ThaqalaynAPI (MohammedArab1) — open GitHub / REST.",
+        description="ThaqalaynAPI — the Four Books and more (Shia).",
+    ),
+    SourceAdapter(
+        slug="fawaz",
+        corpus=SourceCorpus.FAWAZ,
+        sect=None,
+        acquire_module="fawaz",
+        parse_module="fawaz",
+        reachable=True,
+        license_note="fawazahmed0/hadith-api — open, served via jsDelivr.",
+        description="fawazahmed0/hadith-api — multi-collection; sect tagged per collection.",
+    ),
+    SourceAdapter(
+        slug="sunnah",
+        corpus=SourceCorpus.SUNNAH,
+        sect=Sect.SUNNI,
+        acquire_module="sunnah_api",
+        parse_module="sunnah_api",
+        reachable=False,
+        license_note=(
+            "Sunnah.com API (api.sunnah.com/v1) — requires an API key; 403 keyless "
+            "(da#71, never granted)."
+        ),
+        description="Sunnah.com REST API — Sunni collections (gated on an API key).",
+    ),
+    SourceAdapter(
+        slug="sunnah_scraped",
+        corpus=SourceCorpus.SUNNAH,
+        sect=Sect.SUNNI,
+        acquire_module="sunnah_scraper",
+        parse_module="sunnah_scraped",
+        reachable=True,
+        license_note=(
+            "Sunnah.com public web pages — keyless scrape; shares the 'sunnah' corpus "
+            "with the API so the same hadith dedups to one node."
+        ),
+        description="Sunnah.com web scraper — keyless Sunni first-light source.",
+    ),
+    SourceAdapter(
+        slug="open_hadith",
+        corpus=SourceCorpus.OPEN_HADITH,
+        sect=Sect.SUNNI,
+        acquire_module="open_hadith",
+        parse_module="open_hadith",
+        reachable=True,
+        license_note="Open-Hadith-Data (mhashim6) — open GitHub, 9 books incl. the Six Books.",
+        description="Open-Hadith-Data — 9 Sunni books.",
+    ),
+    SourceAdapter(
+        slug="muhaddithat",
+        corpus=SourceCorpus.MUHADDITHAT,
+        sect=None,
+        acquire_module="muhaddithat",
+        parse_module="muhaddithat",
+        reachable=True,
+        license_note="muhaddithat/isnad-datasets — open GitHub CSV.",
+        description="muhaddithat — female narrators across both traditions; sect per record.",
+    ),
+    SourceAdapter(
+        slug="itqan",
+        corpus=SourceCorpus.ITQAN,
+        sect=None,
+        acquire_module="itqan",
+        parse_module="itqan",
+        reachable=True,
+        license_note=(
+            "Itqan (github R3GENESI5/Itqan) — NO upstream license. Owner-approved for "
+            "use (da#92a): non-profit, facts re-expressed in our own schema, cleanly "
+            "removable via source_corpus='itqan' provenance."
+        ),
+        description="Itqan rijal DB — 115,735 narrator profiles from 22 classical texts.",
+    ),
+)
+
+
+def _check_registry_integrity() -> None:
+    """Fail fast at import on a malformed registry (duplicate slug)."""
+    seen: set[str] = set()
+    for adapter in SOURCE_REGISTRY:
+        if adapter.slug in seen:
+            msg = f"duplicate adapter slug in SOURCE_REGISTRY: {adapter.slug!r}"
+            raise ValueError(msg)
+        seen.add(adapter.slug)
+
+
+_check_registry_integrity()
+
+
+def iter_adapters() -> tuple[SourceAdapter, ...]:
+    """All registered adapters, in canonical run order."""
+    return SOURCE_REGISTRY
+
+
+def adapter_slugs() -> list[str]:
+    """Slugs of all registered adapters, in run order."""
+    return [adapter.slug for adapter in SOURCE_REGISTRY]
+
+
+def get_adapter(slug: str) -> SourceAdapter:
+    """Return the adapter registered under *slug*, or raise :class:`KeyError`."""
+    for adapter in SOURCE_REGISTRY:
+        if adapter.slug == slug:
+            return adapter
+    msg = f"no adapter registered with slug {slug!r}; known slugs: {adapter_slugs()}"
+    raise KeyError(msg)
+
+
+def adapters_for_corpus(corpus: SourceCorpus) -> list[SourceAdapter]:
+    """Adapters whose data lands in *corpus* (usually one; two for ``SUNNAH``)."""
+    return [adapter for adapter in SOURCE_REGISTRY if adapter.corpus == corpus]
+
+
+def adapters_for_sect(sect: Sect) -> list[SourceAdapter]:
+    """Adapters that emit records for *sect*.
+
+    Includes adapters that declare *sect* outright, plus multi-sect adapters
+    (``sect is None``) that tag ``sect`` per record and so contribute to every
+    sect's coverage.
+    """
+    return [adapter for adapter in SOURCE_REGISTRY if adapter.sect is sect or adapter.sect is None]
+
+
+def covered_corpora() -> set[SourceCorpus]:
+    """The set of :class:`SourceCorpus` values that have at least one adapter."""
+    return {adapter.corpus for adapter in SOURCE_REGISTRY}

--- a/src/parse/__init__.py
+++ b/src/parse/__init__.py
@@ -1,39 +1,21 @@
-"""Phase 1: Parsers producing normalized Parquet from raw data."""
+"""Phase 1: Parsers producing normalized Parquet from raw data.
+
+The set of sources and their run order is the single registry in
+:mod:`src.adapters` (epic da#81); :func:`run_all` iterates it, so the parse and
+acquire orchestrators can no longer drift on which sources exist.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
-from types import ModuleType
 
-from src.parse import (
-    fawaz,
-    itqan,
-    lk_corpus,
-    muhaddithat,
-    open_hadith,
-    sunnah_api,
-    sunnah_scraped,
-    thaqalayn,
-)
-from src.parse.sanadset import parse_sanadset
+from src.adapters import SOURCE_REGISTRY, ParseOutput
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-PARSERS: list[tuple[str, ModuleType | None]] = [
-    ("lk", lk_corpus),
-    ("sanadset", None),
-    ("thaqalayn", thaqalayn),
-    ("fawaz", fawaz),
-    ("sunnah", sunnah_api),
-    ("sunnah_scraped", sunnah_scraped),
-    ("open_hadith", open_hadith),
-    ("muhaddithat", muhaddithat),
-    ("itqan", itqan),
-]
 
-
-def _normalize_output(result: Path | tuple[Path, ...] | list[Path] | dict[str, Path]) -> list[Path]:
+def _normalize_output(result: ParseOutput) -> list[Path]:
     """Normalize parser return values to a flat list of Paths."""
     if isinstance(result, dict):
         return list(result.values())
@@ -44,23 +26,14 @@ def _normalize_output(result: Path | tuple[Path, ...] | list[Path] | dict[str, P
     return [result]
 
 
-def _parse_one(
-    name: str, module: ModuleType | None, raw_dir: Path, staging_dir: Path
-) -> list[Path]:
-    """Run a single parser, returning its output files as a list."""
-    if name == "sanadset":
-        return _normalize_output(parse_sanadset(raw_dir / "sanadset", staging_dir))
-    assert module is not None
-    return _normalize_output(module.run(raw_dir, staging_dir))
-
-
 def run_all(raw_dir: Path, staging_dir: Path) -> dict[str, list[Path]]:
     """Run all parsers. Continue on failure. Return dict of source -> output files."""
     results: dict[str, list[Path]] = {}
-    for name, module in PARSERS:
+    for adapter in SOURCE_REGISTRY:
+        name = adapter.slug
         try:
             logger.info("parsing", source=name)
-            output_files = _parse_one(name, module, raw_dir, staging_dir)
+            output_files = _normalize_output(adapter.parse(raw_dir, staging_dir))
             results[name] = output_files
             logger.info("parsed", source=name, files=len(output_files))
         except Exception as exc:  # noqa: BLE001

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,175 @@
+"""Tests for the multi-source adapter registry (epic da#81).
+
+The headline test is :meth:`TestCoverageInvariant.test_every_corpus_has_an_adapter`
+— it fails CI if a ``SourceCorpus`` value is added without a matching adapter (or
+vice versa), which is the enforcement that keeps the registry and the enum from
+drifting as new sources are lit up.
+"""
+
+from __future__ import annotations
+
+import inspect
+from importlib import import_module
+
+import pytest
+
+from src.adapters import (
+    SOURCE_REGISTRY,
+    SourceAdapter,
+    adapter_slugs,
+    adapters_for_corpus,
+    adapters_for_sect,
+    covered_corpora,
+    get_adapter,
+    iter_adapters,
+)
+from src.models.enums import Sect, SourceCorpus
+
+# The canonical run order. Pinning it here documents the contract and guards
+# against an accidental reorder/drop in a future light-up PR.
+EXPECTED_SLUGS = [
+    "lk",
+    "sanadset",
+    "thaqalayn",
+    "fawaz",
+    "sunnah",
+    "sunnah_scraped",
+    "open_hadith",
+    "muhaddithat",
+    "itqan",
+]
+
+
+class TestCoverageInvariant:
+    """Every SourceCorpus must be covered by an adapter, and vice versa."""
+
+    def test_every_corpus_has_an_adapter(self) -> None:
+        # If this fails, a SourceCorpus value was added without registering an
+        # adapter in src/adapters.py (or an adapter names an unknown corpus).
+        assert covered_corpora() == set(SourceCorpus)
+
+    def test_every_adapter_corpus_is_a_known_enum_value(self) -> None:
+        for adapter in SOURCE_REGISTRY:
+            assert adapter.corpus in SourceCorpus
+
+    def test_slugs_are_unique(self) -> None:
+        slugs = adapter_slugs()
+        assert len(slugs) == len(set(slugs))
+
+    def test_canonical_run_order(self) -> None:
+        assert adapter_slugs() == EXPECTED_SLUGS
+
+
+class TestSharedCorpus:
+    """Two adapters intentionally share the SUNNAH corpus (API + scraper)."""
+
+    def test_sunnah_corpus_has_two_adapters(self) -> None:
+        slugs = {a.slug for a in adapters_for_corpus(SourceCorpus.SUNNAH)}
+        assert slugs == {"sunnah", "sunnah_scraped"}
+
+    def test_other_corpora_have_exactly_one_adapter(self) -> None:
+        for corpus in SourceCorpus:
+            if corpus is SourceCorpus.SUNNAH:
+                continue
+            assert len(adapters_for_corpus(corpus)) == 1
+
+
+class TestSect:
+    """Sect declarations and the multi-sect (None) convention."""
+
+    def test_multi_sect_sources_declare_none(self) -> None:
+        none_sect = {a.slug for a in SOURCE_REGISTRY if a.sect is None}
+        assert none_sect == {"fawaz", "muhaddithat", "itqan"}
+
+    def test_at_least_one_reachable_sunni_and_one_reachable_shia(self) -> None:
+        # da#81 acceptance: >=1 Sunni + >=1 Shia source must be loadable.
+        reachable_sunni = [
+            a for a in adapters_for_sect(Sect.SUNNI) if a.reachable and a.sect is Sect.SUNNI
+        ]
+        reachable_shia = [
+            a for a in adapters_for_sect(Sect.SHIA) if a.reachable and a.sect is Sect.SHIA
+        ]
+        assert reachable_sunni, "no reachable Sunni source"
+        assert reachable_shia, "no reachable Shia source"
+
+    def test_adapters_for_sect_includes_multi_sect_sources(self) -> None:
+        # A multi-sect (None) source contributes to every sect's coverage.
+        for sect in Sect:
+            covered = adapters_for_sect(sect)
+            assert all(a.sect is sect or a.sect is None for a in covered)
+            assert any(a.sect is None for a in covered)
+
+    def test_declared_sect_agrees_with_parser_constant(self) -> None:
+        # Where a parser hardcodes a module-level SECT constant, the registry's
+        # declared sect must match it — so the registry is the single source of
+        # truth and the two cannot silently diverge.
+        for adapter in SOURCE_REGISTRY:
+            module = import_module(f"src.parse.{adapter.parse_module}")
+            parser_sect = getattr(module, "SECT", None)
+            if parser_sect is None:
+                continue
+            assert adapter.sect is not None, (
+                f"{adapter.slug}: parser declares SECT={parser_sect!r} but registry sect is None"
+            )
+            assert adapter.sect.value == parser_sect, (
+                f"{adapter.slug}: registry {adapter.sect.value!r} != parser SECT {parser_sect!r}"
+            )
+
+
+class TestLookups:
+    """Registry accessor helpers."""
+
+    def test_get_adapter_returns_matching_row(self) -> None:
+        adapter = get_adapter("thaqalayn")
+        assert adapter.slug == "thaqalayn"
+        assert adapter.corpus is SourceCorpus.THAQALAYN
+        assert adapter.sect is Sect.SHIA
+
+    def test_get_adapter_unknown_raises_keyerror(self) -> None:
+        with pytest.raises(KeyError):
+            get_adapter("does_not_exist")
+
+    def test_iter_adapters_matches_registry(self) -> None:
+        assert iter_adapters() == SOURCE_REGISTRY
+
+
+class TestEntryPoints:
+    """The acquire/parse entry points each adapter declares actually exist with a
+    callable of the right arity — without invoking them (no network/IO)."""
+
+    def test_acquire_target_is_callable_with_one_arg(self) -> None:
+        for adapter in SOURCE_REGISTRY:
+            module = import_module(f"src.acquire.{adapter.acquire_module}")
+            fn = getattr(module, adapter.acquire_fn)
+            assert callable(fn)
+            params = inspect.signature(fn).parameters
+            assert len(params) >= 1, f"{adapter.slug}: acquire fn takes no args"
+
+    def test_parse_target_is_callable_with_two_args(self) -> None:
+        for adapter in SOURCE_REGISTRY:
+            module = import_module(f"src.parse.{adapter.parse_module}")
+            fn = getattr(module, adapter.parse_fn)
+            assert callable(fn)
+            params = inspect.signature(fn).parameters
+            assert len(params) >= 2, f"{adapter.slug}: parse fn takes < 2 args"
+
+    def test_adapter_is_frozen(self) -> None:
+        adapter = SOURCE_REGISTRY[0]
+        with pytest.raises(Exception):  # noqa: B017 — FrozenInstanceError
+            adapter.slug = "mutated"  # type: ignore[misc]
+
+
+class TestRunAllDerivesFromRegistry:
+    """The acquire/parse orchestrators must iterate the registry, not a private list."""
+
+    def test_acquire_run_all_uses_registry(self) -> None:
+        source = inspect.getsource(import_module("src.acquire").run_all)
+        assert "SOURCE_REGISTRY" in source
+
+    def test_parse_run_all_uses_registry(self) -> None:
+        source = inspect.getsource(import_module("src.parse").run_all)
+        assert "SOURCE_REGISTRY" in source
+
+
+def test_source_adapter_is_dataclass_instance() -> None:
+    assert all(isinstance(a, SourceAdapter) for a in SOURCE_REGISTRY)


### PR DESCRIPTION
Closes #81

## What this is

The capstone of epic da#81 (multi-source hadith ingestion, Sunni + Shia). **The framework the issue asked me to build already exists** on the wave-4 base — the per-source acquire/parse modules, shared base utilities (`src/acquire/base.py`, `src/parse/base.py`), staging schemas (`src/parse/schemas.py`), the canonical identity grammar (`src/parse/identity.py`, da#82), the provenance conformance gate (da#83), and all 9 adapters including Itqan. `SourceCorpus` already carries every value.

What was **missing** — and what this PR adds — is the single source-of-truth *registry* that binds them into one declared, enforced contract.

## The gap this closes

Two facts could silently drift:

1. **The source list was duplicated.** `src/acquire/__init__.py` and `src/parse/__init__.py` each hand-maintained a parallel `SOURCES` / `PARSERS` list that had to be kept in lockstep.
2. **`sect` was an undeclared, scattered literal** — each parser hardcoded its sect with no one place declaring *this source is Sunni / Shia / multi-sect*, and no machine-checkable link to the `SourceCorpus` enum.

## The framework contract (how adapters plug in)

`src/adapters.py` → `SOURCE_REGISTRY`: a tuple of frozen `SourceAdapter` rows. Each row is pure data — `slug`, `corpus` (`SourceCorpus`), `sect` (`Sect` or `None` for a per-record multi-sect source), where its acquire/parse code lives, `reachable`, `license_note`, `description`. Entry points resolve **lazily** (deferred `import_module`) to avoid a package-init cycle.

Adding a source is a three-step, mechanically-checked pattern:
1. add a distinct value to `SourceCorpus` in `src/models/enums.py` — the one shared registration surface, one non-overlapping value per source;
2. write `src/acquire/<slug>.py` (`run(raw_dir)`) + `src/parse/<slug>.py` (`run(raw_dir, staging_dir)`);
3. add ONE `SourceAdapter` row.

`src.acquire.run_all` / `src.parse.run_all` now **derive** their run order from the registry (the two duplicated lists are deleted; `run_all` signatures unchanged, so `cli.py` and every existing test are unaffected).

## Enforcement

`tests/test_adapters.py` asserts:
- **coverage invariant** — `covered_corpora() == set(SourceCorpus)`; CI fails if a `SourceCorpus` value is added without an adapter (or an adapter names an unknown corpus). This is what makes "one non-overlapping `SourceCorpus` value per source" a red-build guarantee rather than tribal knowledge.
- registry `sect` agrees with any parser-level `SECT` constant (no silent divergence);
- `sunnah` + `sunnah_scraped` share `SourceCorpus.SUNNAH` on purpose (same hadith dedups to one node);
- every declared acquire/parse entry point exists with the right arity (imported, not invoked — no network/IO);
- ≥1 reachable Sunni + ≥1 reachable Shia source (da#81 acceptance).

## Shared files touched (for serial-merge sequencing)

- **NEW** `src/adapters.py`, `tests/test_adapters.py`, `docs/adapters.md`, `docs/adr/002-multi-source-adapter-registry.md`
- **MODIFY** `src/acquire/__init__.py`, `src/parse/__init__.py` (derive from registry — additive; same public `run_all`), `docs/adr/README.md` (index)
- **Does NOT touch** `src/models/enums.py` or `src/parse/base.py` — no conflict with the per-source adapter PRs, da#82, or da#113.

## Test Plan

- `tests/test_adapters.py` — 19 tests, all green.
- Full non-integration suite: **662 passed, 3 skipped** (confirms the `run_all` refactor breaks nothing — incl. `test_messaging` acquire wire-ins and `test_pipeline`).
- `ruff format --check` + `ruff check` clean; `mypy` clean on the three `src/` files.

Reviewers: @Dilara Erdogan (primary), @Kwesi Boateng (secondary).
