### PR TITLE
feat(bihar): Bihar al-Anwar Shia coverage via hubeali (#95)

### DIFF
--- a/src/acquire/bihar.py
+++ b/src/acquire/bihar.py
@@ -1,0 +1,151 @@
+"""Acquire Bihar al-Anwar (بحار الأنوار) from hubeali.com.
+
+Bihar al-Anwar — al-Majlisi's ~100k-hadith Shia encyclopedia — is NOT carried by
+the Thaqalayn data source (which is the Four Books + ~20 secondary texts only;
+verified da#95). hubeali.com's "Read Online" edition is the one openly-readable,
+per-hadith, bilingual (Arabic + English) copy. It is published as one large
+WordPress page per *volume / part*::
+
+    /books-library/bihar-al-anwaar/volume-<V>/                       (volume index)
+    /books-library/bihar-al-anwaar/volume-<V>/part-<P>/
+        bihar-al-anwaar-volume-<V>-part-<P>/                         (content page)
+
+This downloader is a *polite, bounded* scraper modelled on
+:mod:`src.acquire.sunnah_scraper`: it honours ``robots.txt`` (hubeali only
+disallows ``/wp-admin/``), throttles between requests, and caches each content
+page's raw HTML to ``data/raw/bihar/volume-<V>-part-<P>.html`` (idempotent — a
+cached page is skipped). :mod:`src.parse.bihar` parses those cached pages.
+
+``DEFAULT_VOLUMES`` is deliberately small (volume 1): a PR-time acquisition pulls
+a bounded, representative slice rather than the whole ~100k-hadith corpus. Pass
+``volumes=range(1, N)`` (or set it in a job) to widen the crawl for a real
+data-load run.
+
+Licensing (owner-approved da#95, same posture as Itqan da#92a): hubeali content
+carries no machine-readable upstream licence; use is non-profit, the hadith facts
+are re-expressed in our own schema, and everything is cleanly removable via the
+``source_corpus="bihar"`` provenance tag.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from urllib.robotparser import RobotFileParser
+
+import httpx
+
+from src.acquire.base import ensure_dir, write_manifest
+from src.messaging import emit_raw_new_for_manifest
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+BASE_URL = "https://hubeali.com"
+BOOK_ROOT = f"{BASE_URL}/books-library/bihar-al-anwaar"
+RATE_LIMIT_SECONDS = 1.0
+REQUEST_TIMEOUT = 60.0
+USER_AGENT = "isnad-graph/1.0 (hadith-research)"
+
+# A PR-time crawl pulls a bounded slice; widen for a full data-load run.
+DEFAULT_VOLUMES: tuple[int, ...] = (1,)
+
+# The deep "content" link on a volume index page, e.g.
+# ".../volume-1/part-1/bihar-al-anwaar-volume-1-part-1/". The shorter
+# ".../part-1/" part-index link is ignored — we want the page with the text.
+_CONTENT_LINK_RE = re.compile(
+    r"/books-library/bihar-al-anwaar/volume-(\d+)/part-(\d+)/"
+    r"bihar-al-anwaar-volume-\d+-part-\d+/?",
+    re.IGNORECASE,
+)
+
+
+def _check_robots_txt(client: httpx.Client) -> bool:
+    """Return True if ``robots.txt`` permits crawling the book pages."""
+    try:
+        resp = client.get(f"{BASE_URL}/robots.txt")
+        parser = RobotFileParser()
+        parser.parse(resp.text.splitlines())
+        allowed: bool = parser.can_fetch(USER_AGENT, f"{BOOK_ROOT}/volume-1/")
+        if not allowed:
+            logger.warning("bihar_robots_denied")
+        return allowed
+    except Exception:  # noqa: BLE001 — robots unreachable: proceed cautiously, like sunnah_scraper
+        logger.warning("bihar_robots_unavailable")
+        return True
+
+
+def _get(client: httpx.Client, url: str) -> str | None:
+    """GET *url*, returning the response text or ``None`` on any HTTP error."""
+    try:
+        resp = client.get(url)
+        resp.raise_for_status()
+        return resp.text
+    except httpx.HTTPError as exc:
+        logger.warning("bihar_fetch_error", url=url, error=str(exc))
+        return None
+
+
+def _discover_content_links(client: httpx.Client, volume: int) -> list[tuple[int, str]]:
+    """Find ``(part_number, url)`` content links on a volume index page."""
+    html = _get(client, f"{BOOK_ROOT}/volume-{volume}/")
+    if html is None:
+        return []
+    seen: dict[int, str] = {}
+    for match in _CONTENT_LINK_RE.finditer(html):
+        if int(match.group(1)) != volume:
+            continue
+        part = int(match.group(2))
+        url = match.group(0)
+        if not url.startswith("http"):
+            url = BASE_URL + url
+        seen.setdefault(part, url.rstrip("/") + "/")
+    return sorted(seen.items())
+
+
+def run(raw_dir: Path, volumes: Iterable[int] = DEFAULT_VOLUMES) -> Path | None:
+    """Scrape bounded Bihar al-Anwar volume/part pages from hubeali.com.
+
+    Caches each content page's raw HTML to ``<raw_dir>/bihar/volume-<V>-part-<P>.html``
+    (idempotent). Returns the ``bihar`` raw directory, or ``None`` if
+    ``robots.txt`` disallows the crawl or nothing could be fetched.
+    """
+    dest = ensure_dir(raw_dir / "bihar")
+    client = httpx.Client(
+        headers={"User-Agent": USER_AGENT},
+        timeout=REQUEST_TIMEOUT,
+        follow_redirects=True,
+    )
+    try:
+        if not _check_robots_txt(client):
+            return None
+
+        saved: list[Path] = []
+        for volume in volumes:
+            for part, url in _discover_content_links(client, volume):
+                out_path = dest / f"volume-{volume}-part-{part}.html"
+                if out_path.exists() and out_path.stat().st_size > 0:
+                    logger.info("bihar_cached", volume=volume, part=part)
+                    saved.append(out_path)
+                    continue
+
+                time.sleep(RATE_LIMIT_SECONDS)
+                html = _get(client, url)
+                if html is None:
+                    continue
+                out_path.write_text(html, encoding="utf-8")
+                logger.info("bihar_fetched", volume=volume, part=part, bytes=len(html))
+                saved.append(out_path)
+
+        if not saved:
+            logger.warning("bihar_no_pages_acquired")
+            return None
+
+        write_manifest(dest, saved)
+        emit_raw_new_for_manifest(source="bihar", local_dir=dest, files=saved)
+        logger.info("bihar_acquired", pages=len(saved))
+        return dest
+    finally:
+        client.close()

--- a/src/adapters.py
+++ b/src/adapters.py
@@ -245,6 +245,22 @@ SOURCE_REGISTRY: tuple[SourceAdapter, ...] = (
             "made explicit (Sunni); one hadith emits N distinct transmission chains."
         ),
     ),
+    SourceAdapter(
+        slug="bihar",
+        corpus=SourceCorpus.BIHAR,
+        sect=Sect.SHIA,
+        acquire_module="bihar",
+        parse_module="bihar",
+        reachable=True,
+        license_note=(
+            "Bihar al-Anwar via hubeali.com 'Read Online' (bilingual AR+EN) — NOT "
+            "carried by Thaqalayn (da#95). NO machine-readable upstream license; "
+            "owner-approved (da#95, same posture as Itqan da#92a): non-profit, facts "
+            "re-expressed in our own schema, cleanly removable via "
+            "source_corpus='bihar' provenance. Polite bounded scrape (robots.txt OK)."
+        ),
+        description="Bihar al-Anwar — al-Majlisi's ~100k-hadith Shia encyclopedia (hubeali).",
+    ),
 )
 
 

--- a/src/models/enums.py
+++ b/src/models/enums.py
@@ -154,6 +154,7 @@ class SourceCorpus(StrEnum):
     ITQAN = "itqan"
     HALIMBAHAE = "halimbahae"
     MIS = "mis"
+    BIHAR = "bihar"
 
 
 class Sect(StrEnum):

--- a/src/parse/bihar.py
+++ b/src/parse/bihar.py
@@ -1,0 +1,256 @@
+"""Parse Bihar al-Anwar (hubeali.com) raw HTML into staging Parquet.
+
+Source
+------
+Bihar al-Anwar (بحار الأنوار), Allama Muhammad Baqir al-Majlisi's ~100k-hadith
+Shia encyclopedia, is NOT carried by the Thaqalayn data source (the Four Books
++ ~20 secondary texts only). The one openly-readable, per-hadith, bilingual
+(Arabic + English) edition is hubeali.com's "Read Online" set, one big WordPress
+page per *volume / part* under
+``/books-library/bihar-al-anwaar/volume-<V>/part-<P>/...``. ``src/acquire/bihar.py``
+caches those pages; this module turns the cached HTML into hadith rows.
+
+Markup contract (observed on the live pages)
+--------------------------------------------
+The hadith text lives in ``div.entry-content`` as a flat run of ``<p>``
+elements that *alternate* an Arabic line and its English translation::
+
+    <p>كتاب العقل و العلم و الجهل</p>          # كتاب  — book heading
+    <p>باب 1 فضل العقل و ذم الجهل</p>          # باب N — chapter heading
+    <p>الآيات ...</p> <p>The Verses ...</p>     # chapter preamble (Quranic verses)
+    <p>1- مع، معاني الأخبار ... الإسناد</p>     # hadith 1: "<N>- <isnad+matn AR>"
+    <p>In accordance to ...</p>                 #   its English translation
+    <p>From Al-Sadiq ...</p>                     #   (continuation paragraphs)
+    <p>2- لي، الأمالي ...</p>                    # hadith 2 ...
+
+So a hadith **starts** at a paragraph matching ``^<N>- `` whose text is Arabic,
+and runs until the next such marker or the next ``باب`` heading. ``<N>`` is the
+in-chapter ordinal; ``source_id`` is namespaced ``bihar:bihar-al-anwar:<volume>:
+<chapter>:<ordinal>`` (the corpus is ``bihar``; the collection slug is
+``bihar-al-anwar`` — deliberately NOT ``bihar`` so the id is not mistaken for a
+doubled-corpus prefix by :func:`src.parse.identity.is_double_prefixed`).
+
+Like Thaqalayn, hubeali does not separate isnad from matn in a machine field, so
+the whole Arabic body goes to ``full_text_ar`` and the English to
+``full_text_en`` (``matn_*`` / ``isnad_raw_*`` stay null for Phase-2 extraction).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+from bs4 import BeautifulSoup
+
+from src.parse.base import generate_source_id, safe_str, write_parquet
+from src.parse.schemas import COLLECTION_SCHEMA, HADITH_SCHEMA
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+SOURCE_CORPUS = "bihar"
+# Collection slug is NOT "bihar": a "bihar:bihar:..." source_id would trip
+# identity.is_double_prefixed (leading segment == second segment == a known
+# corpus) and be collapsed by the loader. "bihar-al-anwar" keeps it distinct.
+COLLECTION_SLUG = "bihar-al-anwar"
+COLLECTION_NAME = "Bihar al-Anwar"
+COLLECTION_NAME_AR = "بحار الأنوار"
+COMPILER_NAME = "Muhammad Baqir al-Majlisi"
+SECT = "shia"
+
+# Unicode ranges that mark a paragraph as Arabic rather than English.
+_ARABIC_RE = re.compile(r"[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-﻿]")
+# A hadith opener: "<N>- ..." / "<N> – ..." at the very start of an Arabic line.
+_HADITH_START_RE = re.compile(r"^\s*(\d+)\s*[-–—]\s*")
+# A chapter heading: Arabic "باب <N> ...".
+_BAB_RE = re.compile(r"^\s*باب\s*(\d+)")
+# Volume / part numbers parsed from the cached filename, e.g. "volume-1-part-1".
+_VOL_PART_RE = re.compile(r"volume-(\d+)-part-(\d+)", re.IGNORECASE)
+# RTL/LTR marks that pad the scraped Arabic and would defeat str.startswith.
+_BIDI_MARKS = "‎‏‪‫‬​"
+
+
+def _clean(text: str) -> str:
+    """Normalise a scraped paragraph: drop bidi marks, collapse whitespace."""
+    for mark in _BIDI_MARKS:
+        text = text.replace(mark, "")
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _is_arabic(text: str) -> bool:
+    """True if *text* contains Arabic-script characters."""
+    return bool(_ARABIC_RE.search(text))
+
+
+def _volume_part(html_path: Path) -> tuple[int | None, int | None]:
+    """Parse ``(volume, part)`` from a cached filename like ``volume-1-part-1.html``."""
+    match = _VOL_PART_RE.search(html_path.stem)
+    if not match:
+        return None, None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _paragraphs(html: str) -> list[str]:
+    """Cleaned, non-empty ``<p>`` texts from the page's ``div.entry-content``.
+
+    ``<sup>`` honorific glyphs (``asws`` etc.) are dropped before extraction so
+    they do not pollute the text; falls back to the whole document if the page
+    has no ``entry-content`` wrapper.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    container = soup.find("div", class_="entry-content") or soup
+    for sup in container.find_all("sup"):
+        sup.decompose()
+    out: list[str] = []
+    for para in container.find_all("p"):
+        text = _clean(para.get_text(" ", strip=True))
+        if text:
+            out.append(text)
+    return out
+
+
+def _hadith_row(
+    number: int,
+    chapter_number: int | None,
+    volume: int | None,
+    chapter_name_ar: str | None,
+    arabic_parts: list[str],
+    english_parts: list[str],
+) -> dict[str, Any]:
+    """Assemble one HADITH_SCHEMA row from a hadith's collected paragraphs."""
+    # Strip the leading "<N>- " marker off the first Arabic line.
+    if arabic_parts:
+        arabic_parts = [_HADITH_START_RE.sub("", arabic_parts[0], count=1), *arabic_parts[1:]]
+    full_ar = safe_str("\n".join(p for p in arabic_parts if p))
+    full_en = safe_str("\n".join(p for p in english_parts if p))
+    source_id = generate_source_id(
+        SOURCE_CORPUS,
+        COLLECTION_SLUG,
+        volume or 0,
+        chapter_number or 0,
+        number,
+    )
+    return {
+        "source_id": source_id,
+        "source_corpus": SOURCE_CORPUS,
+        "collection_name": COLLECTION_NAME,
+        "book_number": volume,
+        "chapter_number": chapter_number,
+        "hadith_number": number,
+        "matn_ar": None,
+        "matn_en": None,
+        "isnad_raw_ar": None,
+        "isnad_raw_en": None,
+        "full_text_ar": full_ar,
+        "full_text_en": full_en,
+        "grade": None,
+        "chapter_name_ar": chapter_name_ar,
+        "chapter_name_en": None,
+        "sect": SECT,
+    }
+
+
+def _parse_page(html: str, volume: int | None) -> list[dict[str, Any]]:
+    """Segment one cached volume-part page into hadith rows.
+
+    Walks the alternating Arabic/English paragraph run, tracking the current
+    ``باب`` chapter and accumulating each ``<N>- ...`` hadith's Arabic and
+    English paragraphs until the next hadith marker or chapter heading.
+    """
+    rows: list[dict[str, Any]] = []
+    chapter_number: int | None = None
+    chapter_name_ar: str | None = None
+    in_chapter = False  # only collect hadiths once inside a باب (skips the index)
+
+    cur_number: int | None = None
+    cur_ar: list[str] = []
+    cur_en: list[str] = []
+
+    def flush() -> None:
+        nonlocal cur_number, cur_ar, cur_en
+        if cur_number is not None and (cur_ar or cur_en):
+            rows.append(
+                _hadith_row(cur_number, chapter_number, volume, chapter_name_ar, cur_ar, cur_en)
+            )
+        cur_number, cur_ar, cur_en = None, [], []
+
+    for para in _paragraphs(html):
+        bab = _BAB_RE.match(para)
+        if bab:
+            flush()
+            chapter_number = int(bab.group(1))
+            chapter_name_ar = para
+            in_chapter = True
+            continue
+
+        start = _HADITH_START_RE.match(para)
+        if start and in_chapter and _is_arabic(para):
+            flush()
+            cur_number = int(start.group(1))
+            cur_ar = [para]
+            continue
+
+        if cur_number is None:
+            continue  # chapter preamble (verses) or pre-content index — skip
+        (cur_ar if _is_arabic(para) else cur_en).append(para)
+
+    flush()
+    return rows
+
+
+def _collection_row(total_hadiths: int) -> dict[str, Any]:
+    """The single Bihar al-Anwar COLLECTION_SCHEMA row."""
+    return {
+        "collection_id": generate_source_id(SOURCE_CORPUS, COLLECTION_SLUG),
+        "name_ar": COLLECTION_NAME_AR,
+        "name_en": COLLECTION_NAME,
+        "compiler_name": COMPILER_NAME,
+        "compilation_year_ah": None,
+        "sect": SECT,
+        "total_hadiths": total_hadiths,
+        "source_corpus": SOURCE_CORPUS,
+    }
+
+
+def run(raw_dir: Path, staging_dir: Path) -> tuple[Path, Path]:
+    """Parse cached hubeali Bihar HTML into hadiths + collection Parquet."""
+    bihar_dir = raw_dir / "bihar"
+    html_files = sorted(bihar_dir.glob("*.html"))
+    if not html_files:
+        msg = f"No Bihar al-Anwar HTML files found under {bihar_dir}"
+        raise FileNotFoundError(msg)
+
+    logger.info("bihar_parse_start", file_count=len(html_files))
+
+    hadith_rows: list[dict[str, Any]] = []
+    for html_path in html_files:
+        volume, _part = _volume_part(html_path)
+        page_rows = _parse_page(html_path.read_text(encoding="utf-8"), volume)
+        logger.info("bihar_parsed_page", file=html_path.name, hadiths=len(page_rows))
+        hadith_rows.extend(page_rows)
+
+    if not hadith_rows:
+        msg = "Bihar al-Anwar parse produced 0 hadiths — check the page markup contract"
+        raise ValueError(msg)
+
+    hadith_table = pa.table(
+        {field.name: [r[field.name] for r in hadith_rows] for field in HADITH_SCHEMA},
+        schema=HADITH_SCHEMA,
+    )
+    hadiths_path = write_parquet(
+        hadith_table, Path(staging_dir) / "hadiths_bihar.parquet", schema=HADITH_SCHEMA
+    )
+
+    coll_rows = [_collection_row(len(hadith_rows))]
+    coll_table = pa.table(
+        {field.name: [r[field.name] for r in coll_rows] for field in COLLECTION_SCHEMA},
+        schema=COLLECTION_SCHEMA,
+    )
+    collections_path = write_parquet(
+        coll_table, Path(staging_dir) / "collections_bihar.parquet", schema=COLLECTION_SCHEMA
+    )
+
+    logger.info("bihar_parse_complete", hadiths=len(hadith_rows), collections=len(coll_rows))
+    return hadiths_path, collections_path

--- a/tests/test_acquire/test_bihar.py
+++ b/tests/test_acquire/test_bihar.py
@@ -1,0 +1,129 @@
+"""Tests for the Bihar al-Anwar (hubeali) acquire scraper.
+
+Two legs, mirroring the project's acquire-test convention:
+
+* **Mocked unit legs** (always run, no network) — patch ``httpx.Client.get`` to
+  serve a robots.txt, a real-shaped volume-index page, and a content page, then
+  assert robots-gating, content-link discovery, raw caching/idempotency, and the
+  manifest write.
+* **Live smoke** (skip-guarded behind ``BIHAR_LIVE_TEST=1``) — actually crawls a
+  bounded slice of hubeali.com and parses it, proving the live→parse contract
+  without pulling the whole ~100k-hadith corpus.  Off by default so CI never
+  depends on a third-party site being up.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pyarrow.parquet as pq
+import pytest
+
+from src.acquire import bihar
+from src.parse.bihar import run as parse_run
+from src.parse.schemas import HADITH_SCHEMA
+
+ROBOTS_ALLOW = "User-agent: *\nDisallow: /wp-admin/\n"
+ROBOTS_DENY = "User-agent: *\nDisallow: /\n"
+
+# A volume-index page carrying the real deep "content" link shape plus the
+# shorter part-index link that must be ignored.
+VOLUME_INDEX_HTML = """
+<html><body>
+  <a href="https://hubeali.com/books-library/bihar-al-anwaar/volume-1/part-1/">Part 1</a>
+  <a href="https://hubeali.com/books-library/bihar-al-anwaar/volume-1/part-1/bihar-al-anwaar-volume-1-part-1/">Read</a>
+  <a href="https://hubeali.com/books-library/bihar-al-anwaar/volume-2/">Volume 2</a>
+</body></html>
+"""
+
+CONTENT_HTML = """
+<html><body><div class="entry-content">
+<p>باب 1 فضل العقل</p>
+<p>1- مع، معاني الأخبار الإسناد العربي</p>
+<p>In accordance to the chain, English translation.</p>
+</div></body></html>
+"""
+
+
+def _response(text: str, status: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status_code=status, text=text, request=httpx.Request("GET", "https://hubeali.com/x")
+    )
+
+
+def _router(robots: str = ROBOTS_ALLOW):
+    """Return a fake ``Client.get`` that routes by URL to canned responses."""
+
+    def _get(self: httpx.Client, url: str, *args: object, **kwargs: object) -> httpx.Response:
+        if url.endswith("robots.txt"):
+            return _response(robots)
+        if url.endswith("/volume-1/"):
+            return _response(VOLUME_INDEX_HTML)
+        if "bihar-al-anwaar-volume-1-part-1" in url:
+            return _response(CONTENT_HTML)
+        if url.endswith("/volume-2/"):
+            return _response("<html><body>no parts</body></html>")
+        return _response("not found", status=404)
+
+    return _get
+
+
+class TestBiharAcquireMocked:
+    def test_robots_denied_returns_none(self, tmp_path: Path) -> None:
+        with patch.object(httpx.Client, "get", _router(robots=ROBOTS_DENY)):
+            assert bihar.run(tmp_path / "raw", volumes=[1]) is None
+
+    def test_discovers_and_caches_content_page(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        with patch.object(httpx.Client, "get", _router()), patch.object(bihar.time, "sleep"):
+            result = bihar.run(raw_dir, volumes=[1])
+        assert result == raw_dir / "bihar"
+        cached = raw_dir / "bihar" / "volume-1-part-1.html"
+        assert cached.exists()
+        assert "entry-content" in cached.read_text(encoding="utf-8")
+        assert (raw_dir / "bihar" / "manifest.json").exists()
+
+    def test_idempotent_skip_on_second_run(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        get = _router()
+        calls: list[str] = []
+
+        def _counting_get(self: httpx.Client, url: str, *a: object, **k: object) -> httpx.Response:
+            calls.append(url)
+            return get(self, url, *a, **k)
+
+        with patch.object(httpx.Client, "get", _counting_get), patch.object(bihar.time, "sleep"):
+            bihar.run(raw_dir, volumes=[1])
+            first = len([u for u in calls if "part-1/bihar" in u])
+            bihar.run(raw_dir, volumes=[1])
+            second = len([u for u in calls if "part-1/bihar" in u])
+        # The content page is fetched on the first run, served from cache on the second.
+        assert first == 1
+        assert second == 1
+
+    def test_no_pages_returns_none(self, tmp_path: Path) -> None:
+        # Volume 2 in the fixture has no content links → nothing acquired.
+        with patch.object(httpx.Client, "get", _router()), patch.object(bihar.time, "sleep"):
+            assert bihar.run(tmp_path / "raw", volumes=[2]) is None
+
+
+@pytest.mark.skipif(
+    os.getenv("BIHAR_LIVE_TEST") != "1",
+    reason="live hubeali crawl skip-guarded behind BIHAR_LIVE_TEST=1",
+)
+class TestBiharAcquireLive:
+    def test_live_bounded_acquire_and_parse(self, tmp_path: Path) -> None:
+        """Crawl volume 1 from the real site and parse it to conforming Parquet."""
+        raw_dir = tmp_path / "raw"
+        result = bihar.run(raw_dir, volumes=[1])
+        assert result is not None, "live crawl acquired nothing (site down or markup changed)"
+
+        hadiths_path, _ = parse_run(raw_dir, tmp_path / "staging")
+        table = pq.read_table(hadiths_path)
+        assert table.schema == HADITH_SCHEMA
+        assert table.num_rows > 0
+        rows = table.to_pylist()
+        assert all(r["sect"] == "shia" and r["source_corpus"] == "bihar" for r in rows)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -39,6 +39,7 @@ EXPECTED_SLUGS = [
     "itqan",
     "halimbahae",
     "mis",
+    "bihar",
 ]
 
 

--- a/tests/test_parse/fixtures/bihar_volume-1-part-1_sample.html
+++ b/tests/test_parse/fixtures/bihar_volume-1-part-1_sample.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Bihar Al-Anwaar Volume 1 Part 1</title></head><body>
+<h1 class="entry-title">Bihar Al-Anwaar Volume 1 Part 1</h1>
+<div class="entry-content">
+<p>&nbsp;</p>
+<p><a name="_Toc524083455"></a><strong>بحار الأنوار</strong></p>
+<p><a name="_Toc524083456"></a><strong>BIHAR AL-ANWAAR</strong></p>
+<p><strong> </strong></p>
+<p><strong> </strong></p>
+<p><strong> </strong></p>
+<p><a name="_Toc524083457"></a><strong>ج 1</strong></p>
+<p><a name="_Toc524083458"></a><strong>Volume 1</strong></p>
+<p><strong> </strong></p>
+<p><strong> </strong></p>
+<p><strong>بحار الانوار الجامعة لدرر أخبار الائمة الاطهار</strong></p>
+<p><strong>Bihar Al-Anwaar – The summary of the pearls of the Ahadeeth of the Pure Imams<sup>asws</sup></strong></p>
+<p><strong><sup> </sup></strong></p>
+<p><strong> </strong></p>
+<p><strong>تأليف العلامة فخر الامة المولى الشيخ محمد باقر المجلسيى</strong></p>
+<p><strong>Author – The Allama, the pride of the community, the Mullah, the Sheikh Muhammad Baqir Al Majlisi</strong></p>
+<p><a name="_Toc524086348"></a>كتاب العقل و العلم و الجهل‏</p>
+<p><a name="_Toc524086350"></a>باب 1 فضل العقل و ذم الجهل‏</p>
+<p>الآيات البقرة لَآياتٍ لِقَوْمٍ يَعْقِلُونَ‏ و قال تعالى‏ كَذلِكَ يُبَيِّنُ اللَّهُ لَكُمْ آياتِهِ لَعَلَّكُمْ تَعْقِلُونَ‏ و قال تعالى‏ وَ ما يَذَّكَّرُ إِلَّا أُولُوا الْأَلْبابِ‏ آل عمران‏ وَ ما يَذَّكَّرُ إِلَّا أُولُوا الْأَلْبابِ‏</p>
+<p>The Verses of (Surah Al-Baqarah):- <strong><em>there are signs for a people who are understanding [2:164]</em></strong>. And the Exalted Said: <strong><em>Like that, Allah Clarifies His Verses for you all, perhaps you may be minding [2:242]</em></strong>. And the Exalted Said: <strong><em>and none would mention (words of thanks) except for the ones of understanding [2:269]</em></strong>.</p>
+<p>و قال تعالى‏ قَدْ بَيَّنَّا لَكُمُ الْآياتِ إِنْ كُنْتُمْ تَعْقِلُونَ‏ و قال‏ إِنَّ فِي خَلْقِ السَّماواتِ وَ الْأَرْضِ وَ اخْتِلافِ اللَّيْلِ وَ النَّهارِ لَآياتٍ لِأُولِي الْأَلْبابِ</p>
+<p>(Surah) Aal-e-Imran: &#8211; <strong><em>And none (would) mention except those with the understanding [3:7]</em></strong>. And the Exalted Said: <strong><em>We have Clarified the Signs for you, if you use your intellects [3:118]</em></strong>. And Said: <strong><em>In the Creation of the skies and the earth and the alternation of the night and the day there are Signs for the ones of understanding [3:190]</em></strong>.</p>
+<p>المائدة ذلِكَ بِأَنَّهُمْ قَوْمٌ لا يَعْقِلُونَ‏ و قال تعالى‏ فَاتَّقُوا اللَّهَ يا أُولِي الْأَلْبابِ‏ و قال‏ وَ أَكْثَرُهُمْ لا يَعْقِلُونَ</p>
+<p>(Surah) Al-Ma’idah: &#8211; <strong><em>that is because they are a people who are not understanding [5:58]</em></strong>. And the Exalted Said: <strong><em>Therefore, fear Allah, O ones of understanding, [5:100]</em></strong>. And Said: <strong><em>and most of them are not understanding [5:103]</em></strong>.</p>
+<p>الأنعام‏ وَ لكِنَّ أَكْثَرَهُمْ يَجْهَلُونَ‏ و قال‏ وَ لَلدَّارُ الْآخِرَةُ خَيْرٌ لِلَّذِينَ يَتَّقُونَ أَ فَلا تَعْقِلُونَ‏</p>
+<p>Surah Al-Anam: &#8211; <strong><em>but most of them are ignorant [6:111]</em></strong>. And Said: <strong><em>And the House of the Hereafter is better for those who fear. Will you then not understand? [6:32]</em></strong>.</p>
+<p>الأنفال‏ إِنَّ شَرَّ الدَّوَابِّ عِنْدَ اللَّهِ الصُّمُّ الْبُكْمُ الَّذِينَ لا يَعْقِلُونَ‏</p>
+<p>(Surah) Al-Anfaal: &#8211; <strong><em>Surely, the vilest animals in the Presence of Allah are the deaf, the dumb, those who are not using their intellects [8:22]</em></strong>.</p>
+<p>يونس‏ أَ فَأَنْتَ تُسْمِعُ الصُّمَّ وَ لَوْ كانُوا لا يَعْقِلُونَ و قال تعالى‏ وَ يَجْعَلُ الرِّجْسَ عَلَى الَّذِينَ لا يَعْقِلُونَ</p>
+<p>(Surah) Yunus: &#8211; <strong><em>But can you make the deaf to hear and even though they cannot understand? [10:42]</em></strong>. And the Exalted Said: <strong><em>and He Makes the uncleanness to be upon those who are not understanding [10:100]</em></strong>.</p>
+<p>هود وَ لكِنِّي أَراكُمْ قَوْماً تَجْهَلُونَ‏ يوسف‏ إِنَّا أَنْزَلْناهُ قُرْآناً عَرَبِيًّا لَعَلَّكُمْ تَعْقِلُونَ</p>
+<p>(Surah) Hud<sup>as</sup>: &#8211; <strong><em>They will meet their Lord, but I see you as an ignorant people [11:29]</em></strong>.</p>
+<p>يوسف‏ إِنَّا أَنْزَلْناهُ قُرْآناً عَرَبِيًّا لَعَلَّكُمْ تَعْقِلُونَ</p>
+<p>(Surah) Yusuf<sup>as</sup>: &#8211; <strong><em>Surely, We have Revealed it as an Arabic Quran, so you may use your intellect [12:2]</em></strong>.</p>
+<p>الرعد إِنَّما يَتَذَكَّرُ أُولُوا الْأَلْبابِ</p>
+<p>(Surah) Al Ra’ad: &#8211; <strong><em>But rather, the ones with the understanding will be mindful [13:19]</em></strong>.</p>
+<p>إبراهيم‏ وَ لِيَذَّكَّرَ أُولُوا الْأَلْبابِ</p>
+<p>(Surah) Ibrahim<sup>as</sup>: &#8211; <strong><em>and for the ones of understanding to be mindful [14:52]</em></strong></p>
+<p>طه‏ إِنَّ فِي ذلِكَ لَآياتٍ لِأُولِي النُّهى</p>
+<p>(Surah) Ta Ha: &#8211; <strong><em>Surely, in that are Signs for the possessors of intellect [20:54]</em></strong></p>
+<p>النور كَذلِكَ يُبَيِّنُ اللَّهُ لَكُمُ الْآياتِ لَعَلَّكُمْ تَعْقِلُونَ</p>
+<p>(Surah) Al-Noor: &#8211; <strong><em>Like that, Allah Clarifies the Verses, perhaps you will use your intellects [24:61]</em></strong></p>
+<p>الزمر إِنَّ فِي ذلِكَ لَذِكْرى‏ لِأُولِي الْأَلْبابِ‏</p>
+<p>(Surah) Al-Zumar: &#8211; <strong><em>Surely, in that is a reminder for the ones of understanding [39:21] </em></strong></p>
+<p>المؤمن‏ هُدىً وَ ذِكْرى‏ لِأُولِي الْأَلْبابِ‏ و قال تعالى‏ وَ لَعَلَّكُمْ تَعْقِلُونَ</p>
+<p><strong><em>Being a Guidance and a Zikr to the ones of understanding [40:54]</em></strong>. And the Exalted Said: <strong><em>and perhaps you would use your intellects [40:67]</em></strong></p>
+<p>الجاثية آياتٌ لِقَوْمٍ يَعْقِلُونَ‏</p>
+<p>(Surah) Al-Jaasiya: &#8211; <strong><em>there are Signs for a people who are certain [45:4]</em></strong>.</p>
+<p>الحجرات‏ أَكْثَرُهُمْ لا يَعْقِلُونَ‏</p>
+<p>(Surah) Al-Hujuraat: &#8211; <strong><em>most of them are not using their intellects [49:4]</em></strong>.</p>
+<p>الحديد قَدْ بَيَّنَّا لَكُمُ الْآياتِ لَعَلَّكُمْ تَعْقِلُونَ ‏</p>
+<p>(Surah) Al-Hadeed: &#8211; <strong><em>perhaps you would be using your intellects [57:17]</em></strong>.</p>
+<p>الحشر ذلِكَ بِأَنَّهُمْ قَوْمٌ لا يَعْقِلُونَ‏.</p>
+<p>(Surah) Al-Hashar: &#8211; <strong><em>That is because they are a people not using their intellects [59:14]</em></strong>.</p>
+<p>1- مع، معاني الأخبار لي، الأمالي للصدوق الْحَافِظُ عَنْ أَحْمَدَ بْنِ عَبْدِ اللَّهِ الثَّقَفِيِّ عَنْ عِيسَى بْنِ مُحَمَّدٍ الْكَاتِبِ عَنِ الْمَدَائِنِيِّ عَنْ غِيَاثِ بْنِ إِبْرَاهِيمَ عَنِ الصَّادِقِ جَعْفَرِ بْنِ مُحَمَّدٍ عَنْ أَبِيهِ عَنْ جَدِّهِ ع قَالَ قَالَ عَلِيُّ بْنُ أَبِي طَالِبٍ ع‏ عُقُولُ النِّسَاءِ فِي جَمَالِهِنَّ وَ جَمَالُ الرِّجَالِ فِي عُقُولِهِمْ‏.</p>
+<p>In accordance to Al Hafiz, from Ahmad Bin Abdullah Al Saqafy, from Isa Bin Muhammad, the scribe, from Al Madainy, from Gayas Bin Ibrahim,</p>
+<p>From Al-Sadiq Ja’far<sup>asws</sup> Bin Muhammad<sup>asws</sup>, from his<sup>asws</sup> father<sup>asws</sup>, from his<sup>asws</sup> grandfather<sup>asws</sup> who said: ‘Ali<sup>asws</sup> Bin Abu Talib<sup>asws</sup> said: ‘The intellect of the women is in their beauty, and the beauty of the men is in their intellect’.<a href="#_ftn1" name="_ftnref1">[1]</a></p>
+<p>2- لي، الأمالي للصدوق الْعَطَّارُ عَنْ أَبِيهِ عَنْ سَهْلٍ عَنْ مُحَمَّدِ بْنِ عِيسَى عَنِ الْبَزَنْطِيِّ عَنْ جَمِيلٍ عَنِ الصَّادِقِ جَعْفَرِ بْنِ مُحَمَّدٍ ع قَالَ كَانَ أَمِيرُ الْمُؤْمِنِينَ ع يَقُولُ‏ أَصْلُ الْإِنْسَانِ لُبُّهُ وَ عَقْلُهُ دِينُهُ وَ مُرُوَّتُهُ حَيْثُ يَجْعَلُ نَفْسَهُ وَ الْأَيَّامُ دُوَلٌ وَ النَّاسُ إِلَى آدَمَ شَرَعٌ سَوَاءٌ.</p>
+<p>According to Al Attar, from his father, from Sahl, from Muhammad Bin Isa, from Al Bazanty, from Jameel,</p>
+<p>From Al-Sadiq Ja’far<sup>asws</sup> Bin Muhammad<sup>asws</sup> having said: ‘Amir Al-Momineen<sup>asws</sup> said: ‘The essence of the human being is his personality, and his intellect is his Religion, and his character is where he places himself, and the days rotate, and the people up to Adam<sup>as</sup> started equally’.<a href="#_ftn2" name="_ftnref2">[2]</a></p>
+<p>3- لي، الأمالي للصدوق ابْنُ إِدْرِيسَ عَنْ أَبِيهِ عَنِ ابْنِ هَاشِمٍ عَنِ ابْنِ مَرَّارٍ عَنْ يُونُسَ عَنِ ابْنِ سِنَانٍ‏ عَنِ الصَّادِقِ جَعْفَرِ بْنِ مُحَمَّدٍ ع قَالَ: خَمْسٌ مَنْ لَمْ يَكُنَّ فِيهِ لَمْ يَكُنْ فِيهِ كَثِيرُ مُسْتَمْتَعٍ قِيلَ وَ مَا هُنَّ يَا ابْنَ رَسُولِ اللَّهِ</p>
+<p>According to Ibn Idrees, from his father, from Ibn Hashim, from Ibn Marar, from Yunus, from Ibn Sinan,</p>
+<p>From Al-Sadiq Ja’far<sup>asws</sup> Bin Muhammad<sup>asws</sup> having said: ‘Five (things), if these do not happen to be within someone, there would not be a lot of qualities in him’. It was said, ‘And what are these, O son<sup>asws</sup> of Rasool-Allah<sup>saww</sup>?’</p>
+<p>قَالَ الدِّينُ وَ الْعَقْلُ وَ الْحَيَاءُ وَ حُسْنُ الْخُلُقِ وَ حُسْنُ الْأَدَبِ وَ خَمْسٌ مَنْ لَمْ يَكُنَّ فِيهِ لَمْ يَتَهَنَّأِ الْعَيْشُ الصِّحَّةُ وَ الْأَمْنُ وَ الْغِنَى وَ الْقَنَاعَةُ وَ الْأَنِيسُ الْمُوَافِقُ.</p>
+<p>He<sup>asws</sup> said: ‘The Religion, and the intellect, and the bashfulness, and the good mannerisms, and good ethics. And five (things), if these do not happen to be within someone, the life would not be welcoming for him – the health, and the safety, and the riches, and the contentment, and the compatible gentle companion’.<a href="#_ftn3" name="_ftnref3">[3]</a></p>
+<p>4- ل، الخصال أَبِي عَنْ سَعْدٍ عَنِ ابْنِ يَزِيدَ عَنْ إِسْمَاعِيلَ بْنِ قُتَيْبَةَ الْبَصْرِيِّ عَنْ أَبِي خَالِدٍ الْعَجَمِيِّ عَنْ أَبِي عَبْدِ اللَّهِ ع قَالَ: خَمْسٌ مَنْ لَمْ يَكُنَّ فِيهِ لَمْ يَكُنْ فِيهِ كَثِيرُ مُسْتَمْتَعٍ الدِّينُ وَ الْعَقْلُ وَ الْأَدَبُ وَ الْحُرِّيَّةُ وَ حُسْنُ الْخُلُقِ.</p>
+<p>According to my father, from Sa’ad, from Ibn Yazeed, from Ismail Bin Quteyba Al Basry, from Abu Khalid, Al Ajamy,</p>
+<p>‘From Abu Abdullah<sup>asws</sup> having said: ‘Five (things), if these do not happen to be within someone, there would not be a lot of qualities in him – the Religion, and the intellect, and the ethics, and the freedom, and the good mannerisms’.<a href="#_ftn4" name="_ftnref4">[4]</a></p>
+<p>5- لي، الأمالي للصدوق‏ لَا جَمَالَ أَزْيَنُ مِنَ الْعَقْلِ.</p>
+<p>According to me, ‘There is no beauty more adorning than the intellect. It is reported in a lengthy sermon of Amir Al-Momineen<sup>asws</sup>. I shall come with the complete of it in the chapter of his<sup>asws</sup> sermons’.<a href="#_ftn5" name="_ftnref5">[5]</a></p>
+<p>6- لي، الأمالي للصدوق ابْنُ مُوسَى عَنْ مُحَمَّدِ بْنِ يَعْقُوبَ عَنْ عَلِيِّ بْنِ مُحَمَّدِ بْنِ عَبْدِ اللَّهِ عَنْ إِبْرَاهِيمَ بْنِ إِسْحَاقَ الْأَحْمَرِ عَنْ مُحَمَّدِ بْنِ سُلَيْمَانَ عَنْ أَبِيهِ قَالَ: قُلْتُ لِأَبِي عَبْدِ اللَّهِ الصَّادِقِ ع فُلَانٌ مِنْ عِبَادَتِهِ وَ دِينِهِ وَ فَضْلِهِ كَذَا وَ كَذَا</p>
+<p>According to Ibn Musa, from Muhammad Bin Yaqoub, from Ali Bin Muhammad Bin Abdullah, from Ibrahim Bin Is’haq Al Ahmar, from Muhammad Bin Suleyman, from his father who said,</p>
+<p>‘I said to Abu Abdullah Al-Sadiq<sup>asws</sup>, ‘So and so is such and such with his worship, and his Religion, and his meritsare such and such’.</p>
+<p>قَالَ فَقَالَ كَيْفَ عَقْلُهُ فَقُلْتُ لَا أَدْرِي</p>
+<p>He (the narrator) said, ‘So he<sup>asws</sup> said: ‘How is his intellect?’ I said, ‘I don’t know’.</p>
+<p>فَقَالَ إِنَّ الثَّوَابَ عَلَى قَدْرِ الْعَقْلِ إِنَّ رَجُلًا مِنْ بَنِي إِسْرَائِيلَ كَانَ يَعْبُدُ اللَّهَ عَزَّ وَ جَلَّ فِي جَزِيرَةٍ مِنْ جَزَائِرِ الْبَحْرِ خَضْرَاءَ نَضِرَةٍ كَثِيرَةِ الشَّجَرِ طَاهِرَةِ الْمَاءِ وَ إِنَّ مَلَكاً مِنَ الْمَلَائِكَةِ مَرَّ بِهِ فَقَالَ يَا رَبِّ أَرِنِي ثَوَابَ عَبْدِكَ هَذَا</p>
+<p>So he<sup>asws</sup> said: ‘The Rewards are in accordance to the intellect. There used to be a man from the Children of Israel who used to worship Allah<sup>azwj</sup> Mighty and Majestic in an island from the island of the sea. (It was) green to behold, a lot of trees, clean water, and an Angel from the Angels passed by him, and he said, ‘O Lord<sup>azwj</sup>! Show me the Rewards of this servant of yours’.</p>
+<p>فَأَرَاهُ اللَّهُ عَزَّ وَ جَلَّ ذَلِكَ فَاسْتَقَلَّهُ الْمَلَكُ فَأَوْحَى اللَّهُ عَزَّ وَ جَلَّ إِلَيْهِ أَنِ اصْحَبْهُ فَأَتَاهُ الْمَلَكُ فِي صُورَةِ إِنْسِيٍّ فَقَالَ لَهُ مَنْ أَنْتَ قَالَ أَنَا رَجُلٌ عَابِدٌ بَلَغَنَا مَكَانُكَ وَ عِبَادَتُكَ بِهَذَا الْمَكَانِ فَجِئْتُ لِأَعْبُدَ مَعَكَ فَكَانَ مَعَهُ يَوْمَهُ ذَلِكَ</p>
+<p>Allah<sup>azwj</sup> Mighty and Majestic Showed that to him, but the Angel considered it little. Then Allah<sup>azwj</sup> Mighty and Majestic Revealed unto him that he should accompany him. So, the Angel came to him in the image of a human being, and he (the worshipper) said to him, ‘Who are you?’ He (the Angel) said, ‘I am a worshipping man. Your status has reached me, and your worshipping in this place, so I came to worship with you’. And he was with him for that day of his.</p>
+<p>فَلَمَّا أَصْبَحَ قَالَ لَهُ الْمَلَكُ إِنَّ مَكَانَكَ لَنَزِهَةٌ قَالَ لَيْتَ لِرَبِّنَا بَهِيمَةً فَلَوْ كَانَ لِرَبِّنَا حِمَارٌ لَرَعَيْنَاهُ فِي هَذَا الْمَوْضِعِ فَإِنَّ هَذَا الْحَشِيشَ يَضِيعُ فَقَالَ لَهُ الْمَلَكُ وَ مَا لِرَبِّكَ حِمَارٌ فَقَالَ لَوْ كَانَ لَهُ حِمَارٌ مَا كَانَ يَضِيعُ مِثْلُ هَذَا الْحَشِيشِ</p>
+<p>So, when it was morning, the Angel said to him, ‘Your place is natural’. He said, ‘Alas! If only there was an animal for our Lord<sup>azwj</sup>, for if there was a donkey for our Lord<sup>azwj</sup>, we would pasture it in this place, as this plush grass is going to waste’. So the Angel said to him, ‘And there is no donkey for your Lord<sup>azwj</sup>?’ He said, ‘If there was a donkey for him, the likes of these plush grass would not go to waste!’.</p>
+<p>فَأَوْحَى اللَّهُ عَزَّ وَ جَلَّ إِلَى الْمَلَكِ إِنَّمَا أُثِيبُهُ عَلَى قَدْرِ عَقْلِهِ.</p>
+<p>Then Allah<sup>azwj</sup> Mighty and Majestic Revealed unto the Angel: “But rather, I<sup>azwj</sup> Rewarded him in accordance to his intellect”’.<a href="#_ftn6" name="_ftnref6">[6]</a></p>
+<p>7- وَ قَالَ الصَّادِقُ ع‏ مَا كَلَّمَ رَسُولُ اللَّهِ ص الْعِبَادَ بِكُنْهِ عَقْلِهِ قَطُّ</p>
+<p>And Al-Sadiq<sup>asws</sup> said: ‘Rasool-Allah<sup>saww</sup> did not speak to the servants (people) with the peak of his<sup>saww</sup> intellect, at all’.</p>
+<p>قَالَ وَ قَالَ رَسُولُ اللَّهِ ص إِنَّا مَعَاشِرَ الْأَنْبِيَاءِ أُمِرْنَا أَنْ نُكَلِّمَ النَّاسَ عَلَى قَدْرِ عُقُولِهِمْ.</p>
+<p>He<sup>asws</sup> said: ‘And Rasool-Allah<sup>saww</sup> said: ‘We, the group of Prophets<sup>as</sup> have been Ordered that we<sup>as</sup> speak to the people in accordance to their intellects’’.<a href="#_ftn7" name="_ftnref7">[7]</a></p>
+<p>8- ل، الخصال لي، الأمالي للصدوق ابْنُ الْبَرْقِيِّ عَنْ أَبِيهِ عَنْ جَدِّهِ عَنْ عَمْرِو بْنِ عُثْمَانَ عَنْ أَبِي جَمِيلَةَ عَنِ ابْنِ طَرِيفٍ عَنِ ابْنِ نُبَاتَةَ عَنْ عَلِيِّ بْنِ أَبِي طَالِبٍ ع قَالَ: هَبَطَ جَبْرَئِيلُ عَلَى آدَمَ ع فَقَالَ يَا آدَمُ إِنِّي أُمِرْتُ أَنْ أُخَيِّرَكَ وَاحِدَةً مِنْ ثَلَاثٍ فَاخْتَرْ وَاحِدَةً وَ دَعِ اثْنَتَيْنِ</p>
+<p>According to Ibn Al Barqy, from his father, from his grandfather, from Amro Bin Usman, from Abu Jameela, from Ibn Tareyf, from Ibn Nabata,</p>
+<p>‘From Ali<sup>asws</sup> Bin Abu Talib<sup>asws</sup> having said: ‘Jibraeel<sup>as</sup> descended unto Adam<sup>as</sup> and he<sup>as</sup> said: ‘O Adam<sup>as</sup>! I<sup>as</sup> have been Ordered that I<sup>as</sup> should give you one choice from three, and you<sup>as</sup> should choose one, and leave two’.</p>
+<p>فَقَالَ لَهُ آدَمُ وَ مَا الثَّلَاثُ يَا جَبْرَئِيلُ فَقَالَ الْعَقْلُ وَ الْحَيَاءُ وَ الدِّينُ‏ قَالَ آدَمُ فَإِنِّي قَدِ اخْتَرْتُ الْعَقْلَ</p>
+<p>So Adam<sup>as</sup> said to him<sup>as</sup>: ‘And what are the three, O Jibraeel<sup>as</sup>?’ He<sup>as</sup> said: ‘The intellect, and the bashfulness, and the Religion’. Adam<sup>as</sup> said: ‘I<sup>as</sup> have hereby chosen the intellect’.</p>
+<p>فَقَالَ جَبْرَئِيلُ لِلْحَيَاءِ وَ الدِّينِ انْصَرِفَا وَ دَعَاهُ فَقَالا لَهُ يَا جَبْرَئِيلُ إِنَّا أُمِرْنَا أَنْ نَكُونَ مَعَ الْعَقْلِ حَيْثُمَا كَانَ قَالَ فَشَأْنَكُمَا وَ عَرَجَ.</p>
+<p>So Jibraeel<sup>as</sup> said to the bashfulness and the Religion: ‘Depart and leave him<sup>as</sup>’. But they both said to him<sup>as</sup>, ‘O Jibraeel<sup>as</sup>! We are Ordered to always happen to be with the intellect, wherever it may be’. Then that is your business’, and he<sup>as</sup> ascended’.<a href="#_ftn8" name="_ftnref8">[8]</a></p>
+</div></body></html>

--- a/tests/test_parse/test_bihar_parser.py
+++ b/tests/test_parse/test_bihar_parser.py
@@ -1,0 +1,94 @@
+"""End-to-end tests for the Bihar al-Anwar (hubeali) parser.
+
+The fixture ``fixtures/bihar_volume-1-part-1_sample.html`` is a trimmed but
+otherwise verbatim capture of a real hubeali.com Bihar al-Anwar page (Volume 1,
+Part 1 — the start of Kitab al-Aql, chapter 1, hadiths 1-8), so the parser is
+exercised against genuine source markup, not a synthetic toy.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+from src.models.enums import Sect, SourceCorpus
+from src.parse.bihar import run
+from src.parse.identity import is_double_prefixed, validate_source_id
+from src.parse.schemas import COLLECTION_SCHEMA, HADITH_SCHEMA
+
+FIXTURE = Path(__file__).parent / "fixtures" / "bihar_volume-1-part-1_sample.html"
+
+
+def _stage(tmp_path: Path) -> tuple[Path, Path]:
+    """Copy the real hubeali fixture into a raw/bihar dir and run the parser."""
+    raw_dir = tmp_path / "raw"
+    (raw_dir / "bihar").mkdir(parents=True)
+    shutil.copy(FIXTURE, raw_dir / "bihar" / "volume-1-part-1.html")
+    return run(raw_dir, tmp_path / "staging")
+
+
+class TestBiharParser:
+    def test_produces_both_parquet_files(self, tmp_path: Path) -> None:
+        hadiths_path, collections_path = _stage(tmp_path)
+        assert hadiths_path.exists()
+        assert collections_path.exists()
+
+    def test_hadith_schema_conforms_and_nonempty(self, tmp_path: Path) -> None:
+        hadiths_path, _ = _stage(tmp_path)
+        table = pq.read_table(hadiths_path)
+        assert table.schema == HADITH_SCHEMA
+        # The real Volume-1 Part-1 chapter-1 sample holds 8 numbered hadiths.
+        assert table.num_rows == 8
+
+    def test_collection_schema_conforms(self, tmp_path: Path) -> None:
+        _, collections_path = _stage(tmp_path)
+        table = pq.read_table(collections_path)
+        assert table.schema == COLLECTION_SCHEMA
+        assert table.num_rows == 1
+        row = table.to_pylist()[0]
+        assert row["name_en"] == "Bihar al-Anwar"
+        assert row["source_corpus"] == SourceCorpus.BIHAR.value
+        assert row["sect"] == Sect.SHIA.value
+        assert row["total_hadiths"] == 8
+
+    def test_provenance_tagging(self, tmp_path: Path) -> None:
+        hadiths_path, _ = _stage(tmp_path)
+        rows = pq.read_table(hadiths_path).to_pylist()
+        assert all(r["sect"] == Sect.SHIA.value for r in rows)
+        assert all(r["source_corpus"] == SourceCorpus.BIHAR.value for r in rows)
+        assert all(r["collection_name"] == "Bihar al-Anwar" for r in rows)
+
+    def test_real_bilingual_text_extracted(self, tmp_path: Path) -> None:
+        hadiths_path, _ = _stage(tmp_path)
+        rows = pq.read_table(hadiths_path).to_pylist()
+        # Every hadith carries both Arabic and English from the alternating <p> run.
+        assert all(r["full_text_ar"] for r in rows)
+        assert all(r["full_text_en"] for r in rows)
+        # The "<N>- " ordinal marker is stripped from the Arabic body.
+        assert not rows[0]["full_text_ar"].lstrip().startswith("1-")
+
+    def test_in_chapter_ordinals_are_sequential(self, tmp_path: Path) -> None:
+        hadiths_path, _ = _stage(tmp_path)
+        rows = pq.read_table(hadiths_path).to_pylist()
+        assert [r["hadith_number"] for r in rows] == list(range(1, 9))
+        assert all(r["chapter_number"] == 1 for r in rows)
+        assert all(r["book_number"] == 1 for r in rows)  # volume 1
+
+    def test_source_ids_valid_and_not_double_prefixed(self, tmp_path: Path) -> None:
+        hadiths_path, _ = _stage(tmp_path)
+        rows = pq.read_table(hadiths_path).to_pylist()
+        ids = [r["source_id"] for r in rows]
+        # Collision-safe grammar: "bihar:bihar-al-anwar:<vol>:<chapter>:<ordinal>".
+        for sid in ids:
+            assert validate_source_id(sid) == [], f"{sid}: {validate_source_id(sid)}"
+            assert not is_double_prefixed(sid), sid
+            assert sid.startswith("bihar:bihar-al-anwar:1:1:")
+        assert len(set(ids)) == len(ids)  # unique
+
+    def test_missing_raw_dir_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "raw" / "bihar").mkdir(parents=True)
+        with pytest.raises(FileNotFoundError):
+            run(tmp_path / "raw", tmp_path / "staging")


