### PR TITLE
feat(itqan): emit isnad chains→edges (#93) + name variants→aliases (#94)

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -19,8 +19,10 @@ from src.parse.identity import (
     collection_node_id,
     grading_node_id,
     hadith_node_id,
+    make_canonical_id,
     narrator_node_id,
 )
+from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
 from src.utils.neo4j_client import Neo4jClient
 
@@ -477,7 +479,7 @@ def _load_parallel_of(
 
 
 # ---------------------------------------------------------------------------
-# 5. STUDIED_UNDER — from network_edges_muhaddithat.parquet
+# 5. STUDIED_UNDER — from every network_edges_*.parquet (muhaddithat, itqan, …)
 # ---------------------------------------------------------------------------
 
 _STUDIED_UNDER_QUERY = """\
@@ -498,35 +500,62 @@ RETURN row.from_id AS from_id,
 """
 
 
+def _studied_under_endpoint(name: Any, external_id: Any) -> str | None:
+    """Resolve a NETWORK_EDGE endpoint to a canonical Narrator node id.
+
+    Canonical Narrator nodes are keyed ``nar:<uuid5(normalized-name)>``
+    (``identity.make_canonical_id``) — by the narrator's *name*, not by the
+    source's external id. An edge endpoint must therefore be resolved the same
+    way the bio that created the node was: through the name. We key on the
+    narrator name (the value that actually matches a node) and only fall back to
+    prefixing a pre-canonical id when the name is absent. Resolving by
+    ``narrator_node_id(external_id)`` — as an earlier revision did — produced
+    ``nar:<source-id>`` ids that match no canonical node, so every edge was
+    silently dropped as a missing endpoint.
+    """
+    if isinstance(name, str) and name.strip():
+        return make_canonical_id(normalize_arabic(name))
+    if isinstance(external_id, str) and external_id.strip():
+        return narrator_node_id(external_id)
+    return None
+
+
 def _load_studied_under(
     client: Neo4jClient,
     staging_dir: Path,
     *,
     batch_size: int = DEFAULT_BATCH_SIZE,
 ) -> EdgeLoadResult:
-    """Load STUDIED_UNDER edges from network_edges_muhaddithat.parquet.
+    """Load STUDIED_UNDER edges from every ``network_edges_*.parquet``.
 
-    Gracefully skips if file does not exist.
+    Source-agnostic: muhaddithat, itqan, and any future NETWORK_EDGE producer are
+    picked up by glob (mirroring how the bio/canonical loaders glob their inputs).
+    Gracefully skips when no such file exists.
     """
-    path = staging_dir / "network_edges_muhaddithat.parquet"
-    if not path.exists():
-        logger.info("studied_under_skipped", reason="file_not_found", path=str(path))
+    edge_files = _parquet_files(staging_dir, "network_edges_")
+    if not edge_files:
+        logger.info("studied_under_skipped", reason="file_not_found", staging_dir=str(staging_dir))
         return EdgeLoadResult("STUDIED_UNDER", 0, 0, 0)
 
-    rows = _read_parquet_rows(path)
     batch: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
     skipped = 0
 
-    for row in rows:
-        from_id = row.get("from_external_id") or row.get("from_narrator_name")
-        to_id = row.get("to_external_id") or row.get("to_narrator_name")
-        if not from_id or not to_id:
-            skipped += 1
-            continue
-        # Ensure narrator prefix
-        full_from = narrator_node_id(from_id)
-        full_to = narrator_node_id(to_id)
-        batch.append({"from_id": full_from, "to_id": full_to})
+    for path in edge_files:
+        for row in _read_parquet_rows(path):
+            from_id = _studied_under_endpoint(
+                row.get("from_narrator_name"), row.get("from_external_id")
+            )
+            to_id = _studied_under_endpoint(row.get("to_narrator_name"), row.get("to_external_id"))
+            if not from_id or not to_id:
+                skipped += 1
+                continue
+            # Dedup the same student->teacher pair across source files.
+            key = (from_id, to_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            batch.append({"from_id": from_id, "to_id": to_id})
 
     if not batch:
         logger.info("studied_under_no_edges")

--- a/src/parse/itqan.py
+++ b/src/parse/itqan.py
@@ -1,16 +1,34 @@
-"""Parse the Itqan rijal dataset into NARRATOR_BIO staging Parquet.
+"""Parse the Itqan rijal dataset into staging Parquet.
 
-Produces one output file — ``narrators_bio_itqan.parquet`` (NARRATOR_BIO_SCHEMA)
-— from the per-grade profile buckets downloaded by ``src/acquire/itqan.py``.
+Produces three output files from the per-grade profile buckets downloaded by
+``src/acquire/itqan.py``:
+
+* ``narrators_bio_itqan.parquet``    (NARRATOR_BIO_SCHEMA)   — the bios (da#92a).
+* ``network_edges_itqan.parquet``    (NETWORK_EDGE_SCHEMA)   — teacher↔student
+  transmission edges built from each profile's ``teachers``/``students`` id
+  lists (da#93). Loaded as ``STUDIED_UNDER`` edges, mirroring muhaddithat.
+* ``narrator_aliases_itqan.parquet`` (NARRATOR_ALIAS_SCHEMA) — name variants
+  from each profile's ``namings`` array (da#94), keyed to the same canonical
+  identity the bio mints so the resolve stage attaches them as aliases.
 
 Each bucket file (``profiles_<grade>.json``) is a JSON object keyed by the
 narrator id; every value is a profile dict. The jarh-wa-ta'dil grade is carried
 both by the filename bucket and the per-profile ``grade_en`` field (they agree);
 we trust the per-profile field and fall back to the bucket.
 
-Scope (da#92a — narrators only): the ``teachers``/``students`` id lists (isnad
-edges, #93) and the ``namings``/``by_name`` name variants (#94) are deliberately
-NOT emitted here — this PR populates Narrator bios only.
+Edges (da#93): Itqan is a rijal database — it has no hadith-scoped isnad chains,
+so there is nothing to emit as NARRATOR_MENTION rows (those need a
+``source_hadith_id`` + ``position_in_chain``). Instead each profile carries the
+ids of its ``teachers`` and ``students``; the transmission relation is
+``student STUDIED_UNDER teacher`` (``from_narrator`` = student, ``to_narrator`` =
+teacher), exactly the orientation the muhaddithat NETWORK_EDGE loader uses. A
+profile P thus contributes ``(P -> t)`` for each teacher t and ``(s -> P)`` for
+each student s; the two perspectives are deduplicated on the id pair.
+
+Aliases (da#94): each profile's ``namings`` array lists alternate spellings of
+the narrator's name. We emit one alias row per distinct variant, tagged with the
+profile's canonical normalized name so ``bio_promote`` can union the variants
+onto the matching ``nar:`` record without re-reading the source.
 """
 
 from __future__ import annotations
@@ -22,7 +40,11 @@ from pathlib import Path
 import pyarrow as pa
 
 from src.parse.base import safe_str, write_parquet
-from src.parse.schemas import NARRATOR_BIO_SCHEMA
+from src.parse.schemas import (
+    NARRATOR_ALIAS_SCHEMA,
+    NARRATOR_BIO_SCHEMA,
+    NETWORK_EDGE_SCHEMA,
+)
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
 
@@ -144,22 +166,138 @@ def _parse_profile(raw_id: str, profile: dict[str, object]) -> dict[str, object 
     }
 
 
-def _parse_profiles_file(path: Path) -> list[dict[str, object | None]]:
-    """Parse one ``profiles_<grade>.json`` bucket into bio rows."""
-    data = json.loads(path.read_text(encoding="utf-8"))
-    rows: list[dict[str, object | None]] = []
-    for raw_id, profile in data.items():
-        if not isinstance(profile, dict):
+def _id_list(value: object) -> list[str]:
+    """Coerce a ``teachers``/``students`` field (ints or strs) to clean id strings."""
+    if not isinstance(value, list):
+        return []
+    ids: list[str] = []
+    for item in value:
+        s = safe_str(item)
+        if s:
+            ids.append(s)
+    return ids
+
+
+def _iter_profiles(bucket_files: list[Path]) -> list[tuple[str, dict[str, object]]]:
+    """Load every bucket into a flat ``(profile_id, profile)`` list.
+
+    ``id`` is globally unique across buckets (verified — da#92a); the first
+    occurrence of a profile id wins so re-running over an overlapping bucket set
+    does not double-count. A profile with no id is dropped (it can key neither a
+    bio nor a transmission edge).
+    """
+    profiles: list[tuple[str, dict[str, object]]] = []
+    seen: set[str] = set()
+    for bucket in bucket_files:
+        data = json.loads(bucket.read_text(encoding="utf-8"))
+        count = 0
+        for raw_id, profile in data.items():
+            if not isinstance(profile, dict):
+                continue
+            pid = safe_str(profile.get("id")) or safe_str(raw_id)
+            if pid is None:
+                continue
+            if pid in seen:
+                logger.warning("itqan_duplicate_profile_id", profile_id=pid)
+                continue
+            seen.add(pid)
+            profiles.append((pid, profile))
+            count += 1
+        logger.info("itqan_bucket_parsed", file=bucket.name, profiles=count)
+    return profiles
+
+
+def _build_edges(
+    profiles: list[tuple[str, dict[str, object]]],
+    id_to_name: dict[str, str],
+) -> list[dict[str, str | None]]:
+    """Build deduplicated ``student -> teacher`` STUDIED_UNDER edges (da#93).
+
+    For each profile P: ``P -> t`` for every teacher ``t`` in ``P.teachers``, and
+    ``s -> P`` for every student ``s`` in ``P.students``. ``from`` is always the
+    student, ``to`` the teacher (the orientation the NETWORK_EDGE loader maps to
+    ``(student)-[:STUDIED_UNDER]->(teacher)``). The same edge surfaces from both
+    endpoints, so it is deduplicated on the ``(from_id, to_id)`` id pair. The name
+    columns fall back to the bare id when a referenced profile is absent from the
+    parsed slice, keeping them non-null per NETWORK_EDGE_SCHEMA.
+    """
+    edges: list[dict[str, str | None]] = []
+    seen_pairs: set[tuple[str, str]] = set()
+
+    def _add(student_id: str, teacher_id: str) -> None:
+        if student_id == teacher_id:
+            return
+        key = (student_id, teacher_id)
+        if key in seen_pairs:
+            return
+        seen_pairs.add(key)
+        edges.append(
+            {
+                "from_narrator_name": id_to_name.get(student_id, student_id),
+                "to_narrator_name": id_to_name.get(teacher_id, teacher_id),
+                "hadith_id": None,  # rijal transmission network — not hadith-scoped
+                "source": SOURCE,
+                "from_external_id": student_id,
+                "to_external_id": teacher_id,
+            }
+        )
+
+    for pid, profile in profiles:
+        for teacher_id in _id_list(profile.get("teachers")):
+            _add(pid, teacher_id)
+        for student_id in _id_list(profile.get("students")):
+            _add(student_id, pid)
+
+    return edges
+
+
+def _build_aliases(profiles: list[tuple[str, dict[str, object]]]) -> list[dict[str, str]]:
+    """Build name-variant alias rows from each profile's ``namings`` array (da#94).
+
+    One row per distinct variant whose normalized form differs from the
+    narrator's primary normalized name — the primary spelling is not an alias of
+    itself, and exact duplicate variants are collapsed. ``canonical_name_ar_normalized``
+    carries the primary normalized name so ``bio_promote`` can key each variant
+    onto the matching ``nar:`` record.
+    """
+    rows: list[dict[str, str]] = []
+    for pid, profile in profiles:
+        name_ar = _clean(profile.get("full_name"))
+        if name_ar is None:
+            continue  # no canonical name to attach the variants to
+        canonical_norm = normalize_arabic(name_ar)
+        namings = profile.get("namings")
+        if not isinstance(namings, list):
             continue
-        row = _parse_profile(raw_id, profile)
-        if row is not None:
-            rows.append(row)
-    logger.info("itqan_bucket_parsed", file=path.name, rows=len(rows))
+        bio_id = f"{SOURCE}:{pid}"
+        seen: set[str] = set()
+        for raw_variant in namings:
+            variant = _clean(raw_variant)
+            if variant is None:
+                continue
+            variant_norm = normalize_arabic(variant)
+            if not variant_norm or variant_norm == canonical_norm or variant_norm in seen:
+                continue
+            seen.add(variant_norm)
+            rows.append(
+                {
+                    "bio_id": bio_id,
+                    "source": SOURCE,
+                    "canonical_name_ar_normalized": canonical_norm,
+                    "alias": variant,
+                    "alias_normalized": variant_norm,
+                }
+            )
     return rows
 
 
-def run(raw_dir: Path, staging_dir: Path) -> Path:
-    """Parse Itqan rijal buckets into ``narrators_bio_itqan.parquet``."""
+def run(raw_dir: Path, staging_dir: Path) -> list[Path]:
+    """Parse Itqan rijal buckets into bio, network-edge, and alias Parquet.
+
+    Returns ``[bios, edges, aliases]``. ``src.parse.run_all`` flattens a list
+    result, so a single adapter emitting three staging files is a first-class
+    return shape (``ParseOutput``).
+    """
     source_dir = raw_dir / "itqan"
     if not source_dir.exists():
         msg = f"Source directory not found: {source_dir}"
@@ -170,25 +308,47 @@ def run(raw_dir: Path, staging_dir: Path) -> Path:
         msg = f"No profiles_*.json buckets under {source_dir}"
         raise FileNotFoundError(msg)
 
-    rows: list[dict[str, object | None]] = []
-    seen_bio_ids: set[str] = set()
-    for bucket in bucket_files:
-        for row in _parse_profiles_file(bucket):
-            bio_id = str(row["bio_id"])
-            if bio_id in seen_bio_ids:
-                logger.warning("itqan_duplicate_bio_id", bio_id=bio_id)
-                continue
-            seen_bio_ids.add(bio_id)
-            rows.append(row)
+    profiles = _iter_profiles(bucket_files)
 
-    if not rows:
+    # Bios (da#92a) — every named profile becomes a NARRATOR_BIO row.
+    bio_rows: list[dict[str, object | None]] = []
+    for pid, profile in profiles:
+        row = _parse_profile(pid, profile)
+        if row is not None:
+            bio_rows.append(row)
+    if not bio_rows:
         msg = "No valid Itqan narrator bios parsed"
         raise ValueError(msg)
+    bio_arrays = {f.name: [r[f.name] for r in bio_rows] for f in NARRATOR_BIO_SCHEMA}
+    bio_table = pa.table(bio_arrays, schema=NARRATOR_BIO_SCHEMA)
+    bio_path = staging_dir / "narrators_bio_itqan.parquet"
+    write_parquet(bio_table, bio_path, schema=NARRATOR_BIO_SCHEMA)
 
-    arrays = {field.name: [r[field.name] for r in rows] for field in NARRATOR_BIO_SCHEMA}
-    table = pa.table(arrays, schema=NARRATOR_BIO_SCHEMA)
+    # Network edges (da#93) — teacher/student id lists -> STUDIED_UNDER edges.
+    id_to_name: dict[str, str] = {}
+    for pid, profile in profiles:
+        name = _clean(profile.get("full_name"))
+        if name is not None:
+            id_to_name[pid] = name
+    edges = _build_edges(profiles, id_to_name)
+    edge_arrays = {f.name: [e[f.name] for e in edges] for f in NETWORK_EDGE_SCHEMA}
+    edge_table = pa.table(edge_arrays, schema=NETWORK_EDGE_SCHEMA)
+    edge_path = staging_dir / "network_edges_itqan.parquet"
+    write_parquet(edge_table, edge_path, schema=NETWORK_EDGE_SCHEMA)
 
-    out_path = staging_dir / "narrators_bio_itqan.parquet"
-    write_parquet(table, out_path, schema=NARRATOR_BIO_SCHEMA)
-    logger.info("itqan_bios_parsed", total=len(rows), buckets=len(bucket_files))
-    return out_path
+    # Name variants (da#94) -> identity aliases consumed by bio_promote.
+    aliases = _build_aliases(profiles)
+    alias_arrays = {f.name: [a[f.name] for a in aliases] for f in NARRATOR_ALIAS_SCHEMA}
+    alias_table = pa.table(alias_arrays, schema=NARRATOR_ALIAS_SCHEMA)
+    alias_path = staging_dir / "narrator_aliases_itqan.parquet"
+    write_parquet(alias_table, alias_path, schema=NARRATOR_ALIAS_SCHEMA)
+
+    logger.info(
+        "itqan_parsed",
+        buckets=len(bucket_files),
+        profiles=len(profiles),
+        bios=len(bio_rows),
+        edges=len(edges),
+        aliases=len(aliases),
+    )
+    return [bio_path, edge_path, alias_path]

--- a/src/parse/schemas.py
+++ b/src/parse/schemas.py
@@ -13,6 +13,7 @@ __all__ = [
     "HADITH_SCHEMA",
     "NARRATOR_MENTION_SCHEMA",
     "NARRATOR_BIO_SCHEMA",
+    "NARRATOR_ALIAS_SCHEMA",
     "COLLECTION_SCHEMA",
     "NETWORK_EDGE_SCHEMA",
 ]
@@ -102,5 +103,24 @@ NETWORK_EDGE_SCHEMA = pa.schema(
         pa.field("source", pa.string(), nullable=False),
         pa.field("from_external_id", pa.string(), nullable=True),
         pa.field("to_external_id", pa.string(), nullable=True),
+    ]
+)
+
+# One row per (narrator, distinct name-variant). Produced by rijal-style sources
+# that carry alternate spellings of a narrator's name (e.g. Itqan ``namings`` —
+# da#94). ``canonical_name_ar_normalized`` is the SAME normalized form the bio
+# carries as ``name_ar_normalized`` and from which ``identity.make_canonical_id``
+# mints the ``nar:`` id, so the resolve stage (``bio_promote``) can attach each
+# variant to the right canonical Narrator without re-parsing the source. The
+# variant is stored both raw (``alias``) and Arabic-normalized (``alias_normalized``)
+# — the normalized form is what a future matcher keys on, the raw form preserves
+# the source spelling for provenance/display.
+NARRATOR_ALIAS_SCHEMA = pa.schema(
+    [
+        pa.field("bio_id", pa.string(), nullable=False),
+        pa.field("source", pa.string(), nullable=False),
+        pa.field("canonical_name_ar_normalized", pa.string(), nullable=False),
+        pa.field("alias", pa.string(), nullable=False),
+        pa.field("alias_normalized", pa.string(), nullable=False),
     ]
 )

--- a/src/parse/validate.py
+++ b/src/parse/validate.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, ConfigDict
 from src.parse.schemas import (
     COLLECTION_SCHEMA,
     HADITH_SCHEMA,
+    NARRATOR_ALIAS_SCHEMA,
     NARRATOR_BIO_SCHEMA,
     NARRATOR_MENTION_SCHEMA,
     NETWORK_EDGE_SCHEMA,
@@ -37,6 +38,7 @@ EXPECTED_SCHEMAS: dict[str, pa.Schema] = {
     "hadiths_": HADITH_SCHEMA,
     "narrator_mentions_": NARRATOR_MENTION_SCHEMA,
     "narrators_bio_": NARRATOR_BIO_SCHEMA,
+    "narrator_aliases_": NARRATOR_ALIAS_SCHEMA,
     "collections_": COLLECTION_SCHEMA,
     "network_edges_": NETWORK_EDGE_SCHEMA,
 }
@@ -150,6 +152,9 @@ DEFAULT_BASELINES: dict[str, dict[str, float | int]] = {
     "collections_lk": {"row_count": 6},
     "collections_fawaz": {"row_count": 0},
     "network_edges_muhaddithat": {"row_count": 330},
+    # Itqan teacher/student transmission edges and name variants (da#93 / da#94).
+    "network_edges_itqan": {"row_count": 100656},
+    "narrator_aliases_itqan": {"row_count": 217762},
 }
 
 DEFAULT_DRIFT_TOLERANCE_PCT = 30.0
@@ -164,6 +169,7 @@ REQUIRED_COLUMNS: dict[str, set[str]] = {
         "position_in_chain",
     },
     "narrators_bio_": {"bio_id", "source"},
+    "narrator_aliases_": {"bio_id", "source", "canonical_name_ar_normalized", "alias"},
     "collections_": {"collection_id", "name_en", "sect", "source_corpus"},
     "network_edges_": {"from_narrator_name", "to_narrator_name", "source"},
 }

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -70,6 +70,42 @@ def _load_existing_canonical(path: Path) -> dict[str, dict[str, Any]]:
     return rows
 
 
+def _merge_aliases(
+    staging_dir: Path,
+    canonical_map: dict[str, dict[str, Any]],
+    *,
+    sources: set[str] | None,
+) -> int:
+    """Union name-variant aliases from ``narrator_aliases_*.parquet`` (da#94).
+
+    Each alias row carries ``canonical_name_ar_normalized`` — the SAME normalized
+    name the bio mints its ``nar:`` id from — so a variant attaches to exactly the
+    canonical record the matching bio produced. Variants are only attached to
+    records that already exist (an alias never *creates* a narrator: a profile
+    with variants but no promotable bio has no canonical identity to anchor them).
+    Duplicates and the primary spelling are skipped. Returns the number of new
+    alias strings added.
+    """
+    alias_files = sorted(staging_dir.glob("narrator_aliases_*.parquet"))
+    added = 0
+    for af in alias_files:
+        for row in pq.read_table(af).to_pylist():
+            if sources is not None and safe_str(row.get("source")) not in sources:
+                continue
+            norm = safe_str(row.get("canonical_name_ar_normalized"))
+            variant = safe_str(row.get("alias_normalized"))
+            if not norm or not variant:
+                continue
+            rec = canonical_map.get(make_canonical_id(norm))
+            if rec is None:
+                continue  # no promoted bio for this name — nothing to anchor to
+            aliases = rec.setdefault("aliases", [])
+            if variant != rec.get("name_ar_normalized") and variant not in aliases:
+                aliases.append(variant)
+                added += 1
+    return added
+
+
 def promote_bios_to_canonical(
     staging_dir: Path,
     output_dir: Path,
@@ -178,6 +214,9 @@ def promote_bios_to_canonical(
         rec["source_corpus"] = primary_corpus(corpora)
         rec["sect_affiliation"] = derive_sect_affiliation(corpora)
 
+    # Attach name-variant aliases onto the canonical records the bios produced.
+    aliases_added = _merge_aliases(staging_dir, canonical_map, sources=sources)
+
     table_rows = list(canonical_map.values())
     arrays = {f.name: [r.get(f.name) for r in table_rows] for f in NARRATORS_CANONICAL_SCHEMA}
     out_table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
@@ -191,5 +230,6 @@ def promote_bios_to_canonical(
         pre_existing=pre_existing,
         skipped_no_name=skipped_no_name,
         skipped_source=skipped_source,
+        aliases_added=aliases_added,
     )
     return canonical_path

--- a/tests/integration/test_itqan_load.py
+++ b/tests/integration/test_itqan_load.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pyarrow.parquet as pq
 import pytest
 
+from src.graph.load_edges import _load_studied_under
 from src.graph.load_nodes import load_all_nodes
 from src.parse import itqan
 from src.resolve.bio_promote import promote_bios_to_canonical
@@ -96,3 +97,45 @@ class TestItqanNarratorLoadLive:
         load_all_nodes(neo4j_client, staging, curated, strict=False)
         second = neo4j_client.execute_read("MATCH (n:Narrator) RETURN count(n) AS n")[0]["n"]
         assert first == second  # MERGE on canonical_id — no duplicate nodes
+
+    def test_itqan_chains_load_as_studied_under_edges(self, neo4j_client, tmp_path: Path) -> None:
+        # da#93: teacher/student id lists -> STUDIED_UNDER edges that actually
+        # connect two canonical Narrator nodes in the live graph.
+        raw = tmp_path / "raw" / "itqan"
+        raw.mkdir(parents=True)
+        shutil.copy(FIXTURE, raw / "profiles_sample.json")
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        curated = tmp_path / "curated"
+        curated.mkdir()
+
+        itqan.run(tmp_path / "raw", staging)
+        promote_bios_to_canonical(staging, curated, sources={"itqan"})
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+
+        result = _load_studied_under(neo4j_client, staging)
+        assert result.created > 0, "at least one Itqan chain must connect two loaded narrators"
+
+        edges = neo4j_client.execute_read(
+            "MATCH (:Narrator)-[r:STUDIED_UNDER]->(:Narrator) RETURN count(r) AS n"
+        )[0]["n"]
+        assert edges == result.created
+
+    def test_itqan_name_variants_load_as_node_aliases(self, neo4j_client, tmp_path: Path) -> None:
+        # da#94: namings -> aliases attached to the canonical Narrator node.
+        raw = tmp_path / "raw" / "itqan"
+        raw.mkdir(parents=True)
+        shutil.copy(FIXTURE, raw / "profiles_sample.json")
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        curated = tmp_path / "curated"
+        curated.mkdir()
+
+        itqan.run(tmp_path / "raw", staging)
+        promote_bios_to_canonical(staging, curated, sources={"itqan"})
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+
+        with_aliases = neo4j_client.execute_read(
+            "MATCH (n:Narrator) WHERE size(n.aliases) > 0 RETURN count(n) AS n"
+        )[0]["n"]
+        assert with_aliases > 0, "Itqan name variants must land as node aliases"

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -4,20 +4,40 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from src.graph.load_edges import (
     _APPEARS_IN_QUERY,
     EdgeLoadResult,
     _build_chain_pairs,
+    _load_studied_under,
+    _studied_under_endpoint,
     load_all_edges,
 )
+from src.parse.identity import make_canonical_id, narrator_node_id
+from src.parse.schemas import NETWORK_EDGE_SCHEMA
+from src.utils.arabic import normalize_arabic
 from tests.test_graph.conftest import (
     MockNeo4jClient,
     write_hadiths,
     write_narrator_mentions_resolved,
     write_parallel_links,
 )
+
+
+def _write_network_edges(staging: Path, suffix: str, rows: list[dict[str, object]]) -> Path:
+    """Write a network_edges_<suffix>.parquet."""
+    full = []
+    for r in rows:
+        base: dict[str, object] = {f.name: None for f in NETWORK_EDGE_SCHEMA}
+        base.update(r)
+        full.append(base)
+    arrays = {f.name: [r[f.name] for r in full] for f in NETWORK_EDGE_SCHEMA}
+    path = staging / f"network_edges_{suffix}.parquet"
+    pq.write_table(pa.table(arrays, schema=NETWORK_EDGE_SCHEMA), path)
+    return path
 
 
 class TestEdgeLoadResult:
@@ -331,3 +351,82 @@ class TestLoadAllEdges:
             assert r.created >= 0
             assert r.skipped >= 0
             assert r.missing_endpoints >= 0
+
+
+class TestStudiedUnderEndpoint:
+    def test_resolves_by_name_to_canonical_id(self) -> None:
+        # Canonical Narrator nodes are keyed by name, not by the source id.
+        assert _studied_under_endpoint("مالك", "42") == make_canonical_id(normalize_arabic("مالك"))
+
+    def test_falls_back_to_external_id_when_name_missing(self) -> None:
+        assert _studied_under_endpoint(None, "42") == narrator_node_id("42")
+        assert _studied_under_endpoint("   ", "42") == narrator_node_id("42")
+
+    def test_none_when_both_absent(self) -> None:
+        assert _studied_under_endpoint(None, None) is None
+
+
+class TestLoadStudiedUnderGlob:
+    def test_globs_all_sources_and_resolves_by_name(self, staging_dir: Path) -> None:
+        # Two source files: muhaddithat (A->B) and itqan (B->C).
+        _write_network_edges(
+            staging_dir,
+            "muhaddithat",
+            [
+                {
+                    "from_narrator_name": "أ",
+                    "to_narrator_name": "ب",
+                    "source": "muhaddithat",
+                    "from_external_id": "1",
+                    "to_external_id": "2",
+                }
+            ],
+        )
+        _write_network_edges(
+            staging_dir,
+            "itqan",
+            [
+                {
+                    "from_narrator_name": "ب",
+                    "to_narrator_name": "ج",
+                    "source": "itqan",
+                    "from_external_id": "2",
+                    "to_external_id": "3",
+                }
+            ],
+        )
+        client = MockNeo4jClient()
+        client.set_read_results([{"from_exists": True, "to_exists": True} for _ in range(2)])
+        result = _load_studied_under(client, staging_dir)
+        assert result.created == 2  # both files loaded
+        # The written batch keys endpoints by canonical name id, not nar:<source-id>.
+        write_calls = [b for q, b in client.calls if "MERGE" in q and isinstance(b, list)]
+        batch = write_calls[-1]
+        assert {
+            "from_id": make_canonical_id(normalize_arabic("أ")),
+            "to_id": make_canonical_id(normalize_arabic("ب")),
+        } in batch
+        assert {
+            "from_id": make_canonical_id(normalize_arabic("ب")),
+            "to_id": make_canonical_id(normalize_arabic("ج")),
+        } in batch
+
+    def test_dedups_same_pair_across_files(self, staging_dir: Path) -> None:
+        edge = {
+            "from_narrator_name": "أ",
+            "to_narrator_name": "ب",
+            "source": "x",
+            "from_external_id": "1",
+            "to_external_id": "2",
+        }
+        _write_network_edges(staging_dir, "muhaddithat", [edge])
+        _write_network_edges(staging_dir, "itqan", [dict(edge, source="itqan")])
+        client = MockNeo4jClient()
+        client.set_read_results([{"from_exists": True, "to_exists": True}])
+        result = _load_studied_under(client, staging_dir)
+        assert result.created == 1  # the duplicate pair is collapsed
+
+    def test_skips_when_no_edge_files(self, staging_dir: Path) -> None:
+        result = _load_studied_under(MockNeo4jClient(), staging_dir)
+        assert result.edge_type == "STUDIED_UNDER"
+        assert result.created == 0

--- a/tests/test_parse/test_itqan_parser.py
+++ b/tests/test_parse/test_itqan_parser.py
@@ -12,14 +12,27 @@ import pytest
 from src.parse import itqan
 from src.parse.itqan import (
     _GRADE_TO_TRUST,
+    _build_aliases,
+    _build_edges,
     _clean,
     _extract_death_year,
     _generation,
+    _id_list,
+    _iter_profiles,
     _parse_profile,
 )
-from src.parse.schemas import NARRATOR_BIO_SCHEMA
+from src.parse.schemas import (
+    NARRATOR_ALIAS_SCHEMA,
+    NARRATOR_BIO_SCHEMA,
+    NETWORK_EDGE_SCHEMA,
+)
 
 FIXTURE = Path(__file__).parent / "fixtures" / "itqan_rijal_sample.json"
+
+
+def _output(outputs: list[Path], stem: str) -> Path:
+    """Pick the staging file with the given stem from a parser's output list."""
+    return next(p for p in outputs if p.name == f"{stem}.parquet")
 
 
 @pytest.fixture
@@ -120,9 +133,14 @@ class TestRunOverFixture:
         staging = tmp_path / "staging"
         staging.mkdir()
         out = itqan.run(raw_dir, staging)
-        assert out.name == "narrators_bio_itqan.parquet"
+        # run() now emits bios + edges + aliases.
+        assert {p.name for p in out} == {
+            "narrators_bio_itqan.parquet",
+            "network_edges_itqan.parquet",
+            "narrator_aliases_itqan.parquet",
+        }
 
-        table = pq.read_table(out)
+        table = pq.read_table(_output(out, "narrators_bio_itqan"))
         assert table.schema.equals(NARRATOR_BIO_SCHEMA)
 
         with FIXTURE.open(encoding="utf-8") as f:
@@ -146,7 +164,114 @@ class TestRunOverFixture:
         staging = tmp_path / "staging"
         staging.mkdir()
         out = itqan.run(raw_dir, staging)
-        table = pq.read_table(out)
+        table = pq.read_table(_output(out, "narrators_bio_itqan"))
         with FIXTURE.open(encoding="utf-8") as f:
             expected = len(json.load(f))
         assert table.num_rows == expected
+
+
+class TestEdgeExtraction:
+    def test_id_list_coerces_ints_and_strs(self) -> None:
+        assert _id_list([2325, 7019]) == ["2325", "7019"]
+        assert _id_list(["1", "2"]) == ["1", "2"]
+        assert _id_list(None) == []
+        assert _id_list([]) == []
+
+    def test_build_edges_orients_student_to_teacher(self) -> None:
+        # P=1 has teacher 2 and student 3 -> edges (1->2) and (3->1).
+        profiles = [
+            ("1", {"full_name": "الف", "teachers": [2], "students": [3]}),
+            ("2", {"full_name": "باء"}),
+            ("3", {"full_name": "جيم"}),
+        ]
+        id_to_name = {"1": "الف", "2": "باء", "3": "جيم"}
+        edges = _build_edges(profiles, id_to_name)
+        pairs = {(e["from_external_id"], e["to_external_id"]) for e in edges}
+        assert pairs == {("1", "2"), ("3", "1")}
+        by_pair = {(e["from_external_id"], e["to_external_id"]): e for e in edges}
+        # from = student, to = teacher; names resolved from the id map.
+        assert by_pair[("1", "2")]["from_narrator_name"] == "الف"
+        assert by_pair[("1", "2")]["to_narrator_name"] == "باء"
+        # rijal edges are not hadith-scoped.
+        assert all(e["hadith_id"] is None for e in edges)
+        assert all(e["source"] == "itqan" for e in edges)
+
+    def test_build_edges_dedups_reciprocal_perspectives(self) -> None:
+        # 1 lists 2 as teacher AND 2 lists 1 as student -> the SAME edge (1->2).
+        profiles = [
+            ("1", {"full_name": "الف", "teachers": [2]}),
+            ("2", {"full_name": "باء", "students": [1]}),
+        ]
+        edges = _build_edges(profiles, {"1": "الف", "2": "باء"})
+        assert len(edges) == 1
+        assert (edges[0]["from_external_id"], edges[0]["to_external_id"]) == ("1", "2")
+
+    def test_build_edges_skips_self_loops(self) -> None:
+        edges = _build_edges([("1", {"full_name": "الف", "teachers": [1]})], {"1": "الف"})
+        assert edges == []
+
+    def test_run_emits_schema_valid_nonempty_edges(self, raw_dir: Path, tmp_path: Path) -> None:
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        out = itqan.run(raw_dir, staging)
+        table = pq.read_table(_output(out, "network_edges_itqan"))
+        assert table.schema.equals(NETWORK_EDGE_SCHEMA)
+        assert table.num_rows > 0
+        rows = table.to_pylist()
+        assert {r["source"] for r in rows} == {"itqan"}
+        # Provenance: both endpoints carry the source profile id.
+        assert all(r["from_external_id"] and r["to_external_id"] for r in rows)
+
+
+class TestAliasExtraction:
+    def test_build_aliases_drops_primary_spelling_and_dups(self) -> None:
+        profile = {
+            "full_name": "سعيد بن سماك",
+            "namings": [
+                "سعيد بن سماك",  # == primary -> dropped
+                "ابن سماك",
+                "ابن سماك",  # duplicate -> collapsed
+                "-",  # placeholder -> dropped
+            ],
+        }
+        rows = _build_aliases([("320", profile)])
+        variants = [r["alias"] for r in rows]
+        assert variants == ["ابن سماك"]
+        assert rows[0]["bio_id"] == "itqan:320"
+        assert rows[0]["source"] == "itqan"
+        assert rows[0]["alias_normalized"]
+
+    def test_build_aliases_keys_to_canonical_name(self) -> None:
+        # canonical_name_ar_normalized must equal the bio's name_ar_normalized so
+        # bio_promote can recompute the same nar: id.
+        from src.utils.arabic import normalize_arabic
+
+        profile = {"full_name": "محمد", "namings": ["أبو القاسم"]}
+        rows = _build_aliases([("5", profile)])
+        assert rows[0]["canonical_name_ar_normalized"] == normalize_arabic("محمد")
+
+    def test_build_aliases_skips_profile_without_name(self) -> None:
+        assert _build_aliases([("9", {"full_name": "-", "namings": ["x"]})]) == []
+
+    def test_run_emits_schema_valid_nonempty_aliases(self, raw_dir: Path, tmp_path: Path) -> None:
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        out = itqan.run(raw_dir, staging)
+        table = pq.read_table(_output(out, "narrator_aliases_itqan"))
+        assert table.schema.equals(NARRATOR_ALIAS_SCHEMA)
+        assert table.num_rows > 0
+        rows = table.to_pylist()
+        assert {r["source"] for r in rows} == {"itqan"}
+        assert all(r["bio_id"].startswith("itqan:") for r in rows)
+
+
+class TestIterProfiles:
+    def test_first_occurrence_wins_across_buckets(self, raw_dir: Path) -> None:
+        # Duplicate the fixture as a second bucket; profile ids must not double.
+        shutil.copy(FIXTURE, raw_dir / "itqan" / "profiles_dup.json")
+        buckets = sorted((raw_dir / "itqan").glob("profiles_*.json"))
+        profiles = _iter_profiles(buckets)
+        with FIXTURE.open(encoding="utf-8") as f:
+            expected = len(json.load(f))
+        assert len(profiles) == expected
+        assert len({pid for pid, _ in profiles}) == expected

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from src.parse.identity import make_canonical_id
-from src.parse.schemas import NARRATOR_BIO_SCHEMA
+from src.parse.schemas import NARRATOR_ALIAS_SCHEMA, NARRATOR_BIO_SCHEMA
 from src.resolve.bio_promote import promote_bios_to_canonical
 from src.utils.arabic import normalize_arabic
 
@@ -24,6 +24,15 @@ def _write_bios(staging: Path, suffix: str, rows: list[dict[str, Any]]) -> Path:
     arrays = {f.name: [r[f.name] for r in full] for f in NARRATOR_BIO_SCHEMA}
     table = pa.table(arrays, schema=NARRATOR_BIO_SCHEMA)
     path = staging / f"narrators_bio_{suffix}.parquet"
+    pq.write_table(table, path)
+    return path
+
+
+def _write_aliases(staging: Path, suffix: str, rows: list[dict[str, Any]]) -> Path:
+    """Write a narrator_aliases_<suffix>.parquet."""
+    arrays = {f.name: [r[f.name] for r in rows] for f in NARRATOR_ALIAS_SCHEMA}
+    table = pa.table(arrays, schema=NARRATOR_ALIAS_SCHEMA)
+    path = staging / f"narrator_aliases_{suffix}.parquet"
     pq.write_table(table, path)
     return path
 
@@ -180,3 +189,118 @@ def test_no_bio_files_returns_none(tmp_path: Path) -> None:
     out_dir = tmp_path / "curated"
     out_dir.mkdir()
     assert promote_bios_to_canonical(staging, out_dir) is None
+
+
+def test_aliases_attach_to_matching_canonical(tmp_path: Path) -> None:
+    # da#94: name variants emitted by the Itqan parser land on the SAME canonical
+    # narrator the bio produced (keyed by canonical_name_ar_normalized).
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    name = "سعيد بن سماك"
+    norm = normalize_arabic(name)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:320",
+                "source": "itqan",
+                "name_ar": name,
+                "name_ar_normalized": norm,
+            }
+        ],
+    )
+    _write_aliases(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:320",
+                "source": "itqan",
+                "canonical_name_ar_normalized": norm,
+                "alias": "ابن سماك",
+                "alias_normalized": normalize_arabic("ابن سماك"),
+            },
+            # A variant whose normalized form equals the primary name is skipped.
+            {
+                "bio_id": "itqan:320",
+                "source": "itqan",
+                "canonical_name_ar_normalized": norm,
+                "alias": name,
+                "alias_normalized": norm,
+            },
+        ],
+    )
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    rec = next(
+        r for r in pq.read_table(path).to_pylist() if r["canonical_id"] == make_canonical_id(norm)
+    )
+    assert rec["aliases"] == [normalize_arabic("ابن سماك")]
+
+
+def test_alias_without_matching_bio_is_dropped(tmp_path: Path) -> None:
+    # An alias never *creates* a narrator — only a promoted bio anchors one.
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    _write_bios(
+        staging,
+        "itqan",
+        [{"bio_id": "itqan:1", "source": "itqan", "name_ar": "ج", "name_ar_normalized": "ج"}],
+    )
+    _write_aliases(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:999",
+                "source": "itqan",
+                "canonical_name_ar_normalized": "لا أحد",
+                "alias": "x",
+                "alias_normalized": "x",
+            }
+        ],
+    )
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    recs = pq.read_table(path).to_pylist()
+    assert len(recs) == 1  # only the bio-anchored narrator
+    assert recs[0]["aliases"] == []
+
+
+def test_alias_source_filter_respected(tmp_path: Path) -> None:
+    # With sources={"itqan"}, a non-itqan alias file must not be merged.
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    name = "محمد"
+    norm = normalize_arabic(name)
+    _write_bios(
+        staging,
+        "itqan",
+        [{"bio_id": "itqan:7", "source": "itqan", "name_ar": name, "name_ar_normalized": norm}],
+    )
+    _write_aliases(
+        staging,
+        "other",
+        [
+            {
+                "bio_id": "other:7",
+                "source": "other",
+                "canonical_name_ar_normalized": norm,
+                "alias": "أبو القاسم",
+                "alias_normalized": normalize_arabic("أبو القاسم"),
+            }
+        ],
+    )
+    path = promote_bios_to_canonical(staging, out_dir, sources={"itqan"})
+    assert path is not None
+    rec = next(
+        r for r in pq.read_table(path).to_pylist() if r["canonical_id"] == make_canonical_id(norm)
+    )
+    assert rec["aliases"] == []


