### PR TITLE
tech-debt(resolve): wire detect_parallels + bio_promote into run_all, disambiguate-first ordering (#117)

### DIFF
--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -1,7 +1,17 @@
 """Phase 2: Entity Resolution pipeline.
 
-Dependency-aware orchestrator: NER -> disambiguate -> dedup.
-Dedup runs independently of NER/disambiguation (only needs hadith text).
+Dependency-aware orchestrator:
+``NER -> disambiguate -> bio_promote -> (dedup + detect_parallels)``.
+
+Ordering invariants (da#117):
+- ``disambiguate`` OVERWRITES ``narrators_canonical.parquet`` while
+  ``bio_promote`` MERGEs into it, so ``bio_promote`` MUST run *after*
+  ``disambiguate`` or promoted bio-only narrators get clobbered (da#99).
+- ``dedup`` (semantic embeddings, degrades to empty without the model) and
+  ``detect_parallels`` (deterministic lexical, offline/CI) both write the shared
+  ``staging/parallel_links.parquet``. run_all runs both and *composes* their
+  outputs (union, deduped by canonical hadith pair) so an orchestrated run in a
+  no-model environment still emits cross-sect PARALLEL_OF edges (da#100/da#114).
 """
 
 from __future__ import annotations
@@ -9,8 +19,12 @@ from __future__ import annotations
 import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from src.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    import pyarrow as pa
 
 logger = get_logger(__name__)
 
@@ -33,7 +47,9 @@ class ResolveMetrics:
     parallel_cross_sect: int = 0
     ner_files: list[Path] = field(default_factory=list)
     disambiguate_files: list[Path] = field(default_factory=list)
+    bio_promote_files: list[Path] = field(default_factory=list)
     dedup_files: list[Path] = field(default_factory=list)
+    parallels_files: list[Path] = field(default_factory=list)
 
     def summary(self) -> str:
         """Return a human-readable summary string."""
@@ -55,7 +71,13 @@ class ResolveMetrics:
                     f"    cross-sect             : {self.parallel_cross_sect}",
                 ]
             )
-        total_files = len(self.ner_files) + len(self.disambiguate_files) + len(self.dedup_files)
+        total_files = (
+            len(self.ner_files)
+            + len(self.disambiguate_files)
+            + len(self.bio_promote_files)
+            + len(self.dedup_files)
+            + len(self.parallels_files)
+        )
         lines.append(f"  Output files             : {total_files}")
         return "\n".join(lines)
 
@@ -85,6 +107,83 @@ def _collect_dedup_metrics(metrics: ResolveMetrics, staging_dir: Path) -> None:
             metrics.parallel_cross_sect = pc.sum(cs_col).as_py()
     except Exception:  # noqa: BLE001
         logger.warning("dedup_metrics_read_failed", path=str(path))