### PR DESCRIPTION
Closes #95

## New-corpus vs extension decision: NEW `SourceCorpus.BIHAR`
Bihar al-Anwar is a distinct collection from the Four Books, `corpus` is the
identity/dedup namespace, and its real source isn't Thaqalayn — so tagging it
`thaqalayn` would be a provenance lie. New corpus it is.

## Source pivot (da#95) — owner-approved
The issue assumed Bihar is reachable "via Thaqalayn." Verification proved that
false: the ThaqalaynAPI GitHub repo carries 33 books and live `thaqalayn.net`
27 — the Four Books + ~20 secondary texts, **no Bihar** — and no openly-licensed
structured Bihar JSON exists anywhere. The owner approved pivoting to
**hubeali.com**'s bilingual (Arabic + English) "Read Online" edition, the one
openly-readable per-hadith copy.

## What this adds
- **`SourceCorpus.BIHAR = "bihar"`** (`src/models/enums.py`).
- **One `SourceAdapter` row** (`src/adapters.py`): `slug=bihar`, `corpus=BIHAR`,
  `sect=SHIA`, `reachable=True`. The #81 coverage invariant + `EXPECTED_SLUGS`
  updated together.
- **`src/acquire/bihar.py`** — polite bounded scraper (robots.txt honoured,
  throttled, raw-HTML cached, idempotent) over
  `/books-library/bihar-al-anwaar/volume-<V>/part-<P>/...`. `DEFAULT_VOLUMES=(1,)`
  for a bounded PR-time crawl; widen via `volumes=` for a full data-load run.