### PR DESCRIPTION
## Summary
Extends the Itqan rijal adapter (bios shipped in da#92a/PR#110) to emit the two remaining per-profile slices. Both extend `src/parse/itqan.py`, so they ship together to avoid a self-conflict.

- **#93 — isnad chains → isnad edges:** each profile's `teachers`/`students` id lists become student→teacher `STUDIED_UNDER` edges (`NETWORK_EDGE_SCHEMA`), deduped on the id pair across reciprocal perspectives.
- **#94 — name variants → identity aliases:** each profile's `namings` array becomes name-variant alias rows (new `NARRATOR_ALIAS_SCHEMA`) that `bio_promote` unions onto the matching canonical Narrator's `aliases`.

## Outputs added (staging Parquet, `sect`/`source_corpus` tagged)
| File | Schema | Contents |
|---|---|---|
| `network_edges_itqan.parquet` | NETWORK_EDGE_SCHEMA | student→teacher STUDIED_UNDER edges (design ~100,656) |
| `narrator_aliases_itqan.parquet` | NARRATOR_ALIAS_SCHEMA | name variants → aliases (design ~217,762) |

`run()` now returns `[bios, edges, aliases]` (a `ParseOutput` list — `run_all` flattens it).

## Key design decisions
- **No NARRATOR_MENTION rows.** Itqan is a rijal DB with no hadith-scoped chains (no `source_hadith_id`/`position_in_chain`); the teacher/student adjacency maps to STUDIED_UNDER, mirroring muhaddithat. The issue's mention-schema reference doesn't apply to this source.
- **STUDIED_UNDER loader fix (shared):** generalized from the hardcoded `network_edges_muhaddithat.parquet` to glob `network_edges_*.parquet`, and now resolves endpoints by name → `make_canonical_id` instead of `nar:<external_id>`. Canonical Narrator nodes are keyed by `uuid5(normalized-name)`, so the old external-id keying matched no node and silently dropped every edge — this also fixes that latent gap for muhaddithat. No existing test asserted the old behavior (the only prior STUDIED_UNDER test was graceful-skip).
- **Aliases feed the identity layer, not the matcher.** `bio_promote` attaches variants to the canonical record/node (`n.aliases`); making the disambiguator *key* on aliases for cross-source collapse is #X1's job (#94 "feeds" #X1). An alias never creates a narrator.

## Files touched
- `src/parse/itqan.py` — edge + alias extraction; `run()` → list
- `src/parse/schemas.py` — new `NARRATOR_ALIAS_SCHEMA`
- `src/resolve/bio_promote.py` — `_merge_aliases` unions variants onto canonical (source-filtered, merge-safe)
- `src/graph/load_edges.py` — `_studied_under_endpoint` + glob all `network_edges_*`
- `src/parse/validate.py` — register alias schema, baselines, required cols
- tests: parser, bio_promote, load_edges (unit) + live neo4j:5 integration

## Test Plan
- 706 non-integration tests pass; ruff format/check + mypy clean.
- **Live neo4j:5 integration (local Docker):** 4/4 pass, incl. new `test_itqan_chains_load_as_studied_under_edges` (asserts `created > 0` real STUDIED_UNDER edges between two loaded narrators) and `test_itqan_name_variants_load_as_node_aliases` (asserts `n.aliases` populated).
- Reachability/licensing unchanged: Itqan = no upstream license, owner-approved (da#92a), removable via `source_corpus='itqan'` provenance.

## Reviewers
@Jean-Claude Habimana (architect, primary) · @Oyunbileg Batbayar (QA, secondary)

Closes #93
Closes #94
