### PR TITLE
feat(graph): Narrator nodes carry sect_affiliation + source_corpus (#103)

### DIFF
--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -100,7 +100,10 @@ SET n.name_ar           = row.name_ar,
     n.aliases           = row.aliases,
     n.external_id       = row.external_id,
     n.source_ids        = row.source_ids,
-    n.mention_count     = row.mention_count
+    n.mention_count     = row.mention_count,
+    n.source_corpus     = row.source_corpus,
+    n.source_corpora    = row.source_corpora,
+    n.sect_affiliation  = row.sect_affiliation
 """
 
 
@@ -159,6 +162,13 @@ def _load_narrators(
                 # ``MATCH (n:Narrator) WHERE any(s IN n.source_ids WHERE s STARTS WITH 'itqan:')``.
                 "source_ids": _val(row, "source_ids", []),
                 "mention_count": _val(row, "mention_count"),
+                # Sect/corpus provenance (da#103). ``source_corpus`` defaults to ""
+                # so the property is always present even for legacy canonical files
+                # written before these columns existed; ``sect_affiliation`` defaults
+                # to ``unknown`` for the same reason.
+                "source_corpus": _val(row, "source_corpus", ""),
+                "source_corpora": _val(row, "source_corpora", []),
+                "sect_affiliation": _val(row, "sect_affiliation", "unknown"),
             }
         )
 

--- a/src/parse/base.py
+++ b/src/parse/base.py
@@ -55,7 +55,12 @@ def provenance_violations(table: pa.Table) -> list[str]:
         if column not in columns:
             continue
         values = table.column(column)
-        if values.null_count:
+        # A *nullable* provenance column is resolve-derived (e.g. the canonical
+        # narrator master's source_corpus, da#103) where "no attributable corpus"
+        # is legitimately null; only a non-nullable parser-staging column must be
+        # fully populated. Empty-string and out-of-domain checks below still apply
+        # to whatever values ARE present, for both kinds.
+        if values.null_count and not table.schema.field(column).nullable:
             problems.append(f"{column}: {values.null_count} null value(s)")
         non_null = values.drop_null()
         if not len(non_null):

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -28,6 +28,11 @@ import pyarrow.parquet as pq
 from src.parse.base import safe_str, write_parquet
 from src.parse.identity import make_canonical_id
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.resolve.sect_affiliation import (
+    derive_sect_affiliation,
+    normalize_corpus,
+    primary_corpus,
+)
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
 
@@ -58,6 +63,9 @@ def _load_existing_canonical(path: Path) -> dict[str, dict[str, Any]]:
         if cid:
             row.setdefault("source_ids", [])
             row.setdefault("aliases", [])
+            # Preserve corpora a prior producer (disambiguate) already recorded so
+            # the bio-direct merge unions onto them rather than dropping them (da#103).
+            row.setdefault("source_corpora", [])
             rows[cid] = row
     return rows
 
@@ -104,6 +112,9 @@ def promote_bios_to_canonical(
             if sources is not None and source not in sources:
                 skipped_source += 1
                 continue
+            # Normalize the free-text bio provenance to a SourceCorpus value for
+            # sect/corpus tagging (da#103); unknown provenance → None (dropped).
+            corpus = normalize_corpus(source)
 
             name_ar = safe_str(row.get("name_ar"))
             norm = safe_str(row.get("name_ar_normalized")) or (
@@ -132,12 +143,18 @@ def promote_bios_to_canonical(
                     "external_id": safe_str(row.get("external_id")),
                     # mention_count stays 0: a bio is provenance, not a chain hit.
                     "mention_count": 0,
+                    # Corpus provenance for sect derivation (da#103). Finalized into
+                    # source_corpus + sect_affiliation after the merge loop.
+                    "source_corpora": [corpus] if corpus else [],
                 }
             else:
                 rec = canonical_map[cid]
                 src_ids = rec.setdefault("source_ids", [])
                 if bio_id and bio_id not in src_ids:
                     src_ids.append(bio_id)
+                corpora = rec.setdefault("source_corpora", [])
+                if corpus and corpus not in corpora:
+                    corpora.append(corpus)
                 # Back-fill only fields the existing record is missing. Keep the
                 # raw Parquet value (already a clean str / int) — do NOT coerce,
                 # or an int column like death_year_ah gets stringified.
@@ -145,6 +162,21 @@ def promote_bios_to_canonical(
                     if rec.get(field_name) in (None, "") and row.get(field_name) not in (None, ""):
                         rec[field_name] = row.get(field_name)
             promoted += 1
+
+    # Finalize sect/corpus provenance from the accumulated corpora set (da#103).
+    for rec in canonical_map.values():
+        corpora_val = rec.get("source_corpora")
+        # Drop nulls/unknowns a prior producer (or a legacy file) may have left so
+        # the scalar source_corpus stays in the SourceCorpus domain (write_parquet
+        # provenance gate). Normalize defensively in case the prior value was raw.
+        corpora = (
+            sorted({nc for c in corpora_val if (nc := normalize_corpus(c))})
+            if isinstance(corpora_val, list)
+            else []
+        )
+        rec["source_corpora"] = corpora
+        rec["source_corpus"] = primary_corpus(corpora)
+        rec["sect_affiliation"] = derive_sect_affiliation(corpora)
 
     table_rows = list(canonical_map.values())
     arrays = {f.name: [r.get(f.name) for r in table_rows] for f in NARRATORS_CANONICAL_SCHEMA}

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -29,6 +29,11 @@ from src.resolve.schemas import (
     NARRATOR_MENTIONS_RESOLVED_SCHEMA,
     NARRATORS_CANONICAL_SCHEMA,
 )
+from src.resolve.sect_affiliation import (
+    derive_sect_affiliation,
+    normalize_corpus,
+    primary_corpus,
+)
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
 
@@ -655,6 +660,11 @@ def _build_canonical_table(
     canonical_map: dict[str, dict[str, str | int | list[str] | None]],
 ) -> pa.Table:
     """Build narrators_canonical Parquet table."""
+
+    def _corpora(r: dict[str, str | int | list[str] | None]) -> list[str]:
+        v = r.get("source_corpora")
+        return v if isinstance(v, list) else []
+
     rows = list(canonical_map.values())
     if not rows:
         return pa.table(
@@ -680,6 +690,14 @@ def _build_canonical_table(
         ),
         "external_id": pa.array([r.get("external_id") for r in rows], type=pa.string()),
         "mention_count": pa.array([r.get("mention_count", 0) for r in rows], type=pa.int32()),
+        # Sect/corpus provenance finalized from the accumulated corpora set (da#103).
+        "source_corpus": pa.array([primary_corpus(_corpora(r)) for r in rows], type=pa.string()),
+        "source_corpora": pa.array(
+            [sorted(set(_corpora(r))) for r in rows], type=pa.list_(pa.string())
+        ),
+        "sect_affiliation": pa.array(
+            [derive_sect_affiliation(_corpora(r)) for r in rows], type=pa.string()
+        ),
     }
     return pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
 
@@ -721,6 +739,7 @@ def _upsert_canonical(
     name_en: str | None,
     alias: str | None,
     candidate: Candidate | None,
+    corpus: str | None = None,
 ) -> None:
     """Create or merge the canonical narrator record for *canonical_id*.
 
@@ -750,8 +769,18 @@ def _upsert_canonical(
             "source_ids": [],
             "external_id": None,
             "mention_count": 0,
+            # Corpora this canonical narrator has been observed in (da#103). The
+            # scalar ``source_corpus`` + derived ``sect_affiliation`` are finalized
+            # from this set in :func:`_build_canonical_table`.
+            "source_corpora": [],
         }
         canonical_map[canonical_id] = rec
+
+    norm_corpus = normalize_corpus(corpus)
+    if norm_corpus:
+        corpora = rec.get("source_corpora")
+        if isinstance(corpora, list) and norm_corpus not in corpora:
+            corpora.append(norm_corpus)
 
     raw_count = rec.get("mention_count")
     rec["mention_count"] = (int(raw_count) if isinstance(raw_count, int | str) else 0) + 1
@@ -872,6 +901,7 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
                     name_en=c.name_en,
                     alias=mention_text,
                     candidate=c,
+                    corpus=corpus,
                 )
                 naive_identity_pairs.add((corpus, canonical_id))
                 resolved_map[mention_id] = (canonical_id, float(best.score))
