### PR TITLE
tech-debt(resolve): reconcile narrators_canonical.parquet staging/curated location (#112)

### DIFF
--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -4,6 +4,25 @@ Batch UNWIND+MERGE loaders for Narrator, Hadith, Collection, Chain,
 Grading, HistoricalEvent, and Location nodes.  Each loader reads from
 staging/curated Parquet or YAML, validates rows, and merges into Neo4j
 with explicit property SET (no ``SET n += row``) for Phase 4 safety.
+
+Artifact-location contract (resolve -> load)
+--------------------------------------------
+Inputs split by *kind*, not by which loader consumes them:
+
+* **staging dir** — raw, per-source parse outputs and resolve intermediates:
+  ``hadiths_*``, ``collections_*``, ``narrator_mentions_*`` (Chain source),
+  ``parallel_links``. These are the parse/resolve *working* artifacts.
+* **curated dir** — the curated, resolved master tables and hand-maintained
+  reference data: ``narrators_canonical.parquet`` (the canonical narrator
+  master produced by the resolve stage), plus ``historical_events.yaml`` and
+  ``locations.yaml``.
+
+``narrators_canonical.parquet`` is the canonical narrator master *written by
+the resolve stage* — ``disambiguate.run`` and ``bio_promote`` both emit it into
+the resolve ``output_dir``, which ``src/cli.py`` maps to ``DATA_CURATED_DIR``.
+The loader therefore reads it from ``curated_dir`` so writer and reader agree on
+one location (da#112). It is NOT a raw staging intermediate like
+``narrator_mentions_*`` (those stay in staging, read by the Chain loader).
 """
 
 from __future__ import annotations
@@ -93,8 +112,14 @@ def _load_narrators(
     strict: bool = True,
     skip_files: list[str] | None = None,
 ) -> LoadResult:
-    """Load Narrator nodes from narrators_canonical.parquet."""
-    path = staging_dir / "narrators_canonical.parquet"
+    """Load Narrator nodes from narrators_canonical.parquet.
+
+    Reads from ``curated_dir`` — the canonical narrator master is a resolve-stage
+    *output* (written by ``disambiguate.run`` / ``bio_promote`` into the resolve
+    ``output_dir``, which the CLI maps to ``DATA_CURATED_DIR``), not a raw
+    staging intermediate. See the module-level artifact-location contract (da#112).
+    """
+    path = curated_dir / "narrators_canonical.parquet"
     if _should_skip_file(path, staging_dir, skip_files):
         logger.info("narrators_skipped_incremental")
         return LoadResult("Narrator", 0, 0, 0)

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -73,7 +73,11 @@ def promote_bios_to_canonical(
     Args:
         staging_dir: directory holding ``narrators_bio_*.parquet`` files.
         output_dir: directory the canonical Parquet is written to (and read from
-            when merging into a pre-existing file).
+            when merging into a pre-existing file). This is the resolve stage's
+            ``output_dir`` — the same curated location the graph loader reads
+            ``narrators_canonical.parquet`` from (the CLI maps it to
+            ``DATA_CURATED_DIR``; see ``load_nodes`` artifact-location contract,
+            da#112). Point it at the *curated* dir, never staging.
         sources: if given, only bios whose ``source`` column is in this set are
             promoted (e.g. ``{"itqan"}``).
 

--- a/tests/integration/test_cross_source_resolution.py
+++ b/tests/integration/test_cross_source_resolution.py
@@ -106,8 +106,10 @@ class TestCrossSourceResolutionLive:
         assert canonical_tbl.num_rows == _EXPECTED_CANONICAL
         assert canonical_tbl.num_rows < _NAIVE_UNION
 
-        # Load the canonical narrators into the live graph.
-        shutil.copy(canonical_path, staging / "narrators_canonical.parquet")
+        # Load the canonical narrators into the live graph. The loader reads
+        # narrators_canonical.parquet from the curated (resolve-output) dir
+        # (da#112 contract), so stage the resolve output into curated.
+        shutil.copy(canonical_path, curated / "narrators_canonical.parquet")
         results = load_all_nodes(neo4j_client, staging, curated, strict=False)
         narrator_result = next(r for r in results if r.node_type == "Narrator")
         assert narrator_result.created == _EXPECTED_CANONICAL
@@ -268,8 +270,9 @@ class TestCrossSourceResolutionLive:
             assert "itqan:malik" not in records[cid]["source_ids"]
 
         # End-to-end: the merged canonical loads as exactly four Narrator nodes,
-        # all nar:-prefixed, into the live graph.
-        shutil.copy(canonical_path, staging / "narrators_canonical.parquet")
+        # all nar:-prefixed, into the live graph. The loader reads the canonical
+        # master from the curated (resolve-output) dir (da#112 contract).
+        shutil.copy(canonical_path, curated / "narrators_canonical.parquet")
         results = load_all_nodes(neo4j_client, staging, curated, strict=False)
         narrator_result = next(r for r in results if r.node_type == "Narrator")
         assert narrator_result.created == 4

--- a/tests/integration/test_graph_loading.py
+++ b/tests/integration/test_graph_loading.py
@@ -209,8 +209,12 @@ SAMPLE_COLLECTIONS = [
 ]
 
 
-def _write_narrators_parquet(staging: Path, rows: list[dict[str, Any]]) -> Path:
-    """Write narrators_canonical.parquet."""
+def _write_narrators_parquet(curated: Path, rows: list[dict[str, Any]]) -> Path:
+    """Write narrators_canonical.parquet into the curated (resolve-output) dir.
+
+    The loader reads the canonical narrator master from the curated dir
+    (da#112 artifact-location contract).
+    """
     arrays = {
         "canonical_id": pa.array([r["canonical_id"] for r in rows], type=pa.string()),
         "name_ar": pa.array([r.get("name_ar") for r in rows], type=pa.string()),
@@ -229,7 +233,7 @@ def _write_narrators_parquet(staging: Path, rows: list[dict[str, Any]]) -> Path:
         "mention_count": pa.array([r.get("mention_count") for r in rows], type=pa.int32()),
     }
     table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
-    path = staging / "narrators_canonical.parquet"
+    path = curated / "narrators_canonical.parquet"
     pq.write_table(table, path)
     return path
 
@@ -293,7 +297,7 @@ def _write_staging_data(tmp_path: Path) -> tuple[Path, Path]:
     curated = tmp_path / "curated"
     curated.mkdir()
 
-    _write_narrators_parquet(staging, SAMPLE_NARRATORS)
+    _write_narrators_parquet(curated, SAMPLE_NARRATORS)
     _write_hadiths_parquet(staging, SAMPLE_HADITHS)
     _write_collections_parquet(staging, SAMPLE_COLLECTIONS)
 

--- a/tests/integration/test_itqan_load.py
+++ b/tests/integration/test_itqan_load.py
@@ -41,8 +41,9 @@ class TestItqanNarratorLoadLive:
 
         # parse -> narrators_bio_itqan.parquet
         itqan.run(tmp_path / "raw", staging)
-        # promote -> narrators_canonical.parquet IN staging (where the loader reads it)
-        canonical = promote_bios_to_canonical(staging, staging, sources={"itqan"})
+        # promote -> narrators_canonical.parquet IN curated (where the loader reads
+        # it — da#112 artifact-location contract)
+        canonical = promote_bios_to_canonical(staging, curated, sources={"itqan"})
         assert canonical is not None
         expected = pq.read_table(canonical).num_rows
         assert expected >= 20  # the 24-profile fixture, minus any name collisions
@@ -88,7 +89,7 @@ class TestItqanNarratorLoadLive:
         curated.mkdir()
 
         itqan.run(tmp_path / "raw", staging)
-        promote_bios_to_canonical(staging, staging, sources={"itqan"})
+        promote_bios_to_canonical(staging, curated, sources={"itqan"})
 
         load_all_nodes(neo4j_client, staging, curated, strict=False)
         first = neo4j_client.execute_read("MATCH (n:Narrator) RETURN count(n) AS n")[0]["n"]

--- a/tests/integration/test_sanadset_lightup.py
+++ b/tests/integration/test_sanadset_lightup.py
@@ -97,8 +97,10 @@ class TestSanadsetLightupLive:
         canonical = resolve_out / "narrators_canonical.parquet"
         assert canonical.exists(), "disambiguation must produce canonical narrators"
         assert pq.read_table(canonical).num_rows >= 1, "expected >=1 resolved narrator"
-        # The loader reads narrators_canonical.parquet from the staging dir.
-        shutil.copy(canonical, staging / "narrators_canonical.parquet")
+        # The loader reads narrators_canonical.parquet from the curated
+        # (resolve-output) dir — da#112 artifact-location contract. Stage the
+        # resolve output into curated for the load step.
+        shutil.copy(canonical, curated / "narrators_canonical.parquet")
 
         # A sanadset Collection so APPEARS_IN (hadith->collection) can materialize.
         write_collections(

--- a/tests/test_graph/conftest.py
+++ b/tests/test_graph/conftest.py
@@ -75,8 +75,12 @@ def curated_dir(tmp_path: Path) -> Path:
     return d
 
 
-def write_narrators_canonical(staging: Path, rows: list[dict[str, Any]]) -> Path:
-    """Write a narrators_canonical.parquet file."""
+def write_narrators_canonical(curated: Path, rows: list[dict[str, Any]]) -> Path:
+    """Write a narrators_canonical.parquet file into the curated (resolve-output) dir.
+
+    The graph loader reads the canonical narrator master from ``curated_dir``
+    (da#112 artifact-location contract), so tests must place it there.
+    """
     arrays = {
         "canonical_id": pa.array([r.get("canonical_id", "") for r in rows], type=pa.string()),
         "name_ar": pa.array([r.get("name_ar") for r in rows], type=pa.string()),
@@ -95,7 +99,7 @@ def write_narrators_canonical(staging: Path, rows: list[dict[str, Any]]) -> Path
         "mention_count": pa.array([r.get("mention_count") for r in rows], type=pa.int32()),
     }
     table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
-    path = staging / "narrators_canonical.parquet"
+    path = curated / "narrators_canonical.parquet"
     pq.write_table(table, path)
     return path
 

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -34,7 +34,7 @@ class TestLoadNarrators:
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
     ) -> None:
         write_narrators_canonical(
-            staging_dir,
+            curated_dir,
             [
                 {
                     "canonical_id": "nar:abu-hurayra",
@@ -54,7 +54,7 @@ class TestLoadNarrators:
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
     ) -> None:
         write_narrators_canonical(
-            staging_dir,
+            curated_dir,
             [
                 {"canonical_id": "nar:valid", "name_en": "Valid"},
                 {"canonical_id": "INVALID", "name_en": "Bad"},  # no nar: prefix
@@ -79,6 +79,48 @@ class TestLoadNarrators:
         narrator_result = results[0]
         assert narrator_result.created == 0
         assert narrator_result.merged == 0
+
+    def test_canonical_read_path_matches_resolve_write_path(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """da#112 contract: the loader reads narrators_canonical.parquet from the
+        SAME dir the resolve stage writes it to (the curated/resolve-output dir),
+        and NOT from staging.
+
+        ``write_narrators_canonical`` writes into ``curated_dir`` (mirroring
+        ``disambiguate.run`` / ``bio_promote`` whose ``output_dir`` the CLI maps
+        to ``DATA_CURATED_DIR``). A stray copy in ``staging_dir`` must be ignored,
+        proving writer-path == reader-path.
+        """
+        # Resolve-output location (curated): loaded.
+        write_narrators_canonical(
+            curated_dir,
+            [{"canonical_id": "nar:from-curated", "name_en": "From Curated"}],
+        )
+        # A stale staging copy that the OLD loader would have read: must be ignored.
+        write_narrators_canonical(
+            staging_dir,
+            [
+                {"canonical_id": "nar:stale-staging-a", "name_en": "Stale A"},
+                {"canonical_id": "nar:stale-staging-b", "name_en": "Stale B"},
+            ],
+        )
+
+        results = load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        narrator_result = results[0]
+        assert narrator_result.node_type == "Narrator"
+        # Exactly the single curated row — never the two staging rows.
+        assert narrator_result.created + narrator_result.merged == 1
+        assert narrator_result.skipped == 0
+
+        loaded_ids = {
+            row["id"]
+            for _query, batch in mock_client.calls
+            if isinstance(batch, list)
+            for row in batch
+            if isinstance(row, dict) and str(row.get("id", "")).startswith("nar:")
+        }
+        assert loaded_ids == {"nar:from-curated"}
 
 
 class TestLoadHadiths:
@@ -156,7 +198,7 @@ class TestLoadHadiths:
     ) -> None:
         # Provide narrators but no hadiths
         write_narrators_canonical(
-            staging_dir,
+            curated_dir,
             [
                 {"canonical_id": "nar:test", "name_en": "Test"},
             ],
@@ -345,7 +387,7 @@ class TestLoadAllNodes:
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
     ) -> None:
         write_narrators_canonical(
-            staging_dir,
+            curated_dir,
             [
                 {"canonical_id": "nar:1", "name_en": "Narrator 1"},
             ],


### PR DESCRIPTION
## Summary

Reconciles the staging-vs-curated location for `narrators_canonical.parquet`. The graph loader read it from the **staging** dir while `disambiguate.run` / `bio_promote` write it to the resolve `output_dir` (which `src/cli.py` maps to `DATA_CURATED_DIR`). This split was a latent footgun (PR #110 / da#92a): a future change to either path silently breaks narrator loading.

## Contract chosen: CURATED

`narrators_canonical.parquet` is a resolve-stage **output** — the *curated narrator master* produced by entity resolution. It belongs in the curated dir alongside the other curated/load-input artifacts (`historical_events.yaml`, `locations.yaml`). It is **not** a raw staging intermediate like `narrator_mentions_*` (those correctly stay in staging, read by the Chain loader — a different artifact kind, out of scope).

The loader `_load_narrators` already receives `curated_dir`; it now reads the canonical master from it, matching where the writers already emit it. **No change to the disambiguate write path or `run_all` ordering** — that keeps this PR clear of #117 (run_all wiring) and #99 (cross-source resolution), which rework the resolve side.

## Files touched (for #117/#103 sequencing)

- `src/graph/load_nodes.py` — loader read path `staging_dir` -> `curated_dir`; module + `_load_narrators` docstrings document the resolve->stage->load artifact-location contract.
- `src/resolve/bio_promote.py` — **docstring only** clarification (output_dir is the curated dir the loader reads). No logic change. **No touch to `src/resolve/__init__.py` (run_all, #117), `disambiguate.py` write logic (#99), or `schemas.py` (#103).**
- Tests: `tests/test_graph/conftest.py`, `tests/test_graph/test_load_nodes.py`, `tests/integration/{test_graph_loading,test_sanadset_lightup,test_cross_source_resolution,test_itqan_load}.py`.

## Tests

- **New** `test_canonical_read_path_matches_resolve_write_path` (AC: writer-path == reader-path) — a curated copy loads, a stray staging copy is ignored.
- Conftest/helper narrator writers now target the curated dir.
- The resolve-output -> staging **bridge copies** in the integration tests (the exact footgun this issue flags) now point at curated; itqan promote points at curated.

## Test Plan

- [x] `ruff format --check` + `ruff check` clean on all changed files
- [x] `mypy` clean (`load_nodes.py`, `bio_promote.py`)
- [x] 187 unit tests pass (`tests/test_graph`, `tests/test_resolve`)
- [x] 19 **live-neo4j** integration tests pass (Docker available locally) — itqan / sanadset / cross-source / graph-loading flows verified reading narrators from curated end-to-end

Reviewers: @Alejandra Reyes-Fuentes (primary), @Oyunbileg Batbayar (QA, secondary)

Closes #112