+
+
+def _read_parallel_links(staging_dir: Path) -> pa.Table | None:
+    """Read ``parallel_links.parquet`` into a table, or ``None`` if absent/unreadable.
+
+    Used to capture a detector's output before the next detector overwrites the
+    shared artifact, so the two can be composed.
+    """
+    path = staging_dir / "parallel_links.parquet"
+    if not path.exists():
+        return None
+    try:
+        import pyarrow.parquet as pq
+
+        return pq.read_table(path)
+    except Exception:  # noqa: BLE001
+        logger.warning("parallel_links_read_failed", path=str(path))
+        return None
+
+
+def _compose_parallel_links(
+    staging_dir: Path,
+    semantic: pa.Table | None,
+    deterministic: pa.Table | None,
+) -> Path | None:
+    """Union the two PARALLEL_OF detectors' links into the shared artifact.
+
+    ``dedup`` (semantic embeddings) and ``detect_parallels`` (deterministic
+    lexical) both materialize ``staging/parallel_links.parquet`` under the
+    identical ``PARALLEL_LINKS_SCHEMA``. We union them, deduping by the canonical
+    ``(hadith_id_a, hadith_id_b)`` pair; the **semantic** row wins on a key
+    collision (the production embedding signal supersedes the lexical fallback).
+    Composition (rather than last-writer-wins) guarantees an orchestrated run in
+    a no-model environment — where ``dedup`` degrades to an empty table — still
+    emits the deterministic cross-sect edges (da#117).
+
+    Returns the written path, or ``None`` when neither detector produced a table
+    (the shared artifact is then left untouched).
+    """
+    if semantic is None and deterministic is None:
+        return None
+
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    from src.resolve.schemas import PARALLEL_LINKS_SCHEMA
+
+    # Insert deterministic first, then semantic, so a semantic row overwrites a
+    # deterministic one for the same canonical pair.
+    merged: dict[tuple[object, object], dict[str, object]] = {}
+    for table in (deterministic, semantic):
+        if table is None:
+            continue
+        for row in table.to_pylist():
+            merged[(row["hadith_id_a"], row["hadith_id_b"])] = row
+
+    rows = list(merged.values())
+    composed = pa.table(
+        {
+            "hadith_id_a": pa.array([r["hadith_id_a"] for r in rows], type=pa.string()),
+            "hadith_id_b": pa.array([r["hadith_id_b"] for r in rows], type=pa.string()),
+            "similarity_score": pa.array([r["similarity_score"] for r in rows], type=pa.float32()),
+            "variant_type": pa.array([r["variant_type"] for r in rows], type=pa.string()),
+            "cross_sect": pa.array([r["cross_sect"] for r in rows], type=pa.bool_()),
+        },
+        schema=PARALLEL_LINKS_SCHEMA,
+    )
+    output_path = staging_dir / "parallel_links.parquet"
+    pq.write_table(composed, output_path)
+    logger.info(
+        "parallel_links_composed",
+        semantic=0 if semantic is None else semantic.num_rows,
+        deterministic=0 if deterministic is None else deterministic.num_rows,
+        composed=composed.num_rows,
+        path=str(output_path),
+    )
+    return output_path
 
 
 def _collect_disambig_metrics(metrics: ResolveMetrics, output_dir: Path) -> None:
@@ -126,16 +225,31 @@ def _collect_ner_metrics(metrics: ResolveMetrics, output_dir: Path) -> None:
 
 
 def run_all(raw_dir: Path, staging_dir: Path, output_dir: Path) -> dict[str, list[Path]]:
-    """Run full entity resolution pipeline: NER -> disambiguate -> dedup.
+    """Run full entity resolution pipeline.
 