@@ -907,6 +937,7 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
                         name_en=None,
                         alias=None,
                         candidate=None,
+                        corpus=corpus,
                     )
                     naive_identity_pairs.add((corpus, fallback_id))
                     # Self-canonicalized by exact name only (no bio corroboration),

--- a/src/resolve/schemas.py
+++ b/src/resolve/schemas.py
@@ -43,6 +43,15 @@ NARRATORS_CANONICAL_SCHEMA = pa.schema(
         pa.field("source_ids", pa.list_(pa.string()), nullable=True),
         pa.field("external_id", pa.string(), nullable=True),
         pa.field("mention_count", pa.int32(), nullable=True),
+        # Sect/corpus provenance on the canonical narrator (da#103, epic #81).
+        # ``source_corpus`` is the scalar primary corpus (mirrors the Hadith /
+        # Collection node property); ``source_corpora`` is the full multi-source
+        # set; ``sect_affiliation`` is the resolution-time SectAffiliation derived
+        # from those corpora (see src/resolve/sect_affiliation.py). All nullable so
+        # other narrators_canonical producers (#109/#117) need not populate them.
+        pa.field("source_corpus", pa.string(), nullable=True),
+        pa.field("source_corpora", pa.list_(pa.string()), nullable=True),
+        pa.field("sect_affiliation", pa.string(), nullable=True),
     ]
 )
 

