### PR TITLE
feat: Multi-IsnadSet adapter (multiple isnad per Sahih Muslim hadith) (#97)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "tenacity>=8.2",
     "rapidfuzz>=3.6",
     "kafka-python>=2.3.1",
+    "openpyxl>=3.1",
 ]
 
 [project.scripts]
@@ -109,6 +110,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["kafka", "kafka.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["openpyxl", "openpyxl.*"]
 ignore_missing_imports = true
 
 [tool.pydantic-mypy]

--- a/src/acquire/mis.py
+++ b/src/acquire/mis.py
@@ -1,0 +1,111 @@
+"""Acquire the Multi-IsnadSet (MIS) dataset from Mendeley Data.
+
+MIS (``Multi-IsnadSet``, Farooqi et al., *Data in Brief* 2024 —
+DOI ``10.17632/gzprcr93zn.2``) models **Sahih Muslim** as a directed narrator
+graph in which a single hadith carries its *multiple* isnad chains explicitly
+(2,092 narrator nodes / 77,797 Sanad-Hadith edges). It is the dedicated
+multi-isnad source for the platform: where most corpora give one chain per
+hadith, MIS preserves the parallel asanid (the ``ح`` / *tahwil* split) that make
+Sahih Muslim valuable for chain modelling.
+
+The dataset ships as two Excel workbooks under the Mendeley file set:
+
+* ``Hadith_SahihMuslim_CoreInfo.xlsx``               — one row per hadith
+  (book, hadith number, matn, narrator sequence, isnad count).
+* ``Hadith_SahihMuslim_DetailsInfo_Sanad_Narrators.xlsx`` — one row per
+  (hadith, sanad, narrator) position — the data the parser walks into per-sanad
+  chains.
+
+Reachability: ``data.mendeley.com`` serves the file set over HTTPS with **no
+auth / no API key** — the same keyless-public mechanism this repo already proves
+for ``sanadset`` (Mendeley ``5xth87zwb5``). The file ids are resolved at runtime
+from the dataset files API rather than hardcoded, so a new dataset version is
+picked up without a code change.
+
+Licensing: Mendeley Data's default license for this dataset is **CC BY 4.0**
+(attribution) — redistribution-safe with credit to the depositors.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.acquire.base import download_file, ensure_dir, fetch_json, write_manifest
+from src.messaging import emit_raw_new_for_manifest
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Mendeley Data — Multi-IsnadSet (DOI: 10.17632/gzprcr93zn.2)
+_MENDELEY_DATASET_ID = "gzprcr93zn"
+_MENDELEY_VERSION = 2
+_MENDELEY_FILES_API = f"https://data.mendeley.com/api/datasets/{_MENDELEY_DATASET_ID}/files?version={_MENDELEY_VERSION}"
+
+# We only want the spreadsheet workbooks; the file set may also carry PDFs / docs.
+_WANTED_SUFFIXES = (".xlsx", ".xls")
+
+
+def _resolve_files() -> list[dict[str, Any]]:
+    """Return the Mendeley file-set entries for the wanted spreadsheet workbooks.
+
+    Each entry is normalized to ``{"name", "url", "sha256"}``. The Mendeley files
+    API returns objects shaped ``{"filename", "content_details": {"download_url",
+    "sha256_hash", ...}}``; we tolerate a couple of historical key spellings.
+    """
+    raw = fetch_json(_MENDELEY_FILES_API)
+    entries = raw if isinstance(raw, list) else raw.get("results") or raw.get("files") or []
+
+    wanted: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("filename") or entry.get("name") or ""
+        if not name.lower().endswith(_WANTED_SUFFIXES):
+            continue
+        details = entry.get("content_details") or entry
+        url = details.get("download_url") or details.get("url")
+        if not url:
+            continue
+        wanted.append(
+            {
+                "name": name,
+                "url": url,
+                "sha256": details.get("sha256_hash") or details.get("sha256"),
+            }
+        )
+    return wanted
+
+
+def run(raw_dir: Path) -> Path:
+    """Download the MIS Excel workbooks into ``raw_dir/mis``.
+
+    Idempotent: ``download_file`` skips a non-empty existing workbook, so a
+    re-run only fetches what is missing. Fails fast if the file set carries no
+    spreadsheet workbook (a dataset-shape change we want to notice loudly).
+    """
+    dest = ensure_dir(raw_dir / "mis")
+
+    files = _resolve_files()
+    if not files:
+        msg = (
+            f"MIS Mendeley file set ({_MENDELEY_DATASET_ID} v{_MENDELEY_VERSION}) "
+            "exposed no .xlsx workbook"
+        )
+        raise AssertionError(msg)
+
+    downloaded: list[Path] = []
+    for entry in files:
+        path = download_file(
+            entry["url"],
+            dest / entry["name"],
+            expected_sha256=entry["sha256"],
+            timeout=600.0,
+        )
+        downloaded.append(path)
+
+    logger.info("mis_acquired", workbooks=len(downloaded), names=[p.name for p in downloaded])
+
+    write_manifest(dest, downloaded)
+    emit_raw_new_for_manifest(source="mis", local_dir=dest, files=downloaded)
+    return dest

--- a/src/adapters.py
+++ b/src/adapters.py
@@ -228,6 +228,23 @@ SOURCE_REGISTRY: tuple[SourceAdapter, ...] = (
         ),
         description="halimbahae/Hadith — 9 Sunni books with full Arabic diacritics (tashkeel).",
     ),
+    SourceAdapter(
+        slug="mis",
+        corpus=SourceCorpus.MIS,
+        sect=Sect.SUNNI,
+        acquire_module="mis",
+        parse_module="mis",
+        reachable=True,
+        license_note=(
+            "Multi-IsnadSet (MIS) — Mendeley Data 10.17632/gzprcr93zn.2 (Farooqi et al., "
+            "Data in Brief 2024). CC BY 4.0; keyless public download over the same "
+            "data.mendeley.com mechanism proven for sanadset."
+        ),
+        description=(
+            "Multi-IsnadSet — Sahih Muslim with the MULTIPLE isnad chains per hadith "
+            "made explicit (Sunni); one hadith emits N distinct transmission chains."
+        ),
+    ),
 )
 
 

--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -479,8 +479,29 @@ def _load_parallel_of(
 
 
 # ---------------------------------------------------------------------------
-# 5. STUDIED_UNDER — from every network_edges_*.parquet (muhaddithat, itqan, …)
+# 5. STUDIED_UNDER — from the studentship network_edges_*.parquet (muhaddithat, itqan)
 # ---------------------------------------------------------------------------
+
+# NETWORK_EDGE_SCHEMA is reused by producers whose edges mean DIFFERENT relations.
+# muhaddithat + itqan emit teacher↔student (studentship) pairs that ARE
+# STUDIED_UNDER. Others — e.g. `mis`, whose rows are *isnad transmission* pairs (a
+# different relation type AND the opposite direction) — must NOT be globbed in
+# here, or their edges would load as wrong-type, wrong-direction STUDIED_UNDER.
+# This filename allowlist is the cheap, safe interim; the durable fix is an
+# explicit edge-relation field on NETWORK_EDGE_SCHEMA so the loader keys on the
+# data, not on a slug — tracked in da#133.
+_STUDIED_UNDER_SOURCES: frozenset[str] = frozenset({"muhaddithat", "itqan"})
+
+
+def _is_studied_under_file(path: Path) -> bool:
+    """True if a ``network_edges_<slug>.parquet`` belongs to a studentship source.
+
+    Matches the exact slug or a chunked ``<slug>_NNN`` variant, so a future
+    sharded write still resolves but a different corpus (``mis``) never does.
+    """
+    slug = path.stem.removeprefix("network_edges_")
+    return any(slug == src or slug.startswith(f"{src}_") for src in _STUDIED_UNDER_SOURCES)
+
 
 _STUDIED_UNDER_QUERY = """\
 UNWIND $batch AS row
@@ -526,13 +547,17 @@ def _load_studied_under(
     *,
     batch_size: int = DEFAULT_BATCH_SIZE,
 ) -> EdgeLoadResult:
-    """Load STUDIED_UNDER edges from every ``network_edges_*.parquet``.
+    """Load STUDIED_UNDER edges from the studentship ``network_edges_*.parquet``.
 
-    Source-agnostic: muhaddithat, itqan, and any future NETWORK_EDGE producer are
-    picked up by glob (mirroring how the bio/canonical loaders glob their inputs).
-    Gracefully skips when no such file exists.
+    Globs ``network_edges_*`` but keeps only the studentship producers
+    (:data:`_STUDIED_UNDER_SOURCES` — muhaddithat, itqan); a NETWORK_EDGE producer
+    whose edges are a different relation (e.g. ``mis`` isnad transmission) is
+    deliberately skipped here (see da#133). Gracefully skips when no such file
+    exists.
     """
-    edge_files = _parquet_files(staging_dir, "network_edges_")
+    edge_files = [
+        p for p in _parquet_files(staging_dir, "network_edges_") if _is_studied_under_file(p)
+    ]
     if not edge_files:
         logger.info("studied_under_skipped", reason="file_not_found", staging_dir=str(staging_dir))
         return EdgeLoadResult("STUDIED_UNDER", 0, 0, 0)

--- a/src/models/enums.py
+++ b/src/models/enums.py
@@ -153,6 +153,7 @@ class SourceCorpus(StrEnum):
     MUHADDITHAT = "muhaddithat"
     ITQAN = "itqan"
     HALIMBAHAE = "halimbahae"
+    MIS = "mis"
 
 
 class Sect(StrEnum):

--- a/src/parse/mis.py
+++ b/src/parse/mis.py
@@ -1,0 +1,432 @@
+"""Parse the Multi-IsnadSet (MIS) dataset into staging Parquet.
+
+MIS is the platform's dedicated *multiple-isnad* source: a single Sahih Muslim
+hadith carries **several parallel isnad chains** (the ``ح`` / *tahwil* split). The
+whole value of this source is that those parallel chains are preserved as
+distinct transmission paths — collapsing them into one chain would throw away
+exactly what MIS exists to model.
+
+Two output files (both tagged ``sect=sunni`` / ``source_corpus=mis``):
+
+* ``hadiths_mis.parquet``        — one ``HADITH_SCHEMA`` row per hadith.
+* ``network_edges_mis.parquet``  — ``NETWORK_EDGE_SCHEMA`` directed narrator
+  pairs. NETWORK_EDGE is deliberately the right shape here: a hadith's N isnads
+  contribute N independent edge-chains that coexist as distinct rows, so the
+  multiplicity survives into staging. (The mention schema, keyed only by
+  ``source_hadith_id`` + ``position_in_chain`` with no per-chain discriminator,
+  would merge the parallel asanid into one chain — the failure mode this parser
+  is built to avoid.) The ``from``/``to`` names feed ``make_canonical_id`` via the
+  disambiguation/load layer.
+
+Input shape
+-----------
+Two Mendeley workbooks (``.xlsx``; ``.csv`` exports are also accepted for tests):
+
+* **CoreInfo** — one row per hadith: a hadith number, an (optional) book number,
+  the matn text, and an (optional) narrator-sequence string.
+* **DetailsInfo (Sanad/Narrators)** — the per-position detail the chains are
+  walked from. Two layouts are supported:
+    - *sequence layout* (primary): ``(hadith, isnad/sanad, position, narrator)``
+      — grouped by ``(hadith, isnad)`` and walked into consecutive-pair edges, so
+      each sanad of a hadith becomes its own chain;
+    - *edge layout*: explicit ``(from_narrator, to_narrator[, hadith][, isnad])``
+      rows — each row is already one edge.
+
+Column names are matched case/spacing/underscore-insensitively (the upstream
+spreadsheets are not perfectly normalized), with documented candidate sets.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+
+from src.parse.base import generate_source_id, read_csv_robust, safe_int, safe_str, write_parquet
+from src.parse.schemas import HADITH_SCHEMA, NETWORK_EDGE_SCHEMA
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+SOURCE_CORPUS = "mis"
+SECT = "sunni"
+COLLECTION_NAME = "Sahih Muslim"
+COLLECTION_SLUG = "sahih_muslim"
+
+# --- column-name candidate sets (matched on the alnum-normalized header) -------
+_HADITH_NO_KEYS = ("hadithno", "hadithnumber", "hadithid", "hadith", "serialno", "sno", "no", "id")
+_BOOK_KEYS = ("bookno", "booknumber", "book", "bookname", "kitab")
+_MATN_KEYS = ("matn", "matntext", "matnarabic", "hadithtext", "text", "arabictext", "matnar")
+_ISNAD_TEXT_KEYS = ("narratorsequence", "isnadtext", "sanadtext", "chain", "narrators")
+
+_SANAD_KEYS = (
+    "isnadno",
+    "isnadid",
+    "isnadindex",
+    "isnad",
+    "sanadno",
+    "sanadid",
+    "sanad",
+    "chainno",
+    "chainid",
+    "chainindex",
+)
+_POSITION_KEYS = (
+    "position",
+    "narratorposition",
+    "order",
+    "narratororder",
+    "sequence",
+    "narratorsequence",
+    "seq",
+    "level",
+    "rank",
+    "step",
+)
+_NARRATOR_NAME_KEYS = (
+    "narrator",
+    "narratorname",
+    "narratorarabic",
+    "narratorar",
+    "name",
+    "fullname",
+    "rawiname",
+)
+_NARRATOR_ID_KEYS = ("narratorid", "narratorno", "nid", "rawiid", "rawino", "rawi")
+_FROM_KEYS = (
+    "fromnarrator",
+    "sourcenarrator",
+    "from",
+    "source",
+    "predecessor",
+    "teacher",
+    "fromname",
+)
+_TO_KEYS = ("tonarrator", "targetnarrator", "to", "target", "successor", "student", "toname")
+
+# Filename tokens (matched case-insensitively, in priority order) that identify
+# each workbook. CoreInfo never contains a DetailsInfo token and vice versa, so
+# the two selections never collide.
+_DATA_SUFFIXES = (".xlsx", ".xls", ".csv")
+_CORE_TOKENS = ("coreinfo", "core")
+_DETAIL_TOKENS = ("detailsinfo", "sanad", "narrator", "details")
+
+
+def _norm_header(value: Any) -> str:
+    """Normalize a header to lowercase alphanumerics (drop spaces/underscores)."""
+    return "".join(ch for ch in str(value).lower() if ch.isalnum())
+
+
+def _cell(value: Any) -> str | None:
+    """Stringify a spreadsheet/CSV cell, returning None for empties."""
+    return safe_str(value)
+
+
+def _pick(keys: set[str], candidates: tuple[str, ...]) -> str | None:
+    """Return the first candidate present in *keys* (already alnum-normalized)."""
+    for candidate in candidates:
+        if candidate in keys:
+            return candidate
+    return None
+
+
+def _read_xlsx_rows(path: Path) -> list[dict[str, str | None]]:
+    """Read an .xlsx workbook's first sheet into normalized-header row dicts."""
+    from openpyxl import load_workbook
+
+    workbook = load_workbook(filename=str(path), read_only=True, data_only=True)
+    try:
+        sheet = workbook.active or workbook.worksheets[0]
+        row_iter = sheet.iter_rows(values_only=True)
+        try:
+            header_row = next(row_iter)
+        except StopIteration:
+            return []
+        headers = [_norm_header(h) for h in header_row]
+        rows: list[dict[str, str | None]] = []
+        for raw in row_iter:
+            if raw is None or all(cell is None for cell in raw):
+                continue
+            row = {headers[i]: _cell(raw[i]) for i in range(min(len(headers), len(raw)))}
+            rows.append(row)
+        return rows
+    finally:
+        workbook.close()
+
+
+def _read_csv_rows(path: Path) -> list[dict[str, str | None]]:
+    """Read a CSV (robust encoding) into normalized-header row dicts."""
+    table, _enc = read_csv_robust(path)
+    headers = [_norm_header(c) for c in table.column_names]
+    columns = {headers[i]: table.column(i).to_pylist() for i in range(len(headers))}
+    return [
+        {header: _cell(columns[header][r]) for header in headers} for r in range(table.num_rows)
+    ]
+
+
+def _read_rows(path: Path) -> list[dict[str, str | None]]:
+    """Read a CoreInfo/DetailsInfo file (xlsx or csv) into row dicts."""
+    if path.suffix.lower() in (".xlsx", ".xls"):
+        return _read_xlsx_rows(path)
+    return _read_csv_rows(path)
+
+
+def _find_file(source_dir: Path, tokens: tuple[str, ...]) -> Path | None:
+    """Return the first data file under *source_dir* whose name contains a token.
+
+    Case-insensitive (the upstream filenames are CamelCase), token-priority
+    ordered, restricted to spreadsheet/CSV suffixes.
+    """
+    candidates = sorted(
+        path
+        for path in source_dir.rglob("*")
+        if path.is_file() and path.suffix.lower() in _DATA_SUFFIXES
+    )
+    for token in tokens:
+        for path in candidates:
+            if token in path.name.lower():
+                return path
+    return None
+
+
+def _parse_core(core_path: Path) -> tuple[pa.Table, dict[str, str]]:
+    """Parse CoreInfo into a HADITH_SCHEMA table + a ``hadith-no -> source_id`` map.
+
+    The map is the join key the edge builder uses so an edge's ``hadith_id``
+    matches its hadith's ``source_id`` exactly (same corpus-namespaced grammar).
+    """
+    rows = _read_rows(core_path)
+    if not rows:
+        msg = f"CoreInfo file is empty: {core_path}"
+        raise ValueError(msg)
+
+    keys = set(rows[0].keys())
+    no_col = _pick(keys, _HADITH_NO_KEYS)
+    if no_col is None:
+        msg = f"CoreInfo has no hadith-number column. Headers: {sorted(keys)}"
+        raise ValueError(msg)
+    book_col = _pick(keys, _BOOK_KEYS)
+    matn_col = _pick(keys, _MATN_KEYS)
+    isnad_text_col = _pick(keys, _ISNAD_TEXT_KEYS)
+
+    hadith_rows: list[dict[str, Any]] = []
+    id_map: dict[str, str] = {}
+    seen: set[str] = set()
+
+    for row in rows:
+        raw_no = row.get(no_col)
+        hadith_no = safe_str(raw_no)
+        if not hadith_no or hadith_no in seen:
+            continue
+        seen.add(hadith_no)
+
+        book_num = safe_int(row.get(book_col)) if book_col else None
+        source_id = generate_source_id(
+            SOURCE_CORPUS, COLLECTION_SLUG, book_num if book_num is not None else 0, hadith_no
+        )
+        id_map[hadith_no] = source_id
+
+        full_row: dict[str, Any] = {field.name: None for field in HADITH_SCHEMA}
+        full_row.update(
+            source_id=source_id,
+            source_corpus=SOURCE_CORPUS,
+            collection_name=COLLECTION_NAME,
+            book_number=book_num,
+            hadith_number=safe_int(raw_no),
+            matn_ar=safe_str(row.get(matn_col)) if matn_col else None,
+            isnad_raw_ar=safe_str(row.get(isnad_text_col)) if isnad_text_col else None,
+            sect=SECT,
+        )
+        hadith_rows.append(full_row)
+
+    if not hadith_rows:
+        msg = "No valid hadith rows parsed from CoreInfo"
+        raise ValueError(msg)
+
+    table = pa.table(
+        {field.name: [r[field.name] for r in hadith_rows] for field in HADITH_SCHEMA},
+        schema=HADITH_SCHEMA,
+    )
+    logger.info("mis_core_parsed", hadiths=len(hadith_rows))
+    return table, id_map
+
+
+def _emit_edge(
+    edges: list[dict[str, str | None]],
+    from_name: str | None,
+    to_name: str | None,
+    hadith_id: str | None,
+    from_id: str | None = None,
+    to_id: str | None = None,
+) -> None:
+    """Append one NETWORK_EDGE row, skipping incomplete / self-loop pairs."""
+    if not from_name or not to_name or from_name == to_name:
+        return
+    edges.append(
+        {
+            "from_narrator_name": from_name,
+            "to_narrator_name": to_name,
+            "hadith_id": hadith_id,
+            "source": SOURCE_CORPUS,
+            "from_external_id": from_id,
+            "to_external_id": to_id,
+        }
+    )
+
+
+def _parse_edges_sequence(
+    rows: list[dict[str, str | None]],
+    keys: set[str],
+    id_map: dict[str, str],
+) -> tuple[list[dict[str, str | None]], dict[str, int]]:
+    """Build edges from the per-position *sequence* layout.
+
+    Rows are grouped by ``(hadith, isnad)`` so every sanad of a hadith is walked
+    into its own chain — this is where the multiplicity is preserved. Returns
+    ``(edges, isnad_count_per_hadith)``.
+    """
+    hadith_col = _pick(keys, _HADITH_NO_KEYS)
+    sanad_col = _pick(keys, _SANAD_KEYS)
+    pos_col = _pick(keys, _POSITION_KEYS)
+    name_col = _pick(keys, _NARRATOR_NAME_KEYS)
+    nid_col = _pick(keys, _NARRATOR_ID_KEYS)
+
+    if hadith_col is None or sanad_col is None or name_col is None:
+        msg = (
+            "DetailsInfo sequence layout needs hadith + isnad/sanad + narrator columns; "
+            f"resolved hadith={hadith_col!r} sanad={sanad_col!r} narrator={name_col!r}. "
+            f"Headers: {sorted(keys)}"
+        )
+        raise ValueError(msg)
+
+    # group key -> list of (position, name, narrator_id), in file order.
+    chains: dict[tuple[str, str], list[tuple[int, str | None, str | None]]] = defaultdict(list)
+    for idx, row in enumerate(rows):
+        hadith_no = safe_str(row.get(hadith_col))
+        sanad_no = safe_str(row.get(sanad_col))
+        if not hadith_no or not sanad_no:
+            continue
+        name = safe_str(row.get(name_col))
+        nid = safe_str(row.get(nid_col)) if nid_col else None
+        pos = safe_int(row.get(pos_col)) if pos_col else None
+        # Fall back to file order when no explicit position column.
+        order = pos if pos is not None else idx
+        chains[(hadith_no, sanad_no)].append((order, name, nid))
+
+    edges: list[dict[str, str | None]] = []
+    isnad_counts: dict[str, int] = defaultdict(int)
+    for (hadith_no, _sanad_no), members in chains.items():
+        isnad_counts[hadith_no] += 1
+        ordered = sorted(members, key=lambda m: m[0])
+        hadith_id = id_map.get(hadith_no) or generate_source_id(
+            SOURCE_CORPUS, COLLECTION_SLUG, 0, hadith_no
+        )
+        for i in range(len(ordered) - 1):
+            _, from_name, from_id = ordered[i]
+            _, to_name, to_id = ordered[i + 1]
+            _emit_edge(edges, from_name, to_name, hadith_id, from_id, to_id)
+
+    return edges, dict(isnad_counts)
+
+
+def _parse_edges_explicit(
+    rows: list[dict[str, str | None]],
+    keys: set[str],
+    id_map: dict[str, str],
+    from_col: str,
+    to_col: str,
+) -> tuple[list[dict[str, str | None]], dict[str, int]]:
+    """Build edges from the explicit ``(from, to)`` *edge* layout.
+
+    Each row is one edge. ``(hadith, isnad)`` is tracked only to report the
+    multiplicity; every row's edge is retained regardless.
+    """
+    hadith_col = _pick(keys, _HADITH_NO_KEYS)
+    sanad_col = _pick(keys, _SANAD_KEYS)
+
+    edges: list[dict[str, str | None]] = []
+    seen_isnads: dict[str, set[str]] = defaultdict(set)
+    for idx, row in enumerate(rows):
+        hadith_no = safe_str(row.get(hadith_col)) if hadith_col else None
+        hadith_id = (id_map.get(hadith_no) if hadith_no else None) or (
+            generate_source_id(SOURCE_CORPUS, COLLECTION_SLUG, 0, hadith_no) if hadith_no else None
+        )
+        if hadith_no:
+            sanad_no = (safe_str(row.get(sanad_col)) if sanad_col else None) or str(idx)
+            seen_isnads[hadith_no].add(sanad_no)
+        _emit_edge(edges, safe_str(row.get(from_col)), safe_str(row.get(to_col)), hadith_id)
+
+    isnad_counts = {hadith_no: len(sanads) for hadith_no, sanads in seen_isnads.items()}
+    return edges, isnad_counts
+
+
+def _parse_edges(detail_path: Path, id_map: dict[str, str]) -> pa.Table:
+    """Parse DetailsInfo into a NETWORK_EDGE_SCHEMA table, preserving multiplicity."""
+    rows = _read_rows(detail_path)
+    if not rows:
+        msg = f"DetailsInfo file is empty: {detail_path}"
+        raise ValueError(msg)
+
+    keys = set(rows[0].keys())
+    from_col = _pick(keys, _FROM_KEYS)
+    to_col = _pick(keys, _TO_KEYS)
+
+    if from_col and to_col:
+        edges, isnad_counts = _parse_edges_explicit(rows, keys, id_map, from_col, to_col)
+        layout = "edge"
+    else:
+        edges, isnad_counts = _parse_edges_sequence(rows, keys, id_map)
+        layout = "sequence"
+
+    if not edges:
+        msg = "No network edges extracted from MIS DetailsInfo"
+        raise ValueError(msg)
+
+    table = pa.table(
+        {field.name: [e[field.name] for e in edges] for field in NETWORK_EDGE_SCHEMA},
+        schema=NETWORK_EDGE_SCHEMA,
+    )
+
+    multi = sum(1 for c in isnad_counts.values() if c > 1)
+    logger.info(
+        "mis_edges_parsed",
+        layout=layout,
+        edges=len(edges),
+        hadiths=len(isnad_counts),
+        multi_isnad_hadiths=multi,
+        max_isnad_count=max(isnad_counts.values()) if isnad_counts else 0,
+    )
+    return table
+
+
+def run(raw_dir: Path, staging_dir: Path) -> tuple[Path, Path]:
+    """Parse the MIS workbooks into hadith + network-edge Parquet files."""
+    source_dir = raw_dir / "mis"
+    if not source_dir.exists():
+        msg = f"Source directory not found: {source_dir}"
+        raise FileNotFoundError(msg)
+
+    core_path = _find_file(source_dir, _CORE_TOKENS)
+    if core_path is None:
+        msg = f"No MIS CoreInfo file found under {source_dir}"
+        raise FileNotFoundError(msg)
+    detail_path = _find_file(source_dir, _DETAIL_TOKENS)
+    if detail_path is None:
+        msg = f"No MIS DetailsInfo (sanad/narrators) file found under {source_dir}"
+        raise FileNotFoundError(msg)
+
+    logger.info("mis_files_found", core=str(core_path), detail=str(detail_path))
+
+    hadith_table, id_map = _parse_core(core_path)
+    hadiths_path = write_parquet(
+        hadith_table, staging_dir / "hadiths_mis.parquet", schema=HADITH_SCHEMA
+    )
+
+    edge_table = _parse_edges(detail_path, id_map)
+    edges_path = write_parquet(
+        edge_table, staging_dir / "network_edges_mis.parquet", schema=NETWORK_EDGE_SCHEMA
+    )
+
+    return hadiths_path, edges_path

--- a/tests/integration/test_mis_lightup.py
+++ b/tests/integration/test_mis_lightup.py
@@ -1,0 +1,141 @@
+"""Live-Neo4j proof that MIS loads as real Hadith nodes + multi-isnad edges (da#97).
+
+Exercises the slice end-to-end against a live ``neo4j:5`` container:
+
+    parse (mis.run) -> load Hadith nodes (load_all_nodes) -> load network edges
+
+and asserts (a) the Hadith nodes land with canonical ``hdt:`` ids and the
+``mis`` / ``sunni`` provenance, and (b) the **multiplicity** survives all the way
+to graph relationships — a hadith with three isnads yields the chain-specific
+edges (``A->D``, ``E->B``) that would be gone had the parallel asanid been
+collapsed.
+
+The network-edge → graph wiring for non-muhaddithat sources is not yet in the
+production ``load_edges`` loader (it is hardcoded to
+``network_edges_muhaddithat.parquet``); this test loads MIS's own
+``network_edges_mis.parquet`` rows into the live graph directly, which is the
+honest E2E proof for the adapter while that wiring decision (a graph-layer
+follow-up) is made.
+
+Requires Docker; the ``neo4j_client`` fixture ``pytest.skip``s when Docker is
+unreachable (see ``tests/integration/conftest.py``), so this degrades to a clean
+SKIP off-CI rather than a red ERROR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+from openpyxl import Workbook
+
+from src.graph.load_nodes import load_all_nodes
+from src.parse import mis
+from src.parse.identity import narrator_node_id
+
+_LOAD_EDGES = """\
+UNWIND $rows AS row
+MERGE (a:Narrator {id: row.from_id})
+MERGE (b:Narrator {id: row.to_id})
+CREATE (a)-[:ISNAD_TRANSMITTED {hadith_id: row.hadith_id}]->(b)
+"""
+
+
+def _write_xlsx(path: Path, header: list[str], rows: list[list[object]]) -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.append(header)
+    for row in rows:
+        sheet.append(row)
+    workbook.save(str(path))
+
+
+def _make_mis_fixture(raw_dir: Path) -> None:
+    """Hadith 1 = three isnads (A/B/E), hadith 2 = one isnad."""
+    mis_dir = raw_dir / "mis"
+    mis_dir.mkdir(parents=True)
+    _write_xlsx(
+        mis_dir / "Hadith_SahihMuslim_CoreInfo.xlsx",
+        ["HadithNo", "BookNo", "Matn"],
+        [[1, 1, "متن ١"], [2, 1, "متن ٢"]],
+    )
+    _write_xlsx(
+        mis_dir / "Hadith_SahihMuslim_DetailsInfo_Sanad_Narrators.xlsx",
+        ["HadithNo", "IsnadNo", "Position", "Narrator"],
+        [
+            [1, "A", 1, "A"],
+            [1, "A", 2, "B"],
+            [1, "A", 3, "C"],
+            [1, "B", 1, "A"],
+            [1, "B", 2, "D"],
+            [1, "B", 3, "C"],
+            [1, "E", 1, "E"],
+            [1, "E", 2, "B"],
+            [1, "E", 3, "C"],
+            [2, "1", 1, "X"],
+            [2, "1", 2, "Y"],
+        ],
+    )
+
+
+@pytest.mark.integration
+class TestMisLoadLive:
+    def test_mis_loads_hadith_nodes_and_multi_isnad_edges(
+        self, neo4j_client, tmp_path: Path
+    ) -> None:
+        raw = tmp_path / "raw"
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        curated = tmp_path / "curated"
+        curated.mkdir()
+        _make_mis_fixture(raw)
+
+        hadiths_path, edges_path = mis.run(raw, staging)
+
+        # --- Hadith nodes via the production node loader ---------------------
+        results = load_all_nodes(neo4j_client, staging, curated, strict=False)
+        hadith_result = next(r for r in results if r.node_type == "Hadith")
+        assert not hadith_result.validation_errors
+
+        hadith_nodes = neo4j_client.execute_read(
+            "MATCH (h:Hadith) RETURN h.id AS id, h.source_corpus AS corpus, h.sect AS sect"
+        )
+        assert len(hadith_nodes) == 2
+        assert all(n["id"].startswith("hdt:mis:sahih_muslim:") for n in hadith_nodes)
+        assert all(n["corpus"] == "mis" for n in hadith_nodes)
+        assert all(n["sect"] == "sunni" for n in hadith_nodes)
+
+        # --- Multi-isnad edges into the live graph --------------------------
+        edge_rows = pq.read_table(edges_path).to_pylist()
+        graph_rows = [
+            {
+                "from_id": narrator_node_id(r["from_external_id"] or r["from_narrator_name"]),
+                "to_id": narrator_node_id(r["to_external_id"] or r["to_narrator_name"]),
+                "hadith_id": r["hadith_id"],
+            }
+            for r in edge_rows
+        ]
+        neo4j_client.execute_write(_LOAD_EDGES, {"rows": graph_rows})
+
+        # Every staging edge became a real relationship — nothing collapsed.
+        total = neo4j_client.execute_read(
+            "MATCH ()-[t:ISNAD_TRANSMITTED]->() RETURN count(t) AS n"
+        )[0]["n"]
+        assert total == len(edge_rows) == 7
+
+        # The three isnads of hadith 1 survive as distinct directed pairs,
+        # including the chain-specific links that only exist un-collapsed.
+        h1_id = "mis:sahih_muslim:1:1"
+        pairs = neo4j_client.execute_read(
+            "MATCH (a:Narrator)-[t:ISNAD_TRANSMITTED {hadith_id: $h}]->(b:Narrator) "
+            "RETURN DISTINCT a.id AS frm, b.id AS to",
+            {"h": h1_id},
+        )
+        pair_set = {(p["frm"], p["to"]) for p in pairs}
+        assert pair_set == {
+            (narrator_node_id(a), narrator_node_id(b))
+            for a, b in [("A", "B"), ("B", "C"), ("A", "D"), ("D", "C"), ("E", "B")]
+        }
+        assert (narrator_node_id("A"), narrator_node_id("D")) in pair_set
+        assert (narrator_node_id("E"), narrator_node_id("B")) in pair_set

--- a/tests/test_acquire/test_mis.py
+++ b/tests/test_acquire/test_mis.py
@@ -1,0 +1,79 @@
+"""Tests for the MIS acquire downloader (da#97) — no network.
+
+The Mendeley files API and the file downloads are stubbed; the test asserts the
+downloader enumerates the file set, fetches **only** the spreadsheet workbooks
+(skipping non-.xlsx artefacts), and fails fast when no workbook is present.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.acquire import mis
+
+_FILES_RESPONSE = [
+    {
+        "filename": "Hadith_SahihMuslim_CoreInfo.xlsx",
+        "content_details": {
+            "download_url": "https://data.mendeley.com/f/core",
+            "sha256_hash": None,
+        },
+    },
+    {
+        "filename": "Hadith_SahihMuslim_DetailsInfo_Sanad_Narrators.xlsx",
+        "content_details": {
+            "download_url": "https://data.mendeley.com/f/detail",
+            "sha256_hash": None,
+        },
+    },
+    {
+        "filename": "README.pdf",
+        "content_details": {"download_url": "https://data.mendeley.com/f/readme"},
+    },
+]
+
+
+@pytest.fixture
+def fake_mendeley(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Stub the files API + downloads; record requested download URLs."""
+    requested: list[str] = []
+
+    def _fetch_json(url: str, **_kw: object) -> object:
+        assert "gzprcr93zn" in url
+        return _FILES_RESPONSE
+
+    def _download(url: str, dest: Path, **_kw: object) -> Path:
+        requested.append(url)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"PK\x03\x04 fake-xlsx")
+        return dest
+
+    monkeypatch.setattr(mis, "fetch_json", _fetch_json)
+    monkeypatch.setattr(mis, "download_file", _download)
+    monkeypatch.setattr(mis, "emit_raw_new_for_manifest", lambda **_kw: None)
+    return requested
+
+
+def test_downloads_only_xlsx_workbooks(fake_mendeley: list[str], tmp_path: Path) -> None:
+    dest = mis.run(tmp_path / "raw")
+
+    assert dest == tmp_path / "raw" / "mis"
+    # Both workbooks fetched; the PDF is NOT.
+    assert any(u.endswith("/core") for u in fake_mendeley)
+    assert any(u.endswith("/detail") for u in fake_mendeley)
+    assert not any(u.endswith("/readme") for u in fake_mendeley)
+
+    assert (dest / "Hadith_SahihMuslim_CoreInfo.xlsx").exists()
+    assert (dest / "Hadith_SahihMuslim_DetailsInfo_Sanad_Narrators.xlsx").exists()
+    # write_manifest output present.
+    assert (dest / "manifest.json").exists()
+
+
+def test_raises_when_no_workbook(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(mis, "fetch_json", lambda *_a, **_kw: [{"filename": "README.pdf"}])
+    monkeypatch.setattr(mis, "emit_raw_new_for_manifest", lambda **_kw: None)
+
+    with pytest.raises(AssertionError, match="no .xlsx"):
+        mis.run(tmp_path / "raw")

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -38,6 +38,7 @@ EXPECTED_SLUGS = [
     "muhaddithat",
     "itqan",
     "halimbahae",
+    "mis",
 ]
 
 

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -430,3 +430,47 @@ class TestLoadStudiedUnderGlob:
         result = _load_studied_under(MockNeo4jClient(), staging_dir)
         assert result.edge_type == "STUDIED_UNDER"
         assert result.created == 0
+
+    def test_excludes_non_studentship_source(self, staging_dir: Path) -> None:
+        """A non-studentship NETWORK_EDGE producer (mis = isnad transmission) is
+        NOT globbed into STUDIED_UNDER — only the muhaddithat edge loads (da#133)."""
+        _write_network_edges(
+            staging_dir,
+            "muhaddithat",
+            [
+                {
+                    "from_narrator_name": "أ",
+                    "to_narrator_name": "ب",
+                    "source": "muhaddithat",
+                    "from_external_id": "1",
+                    "to_external_id": "2",
+                }
+            ],
+        )
+        _write_network_edges(
+            staging_dir,
+            "mis",
+            [
+                {
+                    "from_narrator_name": "X",
+                    "to_narrator_name": "Y",
+                    "source": "mis",
+                    "hadith_id": "mis:sahih_muslim:1:1",
+                }
+            ],
+        )
+        client = MockNeo4jClient()
+        client.set_read_results([{"from_exists": True, "to_exists": True}])
+        result = _load_studied_under(client, staging_dir)
+        assert result.created == 1  # only the muhaddithat studentship edge
+
+        batch = [b for q, b in client.calls if "MERGE" in q and isinstance(b, list)][-1]
+        # The mis isnad pair never reaches the STUDIED_UNDER batch.
+        assert {
+            "from_id": make_canonical_id(normalize_arabic("X")),
+            "to_id": make_canonical_id(normalize_arabic("Y")),
+        } not in batch
+        assert {
+            "from_id": make_canonical_id(normalize_arabic("أ")),
+            "to_id": make_canonical_id(normalize_arabic("ب")),
+        } in batch

--- a/tests/test_parse/test_mis_parser.py
+++ b/tests/test_parse/test_mis_parser.py
@@ -1,0 +1,188 @@
+"""Tests for the Multi-IsnadSet (MIS) parser (da#97).
+
+The headline property is **multi-isnad multiplicity**: a single hadith with N
+parallel isnad chains must yield N distinct edge-chains in staging, never a
+single collapsed chain. The sequence-layout tests assert chain-specific edges
+(links that exist only because the parallel asanid were kept apart) survive into
+``network_edges_mis.parquet``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+from openpyxl import Workbook
+
+from src.parse.identity import validate_source_id
+from src.parse.mis import run
+from src.parse.schemas import HADITH_SCHEMA, NETWORK_EDGE_SCHEMA
+
+
+def _write_xlsx(path: Path, header: list[str], rows: list[list[object]]) -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.append(header)
+    for row in rows:
+        sheet.append(row)
+    workbook.save(str(path))
+
+
+def _make_sequence_data(raw_dir: Path) -> None:
+    """CoreInfo + sequence-layout DetailsInfo (.xlsx).
+
+    Hadith 1 carries THREE isnads, hadith 2 carries ONE. The three chains of
+    hadith 1 share endpoints but diverge in the middle, so chain-specific edges
+    (A->D, E->B) only exist if the chains are kept distinct.
+    """
+    mis_dir = raw_dir / "mis"
+    mis_dir.mkdir(parents=True)
+
+    _write_xlsx(
+        mis_dir / "Hadith_SahihMuslim_CoreInfo.xlsx",
+        ["HadithNo", "BookNo", "Matn"],
+        [
+            [1, 1, "متن الحديث الأول"],
+            [2, 1, "متن الحديث الثاني"],
+        ],
+    )
+
+    # (HadithNo, IsnadNo, Position, Narrator)
+    detail_rows: list[list[object]] = [
+        # hadith 1, isnad A: A -> B -> C
+        [1, "A", 1, "A"],
+        [1, "A", 2, "B"],
+        [1, "A", 3, "C"],
+        # hadith 1, isnad B: A -> D -> C
+        [1, "B", 1, "A"],
+        [1, "B", 2, "D"],
+        [1, "B", 3, "C"],
+        # hadith 1, isnad E: E -> B -> C
+        [1, "E", 1, "E"],
+        [1, "E", 2, "B"],
+        [1, "E", 3, "C"],
+        # hadith 2, single isnad: X -> Y
+        [2, "1", 1, "X"],
+        [2, "1", 2, "Y"],
+    ]
+    _write_xlsx(
+        mis_dir / "Hadith_SahihMuslim_DetailsInfo_Sanad_Narrators.xlsx",
+        ["HadithNo", "IsnadNo", "Position", "Narrator"],
+        detail_rows,
+    )
+
+
+def _make_edge_data(raw_dir: Path) -> None:
+    """CoreInfo (.xlsx) + explicit edge-layout DetailsInfo (.csv)."""
+    mis_dir = raw_dir / "mis"
+    mis_dir.mkdir(parents=True)
+
+    _write_xlsx(
+        mis_dir / "Hadith_SahihMuslim_CoreInfo.xlsx",
+        ["HadithNo", "BookNo", "Matn"],
+        [[1, 2, "متن"]],
+    )
+
+    csv = "HadithNo,IsnadNo,FromNarrator,ToNarrator\n"
+    csv += "1,A,A,B\n1,A,B,C\n1,B,A,D\n1,B,D,C\n"
+    (mis_dir / "Hadith_SahihMuslim_DetailsInfo_Sanad_Narrators.csv").write_text(
+        csv, encoding="utf-8"
+    )
+
+
+class TestMisSequenceLayout:
+    def test_produces_both_parquet_files(self, tmp_path: Path) -> None:
+        _make_sequence_data(tmp_path / "raw")
+        hadiths_path, edges_path = run(tmp_path / "raw", tmp_path / "staging")
+        assert hadiths_path.exists()
+        assert edges_path.exists()
+
+    def test_hadith_schema_and_tagging(self, tmp_path: Path) -> None:
+        _make_sequence_data(tmp_path / "raw")
+        hadiths_path, _ = run(tmp_path / "raw", tmp_path / "staging")
+
+        table = pq.read_table(hadiths_path)
+        assert table.schema == HADITH_SCHEMA
+        assert table.num_rows == 2
+        assert set(table.column("source_corpus").to_pylist()) == {"mis"}
+        assert set(table.column("sect").to_pylist()) == {"sunni"}
+        # source_id grammar is corpus-namespaced and contract-valid.
+        for sid in table.column("source_id").to_pylist():
+            assert validate_source_id(sid) == [], sid
+            assert sid.startswith("mis:sahih_muslim:")
+
+    def test_edge_schema_and_tagging(self, tmp_path: Path) -> None:
+        _make_sequence_data(tmp_path / "raw")
+        _, edges_path = run(tmp_path / "raw", tmp_path / "staging")
+
+        table = pq.read_table(edges_path)
+        assert table.schema == NETWORK_EDGE_SCHEMA
+        assert set(table.column("source").to_pylist()) == {"mis"}
+
+    def test_multiplicity_preserved(self, tmp_path: Path) -> None:
+        """The three isnads of hadith 1 must survive as three distinct chains."""
+        _make_sequence_data(tmp_path / "raw")
+        _, edges_path = run(tmp_path / "raw", tmp_path / "staging")
+        table = pq.read_table(edges_path)
+        rows = table.to_pylist()
+
+        # Total edges = 2 (isnad A) + 2 (isnad B) + 2 (isnad E) + 1 (hadith 2) = 7.
+        assert len(rows) == 7
+
+        h1_id = "mis:sahih_muslim:1:1"
+        h1_pairs = {
+            (r["from_narrator_name"], r["to_narrator_name"])
+            for r in rows
+            if r["hadith_id"] == h1_id
+        }
+        # Five distinct directed pairs across the three chains.
+        assert h1_pairs == {("A", "B"), ("B", "C"), ("A", "D"), ("D", "C"), ("E", "B")}
+        # Chain-specific edges that ONLY exist because the parallel asanid were
+        # not collapsed into one sequence:
+        assert ("A", "D") in h1_pairs
+        assert ("E", "B") in h1_pairs
+        # Every hadith-1 edge points at the same hadith node as its HADITH row.
+        assert all(
+            r["hadith_id"] == h1_id
+            for r in rows
+            if r["from_narrator_name"] in {"A", "B", "C", "D", "E"}
+            and r["to_narrator_name"] in {"A", "B", "C", "D", "E"}
+        )
+
+    def test_edges_join_to_hadith_source_id(self, tmp_path: Path) -> None:
+        _make_sequence_data(tmp_path / "raw")
+        hadiths_path, edges_path = run(tmp_path / "raw", tmp_path / "staging")
+        hadith_ids = set(pq.read_table(hadiths_path).column("source_id").to_pylist())
+        edge_hadith_ids = set(pq.read_table(edges_path).column("hadith_id").to_pylist())
+        # Every edge references a real hadith node id.
+        assert edge_hadith_ids <= hadith_ids
+
+
+class TestMisEdgeLayout:
+    def test_explicit_edges_csv(self, tmp_path: Path) -> None:
+        _make_edge_data(tmp_path / "raw")
+        hadiths_path, edges_path = run(tmp_path / "raw", tmp_path / "staging")
+
+        edges = pq.read_table(edges_path).to_pylist()
+        pairs = {(e["from_narrator_name"], e["to_narrator_name"]) for e in edges}
+        assert pairs == {("A", "B"), ("B", "C"), ("A", "D"), ("D", "C")}
+        assert all(e["hadith_id"] == "mis:sahih_muslim:2:1" for e in edges)
+        # CoreInfo book number (2) flows into the source_id.
+        assert pq.read_table(hadiths_path).column("source_id").to_pylist() == [
+            "mis:sahih_muslim:2:1"
+        ]
+
+
+class TestMisErrors:
+    def test_missing_source_dir_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "raw").mkdir()
+        with pytest.raises(FileNotFoundError):
+            run(tmp_path / "raw", tmp_path / "staging")
+
+    def test_missing_detail_file_raises(self, tmp_path: Path) -> None:
+        mis_dir = tmp_path / "raw" / "mis"
+        mis_dir.mkdir(parents=True)
+        _write_xlsx(mis_dir / "Hadith_SahihMuslim_CoreInfo.xlsx", ["HadithNo"], [[1]])
+        with pytest.raises(FileNotFoundError):
+            run(tmp_path / "raw", tmp_path / "staging")

--- a/uv.lock
+++ b/uv.lock
@@ -414,6 +414,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "faiss-cpu"
 version = "1.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -590,6 +599,7 @@ dependencies = [
     { name = "kaggle" },
     { name = "lxml" },
     { name = "neo4j" },
+    { name = "openpyxl" },
     { name = "pandas" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pyarrow" },
@@ -633,6 +643,7 @@ requires-dist = [
     { name = "kaggle", specifier = ">=1.6" },
     { name = "lxml", specifier = ">=5.1" },
     { name = "neo4j", specifier = ">=5.15" },
+    { name = "openpyxl", specifier = ">=3.1" },
     { name = "pandas", specifier = ">=2.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
     { name = "pyarrow", specifier = ">=15.0" },
@@ -1163,6 +1174,18 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #97 · Part of epic #81. Net-new T2 source: **Multi-IsnadSet (MIS)** — Sahih Muslim with the *multiple* isnad chains per hadith made explicit.

## Why MIS is different
Most corpora give one chain per hadith. MIS (Mendeley `10.17632/gzprcr93zn.2`, Farooqi et al., *Data in Brief* 2024) is the platform's **multi-isnad** source: a single Sahih Muslim hadith carries several parallel asanid (the tahwil / ح split). The whole value is preserving those as **distinct** transmission chains — collapsing them would throw away exactly what MIS exists to model.

## How multiplicity is preserved
The parser emits **`NETWORK_EDGE_SCHEMA`** (directed `from→to` narrator pairs), not `NARRATOR_MENTION_SCHEMA`. Deliberate and load-bearing:
- A hadith's N isnads contribute **N independent edge-chains** that coexist as distinct rows. Parallel chains that share endpoints but diverge in the middle keep their chain-specific links.
- The mention schema is keyed only by `source_hadith_id` + `position_in_chain` with **no per-chain discriminator** — feeding multi-isnad through it would merge the parallel asanid into one chain. NETWORK_EDGE sidesteps that.
- Each isnad is grouped by `(hadith, sanad)` and walked into consecutive pairs; edge `hadith_id` == the hadith's `source_id` (corpus-namespaced join), so edges tie to their Hadith node.

Proven end-to-end: the live `neo4j:5` lightup loads a 3-isnad hadith and asserts the chain-specific edges (`A→D`, `E→B`) land as real graph relationships — edges that only exist if the chains were **not** collapsed. 7 staging edges → 7 relationships, 5 distinct hadith-1 pairs.

## Changes
- **`src/models/enums.py`** — `SourceCorpus.MIS = "mis"`.
- **`src/adapters.py`** — register the `mis` `SourceAdapter` row (sect=`sunni`, reachable, CC BY 4.0 note).
- **`src/acquire/mis.py`** — download the two Mendeley `.xlsx` workbooks; file ids resolved at runtime from the dataset files API (keyless-public, same mechanism proven for `sanadset`).
- **`src/parse/mis.py`** — `hadiths_mis.parquet` (HADITH_SCHEMA) + `network_edges_mis.parquet` (NETWORK_EDGE_SCHEMA). Tolerant column detection; sequence + explicit-edge DetailsInfo layouts; xlsx + csv readers. `SOURCE_CORPUS="mis"` / `SECT="sunni"`.
- **`pyproject.toml` / `uv.lock`** — add `openpyxl>=3.1` (xlsx engine) + its mypy override.
- **`tests/test_adapters.py`** — `EXPECTED_SLUGS += "mis"` (coverage invariant).
- Tests: `test_parse/test_mis_parser.py` (multiplicity / schema / tagging / source_id grammar, both layouts, both readers), `test_acquire/test_mis.py` (no-network), `tests/integration/test_mis_lightup.py` (live neo4j:5, skip-guarded).

## SERIAL-MERGE NOTE (for #95 Kavitha / #96 Alejandra)
Shared files touched — all **append-only**, no reorders:
- `src/models/enums.py` — appended one enum value `MIS = "mis"`.
- `src/adapters.py` — appended one `SourceAdapter` row (slug `mis`) at the end of `SOURCE_REGISTRY`.
- `tests/test_adapters.py` — appended `"mis"` to `EXPECTED_SLUGS`.
- `pyproject.toml` / `uv.lock` — one dep (`openpyxl>=3.1`) + one mypy override; if a sibling also touches the lock, re-run `uv lock` after merge.

## Edge counts (fixture)
3-isnad hadith → A→B, B→C, A→D, D→C, E→B (5 distinct pairs; 6 raw edges incl. duplicate B→C across two chains) + 1-isnad hadith X→Y = **7 edges**, all schema-valid and tagged `source=mis`.

## Scope boundary / follow-up
The production `network_edges → graph` loader (`load_edges._load_studied_under`) is hardcoded to `network_edges_muhaddithat.parquet`, and isnad-transmission edges are semantically `TRANSMITTED_TO`, not `STUDIED_UNDER`. Wiring MIS's network_edges into the production edge loader is a **graph-layer decision** (glob vs. a new isnad branch) deliberately left out of this acquisition PR; the lightup loads MIS's own staging rows directly to give honest live E2E evidence now. Recommend a graph-repo follow-up issue.

## Test Plan
- [x] `pytest -m "not integration and not ml"` — 701 passed
- [x] `pytest -m integration tests/integration/test_mis_lightup.py` — 1 passed against live `neo4j:5`
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` clean
- [x] `scripts/check_source_id_corpus.py src/parse` — clean (MIS uses module-const `SOURCE_CORPUS`)

Reviewers: @Jean-Claude Habimana (architect, primary) · @Nikolaos Papadopoulos (secondary)
