### PR TITLE
feat(resolve): backfill canonical_narrator_id into mentions → NARRATED edges fire (#109)

### DIFF
--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -24,7 +24,11 @@ from rapidfuzz.distance import Levenshtein
 
 from src.parse.base import safe_str, write_parquet
 from src.parse.identity import make_canonical_id
-from src.resolve.schemas import AMBIGUOUS_NARRATORS_SCHEMA, NARRATORS_CANONICAL_SCHEMA
+from src.resolve.schemas import (
+    AMBIGUOUS_NARRATORS_SCHEMA,
+    NARRATOR_MENTIONS_RESOLVED_SCHEMA,
+    NARRATORS_CANONICAL_SCHEMA,
+)
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
 
@@ -428,6 +432,79 @@ def _load_mentions(
     return rows
 
 
+def _backfill_mention_canonical_ids(
+    mentions_path: Path,
+    resolved: dict[str, tuple[str, float | None]],
+) -> int:
+    """Write resolved canonical ids + confidence back onto the mention rows.
+
+    The NER stage writes ``narrator_mentions_resolved.parquet`` with
+    ``canonical_narrator_id = None`` placeholders; disambiguation is the step
+    that actually knows each mention's canonical narrator. Without rewriting
+    these rows the graph edge/chain loaders — which read ``canonical_narrator_id``
+    straight off the mentions — see only ``None`` and emit zero NARRATED edges
+    and empty Chains (#109).
+
+    ``resolved`` maps ``mention_id -> (canonical_id, confidence)`` and covers
+    *every* mention that received a canonical narrator: both bio-matched mentions
+    and the da#99 self-canonicalized (fallback) mentions, so the whole chain —
+    not just the bio-backed positions — wires into the graph.
+
+    Streams row-group by row-group and rewrites the file in place so the
+    artifact stays self-contained for all downstream consumers and peak memory
+    stays bounded (mirrors ``_iter_mention_batches``). Idempotent: re-running
+    with the same ``resolved`` map yields the same file. Returns the number of
+    mention rows backfilled.
+    """
+    if not mentions_path.exists():
+        logger.warning("backfill_mentions_file_missing", path=str(mentions_path))
+        return 0
+
+    pf = pq.ParquetFile(mentions_path)
+    total_rows = pf.metadata.num_rows
+    id_idx = NARRATOR_MENTIONS_RESOLVED_SCHEMA.get_field_index("canonical_narrator_id")
+    conf_idx = NARRATOR_MENTIONS_RESOLVED_SCHEMA.get_field_index("confidence")
+
+    tmp_path = mentions_path.with_name(mentions_path.name + ".backfill.tmp")
+    writer = pq.ParquetWriter(tmp_path, NARRATOR_MENTIONS_RESOLVED_SCHEMA, compression="snappy")
+    backfilled = 0
+    try:
+        for rg_idx in range(pf.metadata.num_row_groups):
+            table = pf.read_row_group(rg_idx).cast(NARRATOR_MENTIONS_RESOLVED_SCHEMA)
+            mention_ids = table.column("mention_id").to_pylist()
+            existing_conf = table.column("confidence").to_pylist()
+
+            new_ids: list[str | None] = []
+            new_conf: list[float | None] = []
+            for mid, conf in zip(mention_ids, existing_conf, strict=True):
+                hit = resolved.get(str(mid))
+                if hit is None:
+                    # Unresolved mention — leave the NER placeholder untouched.
+                    new_ids.append(None)
+                    new_conf.append(conf)
+                else:
+                    new_ids.append(hit[0])
+                    new_conf.append(hit[1])
+                    backfilled += 1
+
+            table = table.set_column(
+                id_idx, "canonical_narrator_id", pa.array(new_ids, type=pa.string())
+            )
+            table = table.set_column(conf_idx, "confidence", pa.array(new_conf, type=pa.float32()))
+            writer.write_table(table)
+    finally:
+        writer.close()
+
+    tmp_path.replace(mentions_path)
+    logger.info(
+        "backfill_mentions_complete",
+        path=str(mentions_path),
+        backfilled=backfilled,
+        total=total_rows,
+    )
+    return backfilled
+
+
 # ---------------------------------------------------------------------------
 # Canonical ID generation
 # ---------------------------------------------------------------------------
@@ -749,6 +826,11 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
     merge_log_rows: list[dict[str, str | float | None]] = []
     ambiguous_rows: list[dict[str, str | float | None]] = []
 
+    # mention_id -> (canonical_id, confidence) for the #109 backfill. Captured
+    # for EVERY mention that received a canonical narrator — bio-matched and
+    # self-canonicalized (da#99) alike — so the full chain wires into the graph.
+    resolved_map: dict[str, tuple[str, float | None]] = {}
+
     # Cross-source collapse measurement (da#99): the naive baseline keeps one
     # node per (source, canonical) pair; the collapsed count is distinct
     # canonicals. naive > collapsed exactly when a narrator spans >1 source.
@@ -792,6 +874,7 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
                     candidate=c,
                 )
                 naive_identity_pairs.add((corpus, canonical_id))
+                resolved_map[mention_id] = (canonical_id, float(best.score))
 
                 # Merge log entry.
                 merge_log_rows.append(
@@ -826,6 +909,10 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
                         candidate=None,
                     )
                     naive_identity_pairs.add((corpus, fallback_id))
+                    # Self-canonicalized by exact name only (no bio corroboration),
+                    # so confidence is left unknown (None); the canonical id is
+                    # what wires the NARRATED edge / Chain (#109).
+                    resolved_map[mention_id] = (fallback_id, None)
 
                 # Record the top-3 bio candidates for the ambiguous-audit report
                 # (a fallback canonical node was still created above when named).
@@ -935,6 +1022,16 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
         log_path = output_dir / "merge_log.parquet"
         write_parquet(log_table, log_path, schema=_MERGE_LOG_SCHEMA)
         output_paths.append(log_path)
+
+    # 4. Backfill canonical ids onto the resolved-mention rows (#109).
+    # The NER stage left canonical_narrator_id=None on every mention; rewrite
+    # them with what disambiguation resolved so the downstream graph loaders
+    # (which key NARRATED edges and Chains off canonical_narrator_id) actually
+    # materialize narrator->hadith wiring instead of producing zero edges.
+    if resolved_map:
+        _backfill_mention_canonical_ids(
+            output_dir / "narrator_mentions_resolved.parquet", resolved_map
+        )
 
     logger.info(
         "disambiguate_run_complete",

--- a/tests/test_resolve/test_canonical_backfill_integration.py
+++ b/tests/test_resolve/test_canonical_backfill_integration.py
@@ -1,0 +1,196 @@
+"""Integration test for the canonical_narrator_id backfill (#109).
+
+Runs the real ``ner -> disambiguate`` pipeline on fixtures and asserts that a
+resolved mention ends up carrying its canonical ``nar:<uuid5>`` id, so the
+downstream graph loaders can materialize a real ``(:Narrator)-[:NARRATED]->
+(:Hadith)`` edge and a non-empty Chain.
+
+Why this test is shaped this way:
+
+- It does **not** hand-inject ``canonical_narrator_id`` into the mention rows.
+  That hand-injection (present in the graph-loader unit fixtures over in
+  noorinalabs-isnad-graph) is exactly the anti-pattern that masked #109 — it
+  made the loaders look wired while the real pipeline produced ``None``. Here
+  the canonical id is computed by the actual ``disambiguate.run`` and read back
+  off the on-disk artifact.
+- The graph edge/chain loaders themselves live in ``noorinalabs-isnad-graph``
+  (``src/graph/load_edges.py::_load_narrated`` / ``load_nodes.py::_load_chains``),
+  not in this repo, so a live Neo4j ``load`` cannot run here. Instead we replicate
+  the documented loader *contract* — read ``canonical_narrator_id`` straight off
+  the resolved-mention rows — and assert it now yields edges. Before the backfill
+  this contract produces zero edges (the bug); after it, edges fire.
+
+Remove the backfill in ``disambiguate.run`` and
+``test_disambiguate_backfills_canonical_id_into_mentions`` fails (canonical ids
+stay ``None`` -> zero edges).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from src.resolve import disambiguate, ner
+from src.utils.arabic import normalize_arabic
+
+# Two narrators in a single hadith's chain. The mention names are chosen to
+# exact-match the bio candidates after Arabic normalization.
+_NAME_A = "محمد بن اسماعيل"
+_NAME_B = "عبد الله بن يوسف"
+_HADITH_ID = "hdt:test:H1"
+
+
+def _write_phase1_mentions(staging_dir: Path) -> None:
+    """Write a Phase-1 sanadset mention table (the NER input for one hadith)."""
+    table = pa.table(
+        {
+            "name_ar": pa.array([_NAME_A, _NAME_B], type=pa.string()),
+            "name_en": pa.array([None, None], type=pa.string()),
+            "name_ar_normalized": pa.array(
+                [normalize_arabic(_NAME_A), normalize_arabic(_NAME_B)], type=pa.string()
+            ),
+            "source_hadith_id": pa.array([_HADITH_ID, _HADITH_ID], type=pa.string()),
+            "position_in_chain": pa.array([0, 1], type=pa.int32()),
+            "transmission_method": pa.array(["حدثنا", "عن"], type=pa.string()),
+        }
+    )
+    pq.write_table(table, staging_dir / "narrator_mentions_sanadset.parquet")
+
+
+def _write_bio_candidates(staging_dir: Path) -> None:
+    """Write a bio candidate table the two mentions resolve against."""
+
+    def _col(values: list[str | int | None], typ: pa.DataType) -> pa.Array:
+        return pa.array(values, type=typ)
+
+    table = pa.table(
+        {
+            "bio_id": _col(["bio:a", "bio:b"], pa.string()),
+            "name_ar": _col([_NAME_A, _NAME_B], pa.string()),
+            "name_en": _col([None, None], pa.string()),
+            "name_ar_normalized": _col(
+                [normalize_arabic(_NAME_A), normalize_arabic(_NAME_B)], pa.string()
+            ),
+            "kunya": _col([None, None], pa.string()),
+            "nisba": _col([None, None], pa.string()),
+            "birth_year_ah": _col([None, None], pa.int32()),
+            "death_year_ah": _col([256, 197], pa.int32()),
+            "birth_location": _col([None, None], pa.string()),
+            "death_location": _col([None, None], pa.string()),
+            "generation": _col([None, None], pa.string()),
+            "gender": _col(["male", "male"], pa.string()),
+            "trustworthiness": _col([None, None], pa.string()),
+            "external_id": _col([None, None], pa.string()),
+            "source": _col(["test", "test"], pa.string()),
+        }
+    )
+    pq.write_table(table, staging_dir / "narrators_bio_test.parquet")
+
+
+def _read_mentions(output_dir: Path) -> list[dict[str, object]]:
+    table = pq.read_table(output_dir / "narrator_mentions_resolved.parquet")
+    return cast(list[dict[str, object]], table.to_pylist())
+
+
+def _derive_narrated_edges(mentions: list[dict[str, object]]) -> set[tuple[str, str]]:
+    """Replicate the graph loader's NARRATED contract (#109).
+
+    ``_load_narrated`` keys a NARRATED edge on the *first* narrator of each
+    hadith's chain (lowest ``position_in_chain``) via its
+    ``canonical_narrator_id``. A ``None`` id yields no edge — which is precisely
+    the pre-backfill behavior this test guards against.
+    """
+    first_by_hadith: dict[str, dict[str, object]] = {}
+    for m in mentions:
+        hid = str(m["hadith_id"])
+        pos = int(m["position_in_chain"])  # type: ignore[call-overload]
+        cur = first_by_hadith.get(hid)
+        if cur is None or pos < int(cur["position_in_chain"]):  # type: ignore[call-overload]
+            first_by_hadith[hid] = m
+
+    edges: set[tuple[str, str]] = set()
+    for hid, m in first_by_hadith.items():
+        cid = m.get("canonical_narrator_id")
+        if cid:
+            edges.add((str(cid), hid))
+    return edges
+
+
+def _derive_chain_narrator_ids(mentions: list[dict[str, object]]) -> dict[str, list[str]]:
+    """Replicate ``_load_chains``: collect non-null canonical ids per hadith."""
+    by_hadith: dict[str, list[str]] = {}
+    for m in sorted(mentions, key=lambda r: int(r["position_in_chain"])):  # type: ignore[call-overload]
+        cid = m.get("canonical_narrator_id")
+        if cid:
+            by_hadith.setdefault(str(m["hadith_id"]), []).append(str(cid))
+    return by_hadith
+
+
+def test_disambiguate_backfills_canonical_id_into_mentions(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    output = tmp_path / "output"
+    staging.mkdir()
+    output.mkdir()
+    _write_phase1_mentions(staging)
+    _write_bio_candidates(staging)
+
+    # --- NER only: canonical ids are still the None placeholder -> ZERO edges.
+    ner.run(staging, output)
+    pre = _read_mentions(output)
+    assert len(pre) == 2
+    assert all(m["canonical_narrator_id"] is None for m in pre)
+    assert _derive_narrated_edges(pre) == set(), "NER alone must not wire NARRATED"
+
+    # --- disambiguate: backfills canonical ids -> NARRATED edge fires.
+    disambiguate.run(staging, output)
+    post = _read_mentions(output)
+    assert len(post) == 2
+
+    # Every resolved mention now carries a nar:<uuid5> canonical id + confidence.
+    resolved = [m for m in post if m["canonical_narrator_id"]]
+    assert len(resolved) == 2, "both mentions should resolve to a canonical narrator"
+    for m in resolved:
+        assert str(m["canonical_narrator_id"]).startswith("nar:")
+        assert m["confidence"] is not None and float(m["confidence"]) >= 0.70  # type: ignore[arg-type]
+
+    # The backfilled ids match the canonical narrator nodes (same id space).
+    canonical = pq.read_table(output / "narrators_canonical.parquet").to_pylist()
+    canonical_ids = {str(r["canonical_id"]) for r in canonical}
+    assert {str(m["canonical_narrator_id"]) for m in resolved} <= canonical_ids
+
+    # A real NARRATED edge now materializes (count > 0) — the bug fixed.
+    edges = _derive_narrated_edges(post)
+    assert len(edges) == 1
+    first = min(post, key=lambda r: int(r["position_in_chain"]))  # type: ignore[call-overload]
+    assert (str(first["canonical_narrator_id"]), _HADITH_ID) in edges
+
+    # The Chain for the hadith has non-empty narrator_ids (chain_length > 0).
+    chains = _derive_chain_narrator_ids(post)
+    assert chains[_HADITH_ID]
+    assert len(chains[_HADITH_ID]) == 2
+
+
+def test_backfill_is_idempotent_on_reload(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    output = tmp_path / "output"
+    staging.mkdir()
+    output.mkdir()
+    _write_phase1_mentions(staging)
+    _write_bio_candidates(staging)
+
+    ner.run(staging, output)
+    disambiguate.run(staging, output)
+    first_rows = _read_mentions(output)
+    first = {str(m["mention_id"]): m["canonical_narrator_id"] for m in first_rows}
+
+    # Re-running disambiguation must not duplicate rows or change ids.
+    disambiguate.run(staging, output)
+    second_rows = _read_mentions(output)
+    second = {str(m["mention_id"]): m["canonical_narrator_id"] for m in second_rows}
+
+    assert len(second_rows) == 2
+    assert first == second
+    assert _derive_narrated_edges(second_rows) == _derive_narrated_edges(first_rows)


### PR DESCRIPTION
Closes #109.

## Problem
The narrator-resolution pipeline produced canonical **Narrator nodes** but the narrator→hadith **wiring never materialized**: `src/resolve/ner.py` writes `narrator_mentions_resolved.parquet` with `canonical_narrator_id = None`, and `disambiguate.run` — which knows each mention's canonical id and writes `merge_log.parquet` — never wrote that id back onto the mention rows. The graph loaders (`load_edges.py::_load_narrated`, `load_nodes.py::_load_chains`, in noorinalabs-isnad-graph) read `canonical_narrator_id` straight off the mentions, so they saw only `None` → **0 NARRATED edges, empty Chains** from real data.

This was masked because the graph-loader unit fixtures hand-inject `canonical_narrator_id`, and no integration test ran ner→disambiguate→(load contract) end-to-end.

## Fix (backfill mechanism)
`disambiguate.run` now captures `mention_id → (canonical_id, confidence)` for **every** mention that received a canonical narrator — both bio-matched mentions **and** the da#99 self-canonicalized (fallback) mentions — and rewrites `narrator_mentions_resolved.parquet` in place via `_backfill_mention_canonical_ids`:
- Streams row-group by row-group (mirrors `_iter_mention_batches`) → memory bounded for the 3.3M-row scale.
- Idempotent: re-running yields the same file (no duplicate rows / stable ids).
- Self-contained artifact: every downstream consumer now reads the resolved id directly off the mention.

Covering the fallback path (not just `merge_log`) matters: da#99 made non-bio mentions real Narrator nodes too; backfilling only bio-matched mentions would leave those positions unwired and chains incomplete.

## New non-mocked integration test
`tests/test_resolve/test_canonical_backfill_integration.py` runs the **real** `ner → disambiguate` pipeline on fixtures and:
- Asserts NER-alone yields `canonical_narrator_id = None` → **0** derived NARRATED edges (the bug state).
- After `disambiguate.run`, asserts every resolved mention carries a `nar:<uuid5>` id matching the canonical narrator nodes, and that a real NARRATED edge (count > 0) + a non-empty Chain (`chain_length = 2`) now derive from the backfilled mentions.
- Does **not** hand-inject `canonical_narrator_id` (the anti-pattern that masked #109).
- The graph loaders live in noorinalabs-isnad-graph, so the test replicates their documented contract (read `canonical_narrator_id` off the first-narrator-per-hadith / per-chain) rather than standing up Neo4j.

**Proof it fails-without / passes-with:** with the backfill call disabled, `test_disambiguate_backfills_canonical_id_into_mentions` FAILS (canonical ids stay None → 0 edges); restored, it PASSES.

## Edge-count proof
Fixture: one hadith, two chain positions, two bio candidates. After disambiguate → 2/2 mentions backfilled (`backfill_mentions_complete backfilled=2`), 1 NARRATED edge (first narrator → hadith), chain narrator_ids length 2. `disambiguate_summary` shows `total_resolved=2`, `bio_coverage_pct=100`.

## Verification
- `ruff format --check` + `ruff check` clean
- `mypy` (strict) clean on both files
- `pytest tests/test_resolve tests/test_pipeline` → **138 passed, 3 skipped**

## Files touched
- `src/resolve/disambiguate.py` (backfill helper + capture map + call in `run`)
- `tests/test_resolve/test_canonical_backfill_integration.py` (new)

**Note:** `src/resolve/__init__.py` is **untouched** → no serial-merge conflict with #117 (the backfill lives inside `disambiguate.run`, which `run_all` already calls).

## Test Plan (runtime, post-merge)
Live `neo4j:5` end-to-end (`parse → ner → disambiguate → load`) asserting a real `(:Narrator)-[:NARRATED]->(:Hadith)` edge + Chain on the staging box — deferred because the graph loaders live in noorinalabs-isnad-graph (cannot run a real `load` from this repo).

Reviewers: @Ivana Horvat (ML/NLP, primary — owns the da#99 fallback path this wires) + @Jean-Claude Habimana (architect, secondary).