-    Dependency-aware: if NER fails, skip disambiguation but still run dedup
-    (dedup only needs hadith text, not narrator mentions).
+    Order: ``NER -> disambiguate -> bio_promote -> (dedup + detect_parallels)``.
+
+    Dependency-aware: if NER fails, skip disambiguation. ``bio_promote`` runs
+    after disambiguation regardless (it merges bios into the canonical table and
+    must never precede the overwriting ``disambiguate``, da#99/da#117). ``dedup``
+    and ``detect_parallels`` only need hadith text; both write the shared
+    ``parallel_links.parquet`` and their outputs are composed.
+
+    ``output_dir`` is the curated dir — the same location the graph loader reads
+    ``narrators_canonical.parquet`` from; it is passed to both ``disambiguate``
+    and ``bio_promote`` so they reconcile against one canonical artifact (da#112).
     """
     logger.info("resolve_pipeline_start")
 
-    from src.resolve import dedup, disambiguate, ner
+    from src.resolve import bio_promote, dedup, disambiguate, ner, parallels
 
-    results: dict[str, list[Path]] = {"ner": [], "disambiguate": [], "dedup": []}
+    results: dict[str, list[Path]] = {
+        "ner": [],
+        "disambiguate": [],
+        "bio_promote": [],
+        "dedup": [],
+        "parallels": [],
+    }
 
     # Pre-flight check: verify staging has Parquet files.
     if not staging_dir.exists() or not _has_staging_parquets(staging_dir):
@@ -183,19 +297,62 @@ def run_all(raw_dir: Path, staging_dir: Path, output_dir: Path) -> dict[str, lis
             reason="NER failed — no mention data available",
         )
 
-    # Step 3: Dedup (runs independently of NER/disambiguation).
+    # Step 3: Bio promotion — MERGE bios into narrators_canonical.parquet.
+    # MUST run after disambiguate (which OVERWRITES the same file); reversing the
+    # order clobbers promoted bio-only narrators (da#99/da#117). Runs regardless
+    # of NER/disambiguation status — it is merge-safe against whatever canonical
+    # table already exists (or none).
+    try:
+        logger.info("resolve_step", step="bio_promote", status="running")
+        promoted = bio_promote.promote_bios_to_canonical(staging_dir, output_dir)
+        results["bio_promote"] = [promoted] if promoted is not None else []
+        logger.info(
+            "resolve_step",
+            step="bio_promote",
+            status="complete",
+            files=len(results["bio_promote"]),
+        )
+    except Exception:  # noqa: BLE001
+        logger.error("resolve_step_failed", step="bio_promote", traceback=traceback.format_exc())
+
+    # Step 4: Dedup (semantic; degrades to an empty table without the embedding
+    # model). Runs independently of NER/disambiguation. Capture its output before
+    # detect_parallels overwrites the shared artifact, so the two can be composed.
+    semantic_links: pa.Table | None = None
     try:
         logger.info("resolve_step", step="dedup", status="running")
         results["dedup"] = dedup.run(staging_dir, output_dir)
+        semantic_links = _read_parallel_links(staging_dir)
         logger.info("resolve_step", step="dedup", status="complete", files=len(results["dedup"]))
     except Exception:  # noqa: BLE001
         logger.error("resolve_step_failed", step="dedup", traceback=traceback.format_exc())
+
+    # Step 5: Deterministic lexical parallels (offline/CI complement + no-model
+    # fallback). Overwrites parallel_links.parquet — capture its output too.
+    deterministic_links: pa.Table | None = None
+    try:
+        logger.info("resolve_step", step="parallels", status="running")
+        results["parallels"] = parallels.run(staging_dir, output_dir)
+        deterministic_links = _read_parallel_links(staging_dir)
+        logger.info(
+            "resolve_step", step="parallels", status="complete", files=len(results["parallels"])
+        )
+    except Exception:  # noqa: BLE001
+        logger.error("resolve_step_failed", step="parallels", traceback=traceback.format_exc())
+
+    # Step 6: Compose both detectors' links into the single shared artifact so a
+    # no-model run still emits the deterministic cross-sect edges (da#117).
+    composed = _compose_parallel_links(staging_dir, semantic_links, deterministic_links)
+    if composed is not None:
+        results["parallels"] = [composed]
 
     # Collect metrics from output files.
     metrics = ResolveMetrics(
         ner_files=results["ner"],
         disambiguate_files=results["disambiguate"],
+        bio_promote_files=results["bio_promote"],
         dedup_files=results["dedup"],
+        parallels_files=results["parallels"],
     )
     _collect_ner_metrics(metrics, output_dir)
     _collect_disambig_metrics(metrics, output_dir)

--- a/tests/test_resolve/test_run_all.py
+++ b/tests/test_resolve/test_run_all.py
@@ -1,0 +1,160 @@
+"""Orchestrator tests for ``src.resolve.run_all`` wiring (da#117).
+
+Covers the two invariants the wiring must hold:
+
+1. ``run_all`` invokes both the bio promoter and the deterministic parallel
+   detector, and runs ``disambiguate`` *before* ``bio_promote``.
+2. The ordering is *safe*: a promoted bio-only narrator (one with no mention,
+   so absent from the ``disambiguate`` output that OVERWRITES
+   ``narrators_canonical.parquet``) survives a full ``run_all`` instead of being
+   clobbered — proving ``bio_promote`` MERGEs *after* ``disambiguate`` (da#99).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from src.parse.identity import make_canonical_id
+from src.parse.schemas import NARRATOR_BIO_SCHEMA
+from src.resolve import bio_promote, dedup, disambiguate, ner, parallels, run_all
+from src.utils.arabic import normalize_arabic
+from tests.test_graph.conftest import write_hadiths, write_narrator_mentions_resolved
+
+
+def _write_bios(staging: Path, suffix: str, rows: list[dict[str, Any]]) -> Path:
+    """Write a narrators_bio_<suffix>.parquet with schema defaults filled in."""
+    full = []
+    for r in rows:
+        base = {f.name: None for f in NARRATOR_BIO_SCHEMA}
+        base.update(r)
+        full.append(base)
+    arrays = {f.name: [r[f.name] for r in full] for f in NARRATOR_BIO_SCHEMA}
+    table = pa.table(arrays, schema=NARRATOR_BIO_SCHEMA)
+    path = staging / f"narrators_bio_{suffix}.parquet"
+    pq.write_table(table, path)
+    return path
+
+
+def test_run_all_invokes_bio_promote_and_parallels_disambiguate_first(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """run_all wires in bio_promote + detect_parallels, disambiguate-first."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    curated = tmp_path / "curated"
+    # A staging Parquet so the pre-flight passes.
+    write_hadiths(staging, [{"source_id": "h1", "matn_en": "x"}], suffix="t")
+
+    calls: list[str] = []
+
+    def _rec(name: str, ret: Any) -> Any:
+        def _fn(*_a: Any, **_k: Any) -> Any:
+            calls.append(name)
+            return ret
+
+        return _fn
+
+    monkeypatch.setattr(ner, "run", _rec("ner", [staging / "mentions"]))
+    monkeypatch.setattr(disambiguate, "run", _rec("disambiguate", []))
+    monkeypatch.setattr(bio_promote, "promote_bios_to_canonical", _rec("bio_promote", None))
+    monkeypatch.setattr(dedup, "run", _rec("dedup", []))
+    monkeypatch.setattr(parallels, "run", _rec("parallels", []))
+
+    results = run_all(tmp_path / "raw", staging, curated)
+
+    # Both new stages were invoked.
+    assert "bio_promote" in calls
+    assert "parallels" in calls
+    # Ordering invariant: NER -> disambiguate -> bio_promote.
+    assert calls.index("ner") < calls.index("disambiguate")
+    assert calls.index("disambiguate") < calls.index("bio_promote")
+    # The results dict exposes the new stages.
+    assert {"bio_promote", "parallels"} <= results.keys()
+
+
+def test_run_all_promoted_bio_only_narrator_survives(tmp_path: Path, monkeypatch: Any) -> None:
+    """A bio-only narrator survives run_all — disambiguate runs before bio_promote.
+
+    ``disambiguate`` OVERWRITES ``narrators_canonical.parquet`` with only the
+    mentioned narrators; ``bio_promote`` MERGEs the bios on top. If the order
+    were reversed, the overwrite would drop the bio-only narrator. Asserting it
+    is present (alongside a disambiguate-produced narrator) proves the order.
+    """
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    curated = tmp_path / "curated"
+
+    mentioned_name = "زيد بن ثابت"  # has a mention -> emitted by disambiguate
+    bio_only_name = "سعيد بن سماك"  # bio only, no mention -> only via bio_promote
+    bio_only_id = make_canonical_id(normalize_arabic(bio_only_name))
+
+    # Two cross-sect hadiths with identical matn -> a deterministic cross-sect
+    # PARALLEL_OF edge, proving detect_parallels is in the pipeline path.
+    write_hadiths(
+        staging,
+        [
+            {"source_id": "hs1", "matn_en": "actions are by intentions", "sect": "sunni"},
+            {"source_id": "hs2", "matn_en": "actions are by intentions", "sect": "shia"},
+        ],
+        suffix="x",
+    )
+    # Bio for the bio-only narrator (no corresponding mention).
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:1",
+                "source": "itqan",
+                "name_ar": bio_only_name,
+                "name_ar_normalized": normalize_arabic(bio_only_name),
+            }
+        ],
+    )
+
+    # Stub NER to emit a single mention (into the curated output dir, where
+    # disambiguate reads mentions) for the mentioned narrator.
+    def _fake_ner(_staging: Path, output_dir: Path) -> list[Path]:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        return [
+            write_narrator_mentions_resolved(
+                output_dir,
+                [
+                    {
+                        "mention_id": "m1",
+                        "hadith_id": "hs1",
+                        "source_corpus": "sunnah",
+                        "position_in_chain": 0,
+                        "name_raw": mentioned_name,
+                        "name_normalized": normalize_arabic(mentioned_name),
+                    }
+                ],
+            )
+        ]
+
+    monkeypatch.setattr(ner, "run", _fake_ner)
+
+    run_all(tmp_path / "raw", staging, curated)
+
+    canonical_path = curated / "narrators_canonical.parquet"
+    assert canonical_path.exists(), "disambiguate+bio_promote produced no canonical table"
+    ids = set(pq.read_table(canonical_path).column("canonical_id").to_pylist())
+
+    # The bio-only narrator survived the disambiguate overwrite ...
+    assert bio_only_id in ids, (
+        "bio-only narrator was clobbered — bio_promote ran before disambiguate"
+    )
+    # ... and it coexists with a disambiguate-produced narrator (so the overwrite
+    # really happened and the merge landed on top, not a trivial bio-only file).
+    assert len(ids) >= 2, "expected disambiguate-produced narrator alongside the promoted bio"
+
+    # detect_parallels is wired and emits the cross-sect edge even with no model.
+    links_path = staging / "parallel_links.parquet"
+    assert links_path.exists()
+    links = pq.read_table(links_path)
+    assert links.num_rows >= 1
+    assert any(links.column("cross_sect").to_pylist()), "expected a cross-sect PARALLEL_OF edge"


### PR DESCRIPTION
Closes #117

## What

The resolve orchestrator `run_all` (`src/resolve/__init__.py`) ran only `NER -> disambiguate -> dedup`. Two stages that exist but were never in the pipeline path produced nothing in an orchestrated `make resolve`:

- **`detect_parallels`** (deterministic lexical PARALLEL_OF, `parallels.py`) — so a no-model/CI run emitted **zero cross-sect edges** (dedup's FAISS path degrades to empty without the embedding model).
- **`bio_promote`** (bio-direct canonical promoter, `bio_promote.py`) — so bio-only narrators were never promoted into `narrators_canonical.parquet` in an orchestrated run.

## Wiring + ordering

New order: **`NER -> disambiguate -> bio_promote -> (dedup + detect_parallels)`**.

- **`bio_promote` runs AFTER `disambiguate`** (the critical da#99 footgun): `disambiguate` **OVERWRITES** `narrators_canonical.parquet` while `bio_promote` **MERGEs** into it — the reverse order clobbers promoted bio-only narrators. Both stages receive the curated `output_dir`, so they reconcile against one canonical artifact (da#112). `bio_promote` runs regardless of NER/disambiguation status (merge-safe against whatever canonical table already exists, or none).
- **Composition over last-writer-wins** for the shared `staging/parallel_links.parquet`: both detectors write it. `run_all` captures each detector's table and **unions** them, deduped by canonical `(hadith_id_a, hadith_id_b)`, with the **semantic** (dedup) row winning on collision. This guarantees the deterministic cross-sect edges survive even when dedup degrades to empty — directly fixing the issue's "zero cross-sect edges in CI" symptom. (This is the explicit "composition vs last-writer-wins" decision the issue asked for, and the resolution to Oyunbileg's #114 double-write flag.)

## Scope

Orchestration wiring + ordering + composition only. **No changes** to `bio_promote`/`detect_parallels` internals or the `PARALLEL_LINKS`/canonical schemas.

## Files touched (for #109 serial-merge)

- `src/resolve/__init__.py` — **the only shared file with #109.** My edits are confined to: module docstring; `ResolveMetrics` (+`bio_promote_files`/`parallels_files` fields and the `total_files` sum); two new helpers `_read_parallel_links` + `_compose_parallel_links`; and `run_all` (imports, results dict keys, the new bio_promote step, and the dedup+parallels+compose steps). I did **not** touch `disambiguate.run` or `disambiguate.py`. If #109 adds a backfill inside `disambiguate.run` (before the loaders), it composes cleanly with this — my wiring preserves disambiguate running before bio_promote. (Rebased on the current wave tip; clean, no concurrent edit to this file.)
- `tests/test_resolve/test_run_all.py` — new file (no collision).

## Test Plan

`tests/test_resolve/test_run_all.py`:
1. `test_run_all_invokes_bio_promote_and_parallels_disambiguate_first` — `run_all` invokes both `bio_promote` and `detect_parallels`; asserts `NER < disambiguate < bio_promote` call order.
2. `test_run_all_promoted_bio_only_narrator_survives` — real `disambiguate` + `bio_promote`; a promoted bio-only narrator (no mention) survives `run_all` **alongside** a disambiguate-produced narrator (so the overwrite really happened and the merge landed on top) — proves disambiguate-before-bio_promote. Also asserts the composed `parallel_links.parquet` carries a cross-sect edge with **no embedding model**.

Local: `tests/test_resolve/` 117 passed, 3 skipped (Docker-gated). `ruff format --check` + `ruff check` clean; `mypy src/resolve/` clean.

Reviewers: @Ivana Horvat (ML/NLP, primary) + @Jean-Claude Habimana (architect, secondary).