- **`src/parse/bihar.py`** — segments the alternating AR/EN `<p>` run into
  chapters (`باب N`) and numbered hadiths (`<N>- ...`), emitting schema-valid
  parquet tagged `sect=shia` + `source_corpus=bihar`.
  - `source_id` grammar: `bihar:bihar-al-anwar:<volume>:<chapter>:<ordinal>`.
    The collection slug is **`bihar-al-anwar`, deliberately not `bihar`**, so the
    id is not collapsed by `identity.is_double_prefixed` (which fires on a
    repeated leading corpus segment).

## Licensing
Same owner-approved posture as Itqan (da#92a): no machine-readable upstream
license, non-profit use, hadith facts re-expressed in our own schema, cleanly
removable via the `source_corpus='bihar'` provenance tag. Recorded in the
adapter's `license_note`.

## Test Plan
- `tests/test_parse/test_bihar_parser.py` — parser exercised on a **real**
  (trimmed, verbatim) hubeali fixture: 8 hadiths, schema conformance, AR+EN
  extraction, `<N>-` marker stripping, sequential ordinals,
  `validate_source_id == []`, not double-prefixed, sect/corpus provenance.
- `tests/test_acquire/test_bihar.py` — mocked unit legs (robots-gating,
  content-link discovery, raw caching, idempotent re-run, no-pages→None) +
  **skip-guarded live leg** (`BIHAR_LIVE_TEST=1`) that crawls + parses the real
  site.
- `tests/test_adapters.py` — #81 coverage invariant passes with `bihar`.
- Full `tests/test_acquire` + `tests/test_parse`: **272 passed, 2 skipped**;
  mypy strict clean; ruff format + lint clean.
- **Real-data proof:** a live volume-1 crawl produces **394 bilingual hadiths
  across 7 chapters**, every row with non-null Arabic + English and valid,
  unique source_ids.
- **Runtime/data-load step (not PR-time):** the full ~100k-hadith multi-volume
  scrape + Neo4j load is a bounded-by-design follow-up (`volumes=range(...)`),
  documented in the acquire module; the live neo4j:5 E2E load is a runtime
  acceptance item.

## Serial-merge note (#95 / #96 / #97)
Rebased onto wave-4 after **#96 (halimbahae) merged**; the `EXPECTED_SLUGS` /
enum / registry conflicts were resolved keeping all entries (registry tail order
is now `... itqan, halimbahae, bihar`). #97 will hit the same three files —
trivial keep-all resolution.

Reviewers: @Jean-Claude Habimana (architect, primary) + @Oyunbileg Batbayar (QA, secondary).
