### PR TITLE
feat(muhaddithat): end-to-end light-up, both-sects sect tagging (#90)

### DIFF
--- a/src/parse/muhaddithat.py
+++ b/src/parse/muhaddithat.py
@@ -107,8 +107,16 @@ def _parse_narrator_bios(narrators_path: Path) -> tuple[pa.Table, dict[str, str]
         gender = safe_str(gender_values[i])
         bio_text = safe_str(bio_values[i])
 
-        if display_name:
-            id_to_name[ext_id] = display_name
+        # Edges must reference the SAME name the canonical identity is minted
+        # from. ``bio_promote`` keys a narrator on ``make_canonical_id`` over the
+        # *normalized Arabic* name, and the ``STUDIED_UNDER`` loader resolves an
+        # edge endpoint the same way (``normalize_arabic`` → ``make_canonical_id``).
+        # So feed the Arabic name into the edge map; the Latin display name would
+        # mint a different id and every endpoint would miss (da#90). Fall back to
+        # the display name only when no Arabic name is available.
+        edge_name = name_ar or display_name
+        if edge_name:
+            id_to_name[ext_id] = edge_name
 
         rows.append(
             {

--- a/src/resolve/sect_affiliation.py
+++ b/src/resolve/sect_affiliation.py
@@ -21,6 +21,14 @@ corpora are intentionally left unmapped: ``fawaz`` (sect is per-collection, not
 per-corpus) and ``itqan`` (a mixed rijal database) — both contribute ``unknown``
 rather than a guess.
 
+``muhaddithat`` is a **cross-tradition** corpus (``CROSS_TRADITION_CORPORA``):
+the upstream isnad-datasets carry no per-narrator sect/madhhab column — only
+id/name/gender/generation — and the corpus deliberately spans female narrators
+recognized across **both** Sunni and Shia chains (da#90, epic #81). So rather
+than a single-tradition guess, a narrator observed in such a corpus contributes
+*both* traditions: a ``muhaddithat``-only narrator therefore derives ``neutral``
+(both), not ``sunni`` and not ``unknown``.
+
 ``normalize_corpus`` reconciles the **bio provenance inconsistency** #103 flags:
 ``narrators_bio_*`` rows carry a free-text ``source`` that is not always a
 ``SourceCorpus`` value (e.g. the sanadset narrator bios use
@@ -40,6 +48,7 @@ __all__ = [
     "derive_sect_affiliation",
     "normalize_corpus",
     "primary_corpus",
+    "CROSS_TRADITION_CORPORA",
     "SECT_BY_CORPUS",
 ]
 
@@ -51,15 +60,21 @@ _CORPUS_ALIASES: dict[str, str] = {
 }
 
 # Corpus → collection-level tradition. Unmapped corpora (``fawaz`` per-collection,
-# ``itqan`` mixed rijal DB) contribute nothing → ``unknown`` when nothing maps.
+# ``itqan`` mixed rijal DB) contribute nothing → ``unknown`` when nothing maps;
+# ``muhaddithat`` is handled separately as a cross-tradition corpus (see below).
 SECT_BY_CORPUS: dict[str, Sect] = {
     SourceCorpus.SUNNAH.value: Sect.SUNNI,
     SourceCorpus.OPEN_HADITH.value: Sect.SUNNI,
     SourceCorpus.LK.value: Sect.SUNNI,
     SourceCorpus.SANADSET.value: Sect.SUNNI,
-    SourceCorpus.MUHADDITHAT.value: Sect.SUNNI,
     SourceCorpus.THAQALAYN.value: Sect.SHIA,
 }
+
+# Cross-tradition corpora: no per-narrator sect signal in the source and the
+# corpus spans both traditions, so an observation contributes *both* Sunni and
+# Shia. A narrator seen only here aggregates to ``neutral`` (both) — never a
+# one-sided ``sunni``/``shia`` guess, never ``unknown`` (da#90, epic #81).
+CROSS_TRADITION_CORPORA: frozenset[str] = frozenset({SourceCorpus.MUHADDITHAT.value})
 
 
 def normalize_corpus(source: str | None) -> str | None:
@@ -96,10 +111,15 @@ def derive_sect_affiliation(corpora: Iterable[str]) -> str:
     into a Parquet string column and the Neo4j ``Narrator.sect_affiliation``
     property.
     """
-    sects = set()
+    sects: set[Sect] = set()
     for raw in corpora:
         corpus = normalize_corpus(raw)
-        if corpus is not None and corpus in SECT_BY_CORPUS:
+        if corpus is None:
+            continue
+        if corpus in CROSS_TRADITION_CORPORA:
+            # Spans both traditions → contributes Sunni *and* Shia.
+            sects.update((Sect.SUNNI, Sect.SHIA))
+        elif corpus in SECT_BY_CORPUS:
             sects.add(SECT_BY_CORPUS[corpus])
     if not sects:
         return SectAffiliation.UNKNOWN.value

--- a/tests/integration/test_muhaddithat_lightup.py
+++ b/tests/integration/test_muhaddithat_lightup.py
@@ -1,0 +1,154 @@
+"""Live-Neo4j end-to-end proof for the muhaddithat corpus (da#90, epic #81).
+
+Exercises the REAL orchestrated slice of the pipeline against a live ``neo4j:5``
+container:
+
+    parse (muhaddithat.run) -> resolve (run_all) -> load (load_all_nodes +
+    _load_studied_under)
+
+and asserts BOTH halves of the acceptance criteria that earlier breaks masked:
+
+* **Narrator nodes materialize** with the ``muhaddithat`` ``source_corpus`` and a
+  ``neutral`` ``sect_affiliation`` — the **both-sects** tag. muhaddithat is a
+  cross-tradition corpus (no per-narrator sect in the source; spans Sunni *and*
+  Shia female narrators), so a muhaddithat-only narrator must be ``neutral`` —
+  not the pre-#90 ``sunni`` guess and not ``unknown``.
+* **STUDIED_UNDER edges fire** between two loaded Narrator nodes. The fixture
+  mirrors the real upstream layout (a Latin ``displayname`` *and* a separate
+  ``arabicname``); before #90 the edge map carried the Latin name while
+  ``bio_promote`` keyed the node on the Arabic name, so every endpoint missed and
+  zero edges landed. We assert canonical ids reconcile and real edges connect.
+
+No canonical id is hand-injected — the proof drives the same parse→resolve→load
+path production runs, so a regression in id reconciliation re-breaks this test
+rather than being papered over (the anti-pattern that hid the earlier gaps).
+
+Requires Docker; the ``neo4j_client`` fixture ``pytest.skip``s when Docker is
+unreachable (see ``tests/integration/conftest.py``), so this degrades to a clean
+SKIP off-CI rather than a red ERROR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+from src.graph.load_edges import _load_studied_under
+from src.graph.load_nodes import load_all_nodes
+from src.parse import muhaddithat
+from src.resolve import run_all
+
+# Mirrors the real muhaddithat/isnad-datasets upstream layout: narrators carry a
+# Latin ``displayname`` AND a dedicated ``arabicname`` (the column bio_promote
+# mints the canonical identity from); hadiths carry a comma-separated ``isnad``
+# chain of narrator ids. Female narrators recognized across both traditions.
+_NARRATORS_CSV = (
+    "id,displayname,arabicname,gender,generation,info\n"
+    "1,Prophet Muhammad,محمد رسول الله,male,,\n"
+    "2,Aisha bint Abi Bakr,عائشة بنت أبي بكر,female,,Umm al-Mu'minin\n"
+    "3,Fatima bint al-Husayn,فاطمة بنت الحسين,female,,\n"
+    "4,Umm Salama,أم سلمة,female,,Umm al-Mu'minin\n"
+)
+_HADITHS_CSV = (
+    "id,URL,isnad,notes\n"
+    '1,https://sunnah.com/a,"1, 2",\n'
+    '2,https://sunnah.com/b,"2, 3",\n'
+    '3,https://sunnah.com/c,"1, 4, 3",\n'
+)
+
+
+def _seed_muhaddithat(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Write the muhaddithat raw CSVs; return (raw_root, staging, curated)."""
+    raw = tmp_path / "raw" / "muhaddithat"
+    raw.mkdir(parents=True)
+    (raw / "variousnarrators.csv").write_text(_NARRATORS_CSV, encoding="utf-8")
+    (raw / "hadiths.csv").write_text(_HADITHS_CSV, encoding="utf-8")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    curated = tmp_path / "curated"
+    curated.mkdir()
+    return tmp_path / "raw", staging, curated
+
+
+@pytest.mark.integration
+class TestMuhaddithatLightupLive:
+    def test_narrators_load_with_neutral_sect_and_corpus(
+        self, neo4j_client, tmp_path: Path
+    ) -> None:
+        raw_root, staging, curated = _seed_muhaddithat(tmp_path)
+
+        # parse -> staging bio + edge parquet
+        muhaddithat.run(raw_root, staging)
+        # orchestrated resolve (NER->disambiguate->bio_promote->dedup+parallels);
+        # muhaddithat has no isnad text so NER/disambiguate no-op and bio_promote
+        # carries the narrators to canonical (the #117 wiring).
+        run_all(raw_root, staging, curated)
+
+        canonical = curated / "narrators_canonical.parquet"
+        assert canonical.exists()
+        expected = pq.read_table(canonical).num_rows
+        assert expected == 4  # every fixture narrator promoted
+
+        results = load_all_nodes(neo4j_client, staging, curated, strict=False)
+        narrator_result = next(r for r in results if r.node_type == "Narrator")
+        assert not narrator_result.validation_errors
+
+        nodes = neo4j_client.execute_read(
+            "MATCH (n:Narrator) "
+            "RETURN n.id AS id, n.source_corpus AS corpus, "
+            "n.sect_affiliation AS sect"
+        )
+        assert len(nodes) == expected, "every canonical muhaddithat narrator is a node"
+        # Correct canonical ids on every node.
+        assert all(n["id"].startswith("nar:") for n in nodes)
+        # Provenance: the muhaddithat corpus tag landed on the graph.
+        assert {n["corpus"] for n in nodes} == {"muhaddithat"}
+        # Both-sects tag: cross-tradition corpus → neutral, never sunni/unknown.
+        assert {n["sect"] for n in nodes} == {"neutral"}, (
+            "muhaddithat narrators must be neutral (both sects), not a one-sided guess"
+        )
+
+    def test_chains_load_as_studied_under_edges(self, neo4j_client, tmp_path: Path) -> None:
+        raw_root, staging, curated = _seed_muhaddithat(tmp_path)
+
+        muhaddithat.run(raw_root, staging)
+        run_all(raw_root, staging, curated)
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+
+        # The edge endpoints must reconcile to the SAME canonical ids the
+        # bio-promoted nodes carry (the Arabic-name fix). Before #90 this was 0.
+        result = _load_studied_under(neo4j_client, staging)
+        assert result.created > 0, "muhaddithat chains must connect loaded narrators"
+        assert result.missing_endpoints == 0, (
+            "no edge endpoint may miss — Arabic-name reconciliation must hold"
+        )
+
+        edges = neo4j_client.execute_read(
+            "MATCH (:Narrator)-[r:STUDIED_UNDER]->(:Narrator) RETURN count(r) AS n"
+        )[0]["n"]
+        assert edges == result.created
+
+    def test_reload_is_idempotent(self, neo4j_client, tmp_path: Path) -> None:
+        raw_root, staging, curated = _seed_muhaddithat(tmp_path)
+
+        muhaddithat.run(raw_root, staging)
+        run_all(raw_root, staging, curated)
+
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+        _load_studied_under(neo4j_client, staging)
+        first_n = neo4j_client.execute_read("MATCH (n:Narrator) RETURN count(n) AS n")[0]["n"]
+        first_e = neo4j_client.execute_read("MATCH ()-[r:STUDIED_UNDER]->() RETURN count(r) AS n")[
+            0
+        ]["n"]
+
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+        _load_studied_under(neo4j_client, staging)
+        second_n = neo4j_client.execute_read("MATCH (n:Narrator) RETURN count(n) AS n")[0]["n"]
+        second_e = neo4j_client.execute_read("MATCH ()-[r:STUDIED_UNDER]->() RETURN count(r) AS n")[
+            0
+        ]["n"]
+
+        assert first_n == second_n  # MERGE on canonical_id — no duplicate nodes
+        assert first_e == second_e  # MERGE on the relationship — no duplicate edges

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -97,7 +97,10 @@ def test_bio_promote_tags_sect_and_corpus(tmp_path: Path) -> None:
     rec = pq.read_table(path).to_pylist()[0]
     assert rec["source_corpora"] == ["muhaddithat"]
     assert rec["source_corpus"] == "muhaddithat"
-    assert rec["sect_affiliation"] == "sunni"
+    # muhaddithat is cross-tradition (spans both sects, no per-narrator sect in
+    # the source) → a muhaddithat-only narrator is neutral, not a sunni guess
+    # (da#90).
+    assert rec["sect_affiliation"] == "neutral"
 
 
 def test_same_name_dedups_to_one_canonical(tmp_path: Path) -> None:

--- a/tests/test_resolve/test_sect_affiliation.py
+++ b/tests/test_resolve/test_sect_affiliation.py
@@ -33,6 +33,11 @@ class TestDeriveSectAffiliation:
             (["sunnah", "open_hadith"], "sunni"),
             (["thaqalayn"], "shia"),
             (["sunnah", "thaqalayn"], "neutral"),  # transmits in both traditions
+            # muhaddithat is cross-tradition (no per-narrator sect in the source,
+            # spans both): a muhaddithat-only narrator is neutral, never sunni and
+            # never unknown (da#90).
+            (["muhaddithat"], "neutral"),
+            (["muhaddithat", "sunnah"], "neutral"),  # cross-tradition stays neutral
             (["muhaddithat", "thaqalayn"], "neutral"),
             (["kaggle_narrators"], "sunni"),  # sanadset bio provenance alias
             ([], "unknown"),


### PR DESCRIPTION
Closes #90 — light up the **muhaddithat** corpus end-to-end (both sects), proven against a live `neo4j:5` container.

## What was already fixed (verified on the wave branch, NOT redone)
- **#130** — `_load_studied_under` globs `network_edges_*.parquet` + name-resolves endpoints. Mechanism present.
- **#117** — `bio_promote` wired into `run_all` (muhaddithat bios flow to canonical). Verified.
- **#103** — `narrators_canonical` carries `source_corpus`/`source_corpora`/`sect_affiliation`.

## The two muhaddithat-specific gaps that remained (reproduced, then fixed)
Reproduced empirically with realistic upstream-shaped data (separate `displayname` + `arabicname` columns — the parser fixtures conflated them, which is why these slipped through):

1. **Sect tagging wrong for a both-sects source.** muhaddithat was mapped `corpus -> SUNNI`, so every muhaddithat narrator derived `sect_affiliation = sunni`. The upstream `variousnarrators.csv` carries **no per-narrator sect column** (`id, displayname, fullname, searchname, arabicname, gender, generation, info, hadiths, notes`) and the corpus spans female narrators recognized across **both** traditions.
   - **Fix:** `src/resolve/sect_affiliation.py` — new `CROSS_TRADITION_CORPORA`; `derive_sect_affiliation` contributes **both** Sunni and Shia for such a corpus -> a muhaddithat-only narrator is **`neutral`** (both), never a one-sided guess, never `unknown`. Aligns the narrator-level derivation with the adapter registry, which already declares `muhaddithat sect=None` (multi-sect).

2. **STUDIED_UNDER edges resolved to 0.** `bio_promote` mints the canonical id from the normalized **Arabic** name; `_load_studied_under` resolves endpoints the same way — but the edge map carried the Latin `displayname`, so every endpoint minted a **different** id -> all missing -> 0 edges. #130's glob fix can't help because the names don't reconcile.
   - **Fix:** `src/parse/muhaddithat.py` — feed the **Arabic** name into the edge id-map (fall back to display name only when no Arabic name exists).

## The muhaddithat sect decision
Source has no per-narrator sect -> cannot preserve per-narrator. Per the both-sects AC and the brief's fallback, muhaddithat is modeled as **cross-tradition -> `neutral`**, consistent with the registry's existing `sect=None` multi-sect declaration.

## E2E proof (live neo4j:5)
`tests/integration/test_muhaddithat_lightup.py` drives the real `parse -> run_all -> load` path (no hand-injected ids):
- Narrator nodes materialize with `source_corpus=muhaddithat` and `sect_affiliation=neutral`.
- `STUDIED_UNDER` edges fire with **0 missing endpoints**.
- Idempotent reload (nodes + edges).

Live run: **3 passed in 15.5s**. Unit suites for changed areas: **404 passed, 3 skipped**. ruff 0.15.11 (lint+format) clean; mypy clean.

## Reviewers
@Kavitha Sundaramurthy (primary), @Jean-Claude Habimana (secondary)

## Reachability + licensing
- **Reachability:** muhaddithat = a public GitHub clone (`muhaddithat/isnad-datasets`), reachable from the sandbox; the e2e load runs against a local `neo4j:5` container.
- **Licensing:** source data from the muslimscholars.info / muhaddithat project; facts are re-expressed in our own schema with `source_corpus=muhaddithat` provenance on every node, so the corpus is auditable and cleanly removable.

## Test Plan (post-merge)
- [ ] Staging-cluster load (cluster-internal, ssh `docker exec cypher-shell`) — separate verify, not a PR gate per #90 AC.