--- a/src/resolve/sect_affiliation.py
+++ b/src/resolve/sect_affiliation.py
@@ -1,0 +1,110 @@
+"""Derive a narrator-level :class:`SectAffiliation` from observed source corpora.
+
+Narrator sect is *not* the collection-level binary :class:`~src.models.enums.Sect`
+(``sunni``/``shia``). A narrator — especially a female *muhaddithat* — can transmit
+in chains of more than one tradition, so the narrator-level determination is
+:class:`~src.models.enums.SectAffiliation` (``sunni``/``shia``/``neutral``/``unknown``)
+and it is made at **resolution time** by aggregating the corpora a canonical
+narrator was actually seen in (da#103, epic #81).
+
+Aggregation rule (``derive_sect_affiliation``):
+
+* observed only in Sunni-tradition corpora  → ``sunni``
+* observed only in Shia-tradition corpora   → ``shia``
+* observed in **both** traditions           → ``neutral`` (transmits across them)
+* no corpus maps to a known tradition        → ``unknown``
+
+The corpus→tradition map below is keyed by :class:`~src.models.enums.SourceCorpus`
+*values*, mirroring the per-corpus ``SECT`` the parsers stamp onto Hadith/Collection
+nodes (``src/parse/sunnah_api.py``, ``thaqalayn.py``, ``lk_corpus.py``, …). Two
+corpora are intentionally left unmapped: ``fawaz`` (sect is per-collection, not
+per-corpus) and ``itqan`` (a mixed rijal database) — both contribute ``unknown``
+rather than a guess.
+
+``normalize_corpus`` reconciles the **bio provenance inconsistency** #103 flags:
+``narrators_bio_*`` rows carry a free-text ``source`` that is not always a
+``SourceCorpus`` value (e.g. the sanadset narrator bios use
+``source="kaggle_narrators"``). Producers normalize through it so the scalar
+``Narrator.source_corpus`` stays inside the enum domain (the ``write_parquet``
+provenance gate enforces this), while genuinely-unknown provenance maps to
+``None`` rather than leaking a non-enum string onto the node.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from src.models.enums import Sect, SectAffiliation, SourceCorpus
+
+__all__ = [
+    "derive_sect_affiliation",
+    "normalize_corpus",
+    "primary_corpus",
+    "SECT_BY_CORPUS",
+]
+
+_VALID_CORPORA: frozenset[str] = frozenset(c.value for c in SourceCorpus)
+
+# Free-text bio ``source`` labels that are not yet ``SourceCorpus`` values (#103).
+_CORPUS_ALIASES: dict[str, str] = {
+    "kaggle_narrators": SourceCorpus.SANADSET.value,  # sanadset narrator biographies
+}
+
+# Corpus → collection-level tradition. Unmapped corpora (``fawaz`` per-collection,
+# ``itqan`` mixed rijal DB) contribute nothing → ``unknown`` when nothing maps.
+SECT_BY_CORPUS: dict[str, Sect] = {
+    SourceCorpus.SUNNAH.value: Sect.SUNNI,
+    SourceCorpus.OPEN_HADITH.value: Sect.SUNNI,
+    SourceCorpus.LK.value: Sect.SUNNI,
+    SourceCorpus.SANADSET.value: Sect.SUNNI,
+    SourceCorpus.MUHADDITHAT.value: Sect.SUNNI,
+    SourceCorpus.THAQALAYN.value: Sect.SHIA,
+}
+
+
+def normalize_corpus(source: str | None) -> str | None:
+    """Map a raw corpus / bio-``source`` label to a :class:`SourceCorpus` value.
+
+    Returns the canonical corpus value, or ``None`` when *source* is empty or not
+    a recognized corpus (so callers can drop it rather than tag a node with an
+    out-of-domain provenance string).
+    """
+    if not source:
+        return None
+    resolved = _CORPUS_ALIASES.get(source, source)
+    return resolved if resolved in _VALID_CORPORA else None
+
+
+def primary_corpus(corpora: Iterable[str]) -> str | None:
+    """Return a deterministic primary corpus for a multi-source narrator.
+
+    The canonical narrator carries the full set in ``source_corpora``; the scalar
+    ``source_corpus`` (mirroring the Hadith/Collection node property) is the
+    lexicographically-first observed corpus, or ``None`` when none were observed.
+    Input is assumed already normalized; falsy entries are ignored defensively.
+    """
+    uniq = sorted({c for c in corpora if c})
+    return uniq[0] if uniq else None
+
+
+def derive_sect_affiliation(corpora: Iterable[str]) -> str:
+    """Derive a :class:`SectAffiliation` value from the corpora a narrator spans.
+
+    See the module docstring for the aggregation rule. Each corpus is normalized
+    first (so a not-yet-enum-aligned bio ``source`` still resolves), then mapped to
+    its tradition. Returns the enum *value* (a plain ``str``) so it drops straight
+    into a Parquet string column and the Neo4j ``Narrator.sect_affiliation``
+    property.
+    """
+    sects = set()
+    for raw in corpora:
+        corpus = normalize_corpus(raw)
+        if corpus is not None and corpus in SECT_BY_CORPUS:
+            sects.add(SECT_BY_CORPUS[corpus])
+    if not sects:
+        return SectAffiliation.UNKNOWN.value
+    if sects == {Sect.SUNNI}:
+        return SectAffiliation.SUNNI.value
+    if sects == {Sect.SHIA}:
+        return SectAffiliation.SHIA.value
+    return SectAffiliation.NEUTRAL.value

--- a/tests/integration/test_graph_loading.py
+++ b/tests/integration/test_graph_loading.py
@@ -38,6 +38,10 @@ SAMPLE_NARRATORS = [
         "source_ids": ["src:1"],
         "external_id": "ext:001",
         "mention_count": 5,
+        # da#103: transmits in both Sunni and Shia chains → neutral affiliation.
+        "source_corpus": "sunnah",
+        "source_corpora": ["sunnah", "thaqalayn"],
+        "sect_affiliation": "neutral",
     },
     {
         "canonical_id": "nar:002",
@@ -231,6 +235,11 @@ def _write_narrators_parquet(curated: Path, rows: list[dict[str, Any]]) -> Path:
         "source_ids": pa.array([r.get("source_ids", []) for r in rows], type=pa.list_(pa.string())),
         "external_id": pa.array([r.get("external_id") for r in rows], type=pa.string()),
         "mention_count": pa.array([r.get("mention_count") for r in rows], type=pa.int32()),
+        "source_corpus": pa.array([r.get("source_corpus") for r in rows], type=pa.string()),
+        "source_corpora": pa.array(
+            [r.get("source_corpora", []) for r in rows], type=pa.list_(pa.string())
+        ),
+        "sect_affiliation": pa.array([r.get("sect_affiliation") for r in rows], type=pa.string()),
     }
     table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
     path = curated / "narrators_canonical.parquet"
@@ -411,6 +420,10 @@ class TestNodeLoading:
         assert props["name_en"] == "Abu Hurayrah"
         assert props["death_year_ah"] == 59
         assert props["generation"] == "sahabi"
+        # da#103 live acceptance: Narrator nodes carry sect/corpus provenance.
+        assert props["source_corpus"] == "sunnah"
+        assert sorted(props["source_corpora"]) == ["sunnah", "thaqalayn"]
+        assert props["sect_affiliation"] == "neutral"
 
     def test_idempotent_reload(self, neo4j_client: Neo4jClient, tmp_path: Path) -> None:
         """Loading twice should not duplicate nodes (MERGE semantics)."""

--- a/tests/test_graph/conftest.py
+++ b/tests/test_graph/conftest.py
@@ -97,6 +97,11 @@ def write_narrators_canonical(curated: Path, rows: list[dict[str, Any]]) -> Path
         "source_ids": pa.array([r.get("source_ids", []) for r in rows], type=pa.list_(pa.string())),
         "external_id": pa.array([r.get("external_id") for r in rows], type=pa.string()),
         "mention_count": pa.array([r.get("mention_count") for r in rows], type=pa.int32()),
+        "source_corpus": pa.array([r.get("source_corpus") for r in rows], type=pa.string()),
+        "source_corpora": pa.array(
+            [r.get("source_corpora", []) for r in rows], type=pa.list_(pa.string())
+        ),
+        "sect_affiliation": pa.array([r.get("sect_affiliation") for r in rows], type=pa.string()),
     }
     table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
     path = curated / "narrators_canonical.parquet"

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -50,6 +50,50 @@ class TestLoadNarrators:
         assert narrator_result.created + narrator_result.merged == 2
         assert narrator_result.skipped == 0
 
+    def test_narrator_sets_sect_and_corpus(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """da#103: Narrator nodes carry sect_affiliation + source_corpus/_corpora."""
+        write_narrators_canonical(
+            curated_dir,
+            [
+                {
+                    "canonical_id": "nar:cross-sect",
+                    "name_en": "Cross Sect",
+                    "source_corpus": "sunnah",
+                    "source_corpora": ["sunnah", "thaqalayn"],
+                    "sect_affiliation": "neutral",
+                },
+            ],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        query, batch = next((q, b) for q, b in mock_client.calls if "MERGE (n:Narrator" in q)
+        # The MERGE explicitly SETs each property (no blanket ``SET n += row``).
+        assert "n.source_corpus" in query
+        assert "n.source_corpora" in query
+        assert "n.sect_affiliation" in query
+        assert isinstance(batch, list)
+        row = batch[0]
+        assert row["source_corpus"] == "sunnah"
+        assert row["source_corpora"] == ["sunnah", "thaqalayn"]
+        assert row["sect_affiliation"] == "neutral"
+
+    def test_narrator_sect_corpus_defaults_when_absent(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """A legacy canonical row with null sect/corpus loads with safe defaults."""
+        write_narrators_canonical(
+            curated_dir,
+            [{"canonical_id": "nar:legacy", "name_en": "Legacy"}],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        _, batch = next((q, b) for q, b in mock_client.calls if "MERGE (n:Narrator" in q)
+        assert isinstance(batch, list)
+        row = batch[0]
+        assert row["source_corpus"] == ""
+        assert row["source_corpora"] == []
+        assert row["sect_affiliation"] == "unknown"
+
     def test_invalid_canonical_id_skipped(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
     ) -> None:

--- a/tests/test_parse/test_provenance_conformance.py
+++ b/tests/test_parse/test_provenance_conformance.py
@@ -120,9 +120,29 @@ class TestProvenanceValidatorCatchesGaps:
         assert any("source" in p and "empty" in p for p in problems)
 
     def test_null_provenance_flagged(self) -> None:
-        table = pa.table({"sect": ["sunni", None], "source_corpus": ["sunnah", "sunnah"]})
+        # A null in a column the schema declares NON-nullable is flagged (the
+        # parser-staging contract: sect/source_corpus are mandatory tags).
+        schema = pa.schema(
+            [
+                pa.field("sect", pa.string(), nullable=False),
+                pa.field("source_corpus", pa.string(), nullable=False),
+            ]
+        )
+        table = pa.table(
+            {"sect": ["sunni", None], "source_corpus": ["sunnah", "sunnah"]}, schema=schema
+        )
         problems = provenance_violations(table)
         assert any("sect" in p and "null" in p for p in problems)
+
+    def test_null_allowed_in_nullable_column(self) -> None:
+        # A resolve-derived NULLABLE provenance column (e.g. narrators_canonical
+        # ``source_corpus``, da#103) permits null — "no attributable corpus" — but
+        # empty-string / wrong-domain are still caught on the values that ARE present.
+        schema = pa.schema([pa.field("source_corpus", pa.string(), nullable=True)])
+        clean = pa.table({"source_corpus": ["sunnah", None]}, schema=schema)
+        assert provenance_violations(clean) == []
+        bad = pa.table({"source_corpus": ["sunna", None]}, schema=schema)
+        assert any("source_corpus" in p and "outside" in p for p in provenance_violations(bad))
 
 
 class TestWriteParquetEnforces:

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -63,6 +63,34 @@ def test_promotes_bios_to_canonical_with_nar_ids(tmp_path: Path) -> None:
     assert rec["mention_count"] == 0
 
 
+def test_bio_promote_tags_sect_and_corpus(tmp_path: Path) -> None:
+    """da#103: promoted bios carry source_corpus/_corpora + derived sect_affiliation."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    name = "فاطمة بنت محمد"
+    _write_bios(
+        staging,
+        "muhaddithat",
+        [
+            {
+                "bio_id": "muhaddithat:1",
+                "source": "muhaddithat",
+                "name_ar": name,
+                "name_ar_normalized": normalize_arabic(name),
+            }
+        ],
+    )
+
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    rec = pq.read_table(path).to_pylist()[0]
+    assert rec["source_corpora"] == ["muhaddithat"]
+    assert rec["source_corpus"] == "muhaddithat"
+    assert rec["sect_affiliation"] == "sunni"
+
+
 def test_same_name_dedups_to_one_canonical(tmp_path: Path) -> None:
     staging = tmp_path / "staging"
     staging.mkdir()

--- a/tests/test_resolve/test_schemas.py
+++ b/tests/test_resolve/test_schemas.py
@@ -60,9 +60,15 @@ class TestSampleData:
             "source_ids": pa.array([["bio-1"]], type=pa.list_(pa.string())),
             "external_id": pa.array([None], type=pa.string()),
             "mention_count": pa.array([5], type=pa.int32()),
+            "source_corpus": pa.array(["sunnah"], type=pa.string()),
+            "source_corpora": pa.array([["sunnah", "thaqalayn"]], type=pa.list_(pa.string())),
+            "sect_affiliation": pa.array(["neutral"], type=pa.string()),
         }
         table = pa.table(data, schema=NARRATORS_CANONICAL_SCHEMA)
         assert table.num_rows == 1
+        assert {"source_corpus", "source_corpora", "sect_affiliation"} <= set(
+            NARRATORS_CANONICAL_SCHEMA.names
+        )
 
     def test_ambiguous_narrators(self) -> None:
         data = {

--- a/tests/test_resolve/test_sect_affiliation.py
+++ b/tests/test_resolve/test_sect_affiliation.py
@@ -1,0 +1,60 @@
+"""Tests for narrator-level sect derivation (da#103)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.resolve.sect_affiliation import (
+    derive_sect_affiliation,
+    normalize_corpus,
+    primary_corpus,
+)
+
+
+class TestNormalizeCorpus:
+    def test_passthrough_valid(self) -> None:
+        assert normalize_corpus("sunnah") == "sunnah"
+        assert normalize_corpus("thaqalayn") == "thaqalayn"
+
+    def test_alias_mapped(self) -> None:
+        assert normalize_corpus("kaggle_narrators") == "sanadset"
+
+    def test_unknown_and_empty_to_none(self) -> None:
+        assert normalize_corpus("not_a_corpus") is None
+        assert normalize_corpus("") is None
+        assert normalize_corpus(None) is None
+
+
+class TestDeriveSectAffiliation:
+    @pytest.mark.parametrize(
+        "corpora,expected",
+        [
+            (["sunnah"], "sunni"),
+            (["sunnah", "open_hadith"], "sunni"),
+            (["thaqalayn"], "shia"),
+            (["sunnah", "thaqalayn"], "neutral"),  # transmits in both traditions
+            (["muhaddithat", "thaqalayn"], "neutral"),
+            (["kaggle_narrators"], "sunni"),  # sanadset bio provenance alias
+            ([], "unknown"),
+            (["itqan"], "unknown"),  # mixed rijal DB — intentionally unmapped
+            (["fawaz"], "unknown"),  # per-collection sect, not per-corpus
+            (["itqan", "thaqalayn"], "shia"),  # unmapped corpus drops out
+        ],
+    )
+    def test_derivation(self, corpora: list[str], expected: str) -> None:
+        assert derive_sect_affiliation(corpora) == expected
+
+    def test_ignores_empty_strings(self) -> None:
+        assert derive_sect_affiliation(["", "sunnah"]) == "sunni"
+
+
+class TestPrimaryCorpus:
+    def test_lexicographically_first(self) -> None:
+        assert primary_corpus(["thaqalayn", "sunnah"]) == "sunnah"
+
+    def test_dedups(self) -> None:
+        assert primary_corpus(["sunnah", "sunnah"]) == "sunnah"
+
+    def test_none_when_empty(self) -> None:
+        assert primary_corpus([]) is None
+        assert primary_corpus(["", None]) is None  # type: ignore[list-item]


### PR DESCRIPTION
## Summary

`Closes #103`. Narrator (and edge) graph nodes carried **no** `sect_affiliation`/`source_corpus` for any source — only Hadith/Collection nodes did. This wires sect/corpus provenance through the full chain `resolve → canonical-schema → loader` so a Narrator node in Neo4j is sect- and corpus-tagged.

## Changes

**Schema** (`src/resolve/schemas.py`)
- `NARRATORS_CANONICAL_SCHEMA` gains `source_corpus` (scalar primary), `source_corpora` (multi-source list), `sect_affiliation` — **all nullable** so the other `narrators_canonical` producers (#109 / #117) are not forced to populate them.

**Derivation** (new `src/resolve/sect_affiliation.py`)
- `derive_sect_affiliation(corpora)` → narrator-level `SectAffiliation` (`sunni`/`shia`/`neutral`/`unknown`). Aggregation: only-Sunni→`sunni`, only-Shia→`shia`, **both→`neutral`** (a muhaddithat transmitting across Sunni *and* Shia chains), nothing-mapped→`unknown`. The corpus→tradition map mirrors the per-corpus `SECT` the parsers stamp; `fawaz` (per-collection sect) and `itqan` (mixed rijal DB) are intentionally unmapped → `unknown` rather than a guess.
- `normalize_corpus()` reconciles the **bio-provenance inconsistency** the issue flags (sanadset bios carry `source="kaggle_narrators"`, not a `SourceCorpus` value) so the scalar `Narrator.source_corpus` stays inside the enum domain; genuinely-unknown provenance → dropped.

**Producers** (`disambiguate.py`, `bio_promote.py`)
- `disambiguate` accumulates each mention's `source_corpus`; `bio_promote` each bio's normalized `source`. `bio_promote` is **merge-safe** — it unions onto corpora a prior `disambiguate` run already recorded (`_load_existing_canonical` setdefaults `source_corpora`), preserving the two-producer ordering contract.

**Loader** (`src/graph/load_nodes.py`)
- `_NARRATOR_MERGE` SETs `n.source_corpus` / `n.source_corpora` / `n.sect_affiliation` (explicit SET, no blanket `SET n += row`). Legacy/unpopulated rows default to `""` / `[]` / `"unknown"`.

**Provenance gate** (`src/parse/base.py`)
- Adding `source_corpus` to the canonical schema newly subjected `narrators_canonical.parquet` to `write_parquet`'s `provenance_violations` gate. The gate's null-check now **honors schema nullability**: a null is a violation only for a **non-nullable** provenance column (parser staging, where the tag is mandatory); the resolve-derived **nullable** canonical `source_corpus` permits null ("no attributable corpus"). Empty-string + wrong-domain checks still apply to present values for both — so a bad corpus on a canonical narrator is still caught.

## How `sect_affiliation` is derived
From the set of corpora a canonical narrator was actually observed in (mentions + promoted bios), each normalized to a `SourceCorpus` value, each mapped to its collection-level tradition, then aggregated (both traditions ⇒ `neutral`). It is a **resolution-time** determination, distinct from the collection-level binary `Sect` on Hadith/Collection nodes.

## Test Plan
- `tests/test_resolve/test_sect_affiliation.py` — derivation table + `normalize_corpus` (alias/unknown/empty).
- `tests/test_resolve/test_schemas.py` — canonical schema carries the three fields.
- `tests/test_resolve/test_bio_promote.py` — promoted bios carry source_corpus/_corpora + derived sect.
- `tests/test_graph/test_load_nodes.py` — loader SETs all three (populated + legacy-default).
- `tests/test_parse/test_provenance_conformance.py` — null allowed in nullable column, still flagged in non-nullable; domain/empty still enforced.
- `tests/integration/test_graph_loading.py::test_narrator_properties` — **live `neo4j:5` acceptance**: a loaded Narrator node carries `sect_affiliation="neutral"`, `source_corpus="sunnah"`, `source_corpora=["sunnah","thaqalayn"]`. *(This is the live-Neo4j node-tagging proof #83 originally named, relocated here per the issue.)*
- Full suite: 709 passed, 3 skipped. `ruff format --check` + `ruff check` clean; `mypy src/` clean.

## Coordination (serial-merge)
- Files touched: `src/resolve/schemas.py`, `src/resolve/disambiguate.py`, `src/resolve/bio_promote.py`, `src/graph/load_nodes.py`, `src/parse/base.py` (+ the new `sect_affiliation.py`). The new schema field is **nullable** → #109 (disambiguate/load_edges) and #117 (resolve/`__init__`) producers need not populate it; if they write `narrators_canonical`, a null `source_corpus` is now legal under the refreshed provenance gate.
- da#90 (muhaddithat e2e) can tag at the parser side and rely on this schema as the canonical home for narrator sect/corpus.

Reviewers: @Kavitha Sundaramurthy (primary), @Oyunbileg Batbayar (QA).
