### PR TITLE
feat(resolve): fuzzy cross-source narrator clustering — recall increment on #99 exact pass (#118)

### DIFF
--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -1,12 +1,17 @@
 """Phase 2: Entity Resolution pipeline.
 
 Dependency-aware orchestrator:
-``NER -> disambiguate -> bio_promote -> (dedup + detect_parallels)``.
+``NER -> disambiguate -> bio_promote -> fuzzy_cluster -> (dedup + detect_parallels)``.
 
 Ordering invariants (da#117):
 - ``disambiguate`` OVERWRITES ``narrators_canonical.parquet`` while
   ``bio_promote`` MERGEs into it, so ``bio_promote`` MUST run *after*
   ``disambiguate`` or promoted bio-only narrators get clobbered (da#99).
+- ``fuzzy_cluster`` (da#118) runs *after* both: it clusters cross-source name
+  variants the exact-name pass under-merged, operating on the canonical set
+  those two produce. It re-keys nothing (merges route through
+  ``make_canonical_id``) and is idempotent, so adding it never perturbs the
+  disambiguate→bio_promote invariant above.
 - ``dedup`` (semantic embeddings, degrades to empty without the model) and
   ``detect_parallels`` (deterministic lexical, offline/CI) both write the shared
   ``staging/parallel_links.parquet``. run_all runs both and *composes* their
@@ -241,12 +246,13 @@ def run_all(raw_dir: Path, staging_dir: Path, output_dir: Path) -> dict[str, lis
     """
     logger.info("resolve_pipeline_start")
 
-    from src.resolve import bio_promote, dedup, disambiguate, ner, parallels
+    from src.resolve import bio_promote, dedup, disambiguate, fuzzy_cluster, ner, parallels
 
     results: dict[str, list[Path]] = {
         "ner": [],
         "disambiguate": [],
         "bio_promote": [],
+        "cluster": [],
         "dedup": [],
         "parallels": [],
     }
@@ -314,6 +320,31 @@ def run_all(raw_dir: Path, staging_dir: Path, output_dir: Path) -> dict[str, lis
         )
     except Exception:  # noqa: BLE001
         logger.error("resolve_step_failed", step="bio_promote", traceback=traceback.format_exc())
+
+    # Step 3.5: Fuzzy cross-source clustering (da#118) — recall increment on the
+    # exact-name pass. Merges high-confidence cross-source name variants the
+    # byte-exact collapse left split, operating ON the canonical set the prior two
+    # steps produced. Routes every merge through make_canonical_id and is
+    # idempotent, so it never perturbs the disambiguate→bio_promote ordering. The
+    # mentions file is remapped so graph NARRATED edges follow the merge (#109).
+    try:
+        logger.info("resolve_step", step="cluster", status="running")
+        canonical_path = output_dir / "narrators_canonical.parquet"
+        mentions_path = output_dir / "narrator_mentions_resolved.parquet"
+        cluster_metrics = fuzzy_cluster.cluster_canonical_narrators(
+            canonical_path,
+            mentions_path=mentions_path if mentions_path.exists() else None,
+        )
+        results["cluster"] = [canonical_path] if cluster_metrics.merged_records else []
+        logger.info(
+            "resolve_step",
+            step="cluster",
+            status="complete",
+            merged=cluster_metrics.merged_records,
+            clusters=cluster_metrics.multi_member_clusters,
+        )
+    except Exception:  # noqa: BLE001
+        logger.error("resolve_step_failed", step="cluster", traceback=traceback.format_exc())
 
     # Step 4: Dedup (semantic; degrades to an empty table without the embedding
     # model). Runs independently of NER/disambiguation. Capture its output before

--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -1,0 +1,510 @@
+"""Fuzzy cross-source narrator clustering — recall increment on the exact-name pass.
+
+The exact-name cross-source collapse (da#99, in ``disambiguate``/``bio_promote``)
+keys every canonical narrator on ``make_canonical_id(name_ar_normalized)``: two
+records merge **only** when their normalized names are byte-identical. That is
+high precision, but it leaves *recall* on the table — the same real person whose
+spelling survives Arabic normalization differently across sources (kunya-only
+forms, nasab/nisba expansion or truncation, an optional ``ابن``/``بن``,
+transliteration drift, honorifics) lands as two separate ``nar:`` nodes.
+
+This module is that recall increment. It runs **on top of** — never replacing —
+the exact-name pass: it reads the already-collapsed ``narrators_canonical.parquet``
+and clusters records that are high-confidence name variants of one person, then
+merges each cluster into a single canonical record. It is the bio/canonical-level
+analogue of the rapidfuzz mention stage in ``disambiguate`` (which matches
+*mentions* to *bios*); here both sides are canonical narrators.
+
+Signals (issue da#118)
+----------------------
+* **rapidfuzz ``token_set_ratio``** over each record's match keys — its
+  ``name_ar_normalized`` **plus** every ``alias`` (the da#94 Itqan name-variant
+  feed): token-set is order- and extra-token-insensitive, so a nasab expansion
+  (``محمد بن اسماعيل`` ↔ ``محمد بن اسماعيل البخاري``) scores high while a genuinely
+  different name does not.
+* **Token blocking** — only records sharing a significant (non-connector) name
+  token are ever compared, keeping the pass near-linear instead of O(n²).
+
+Precision guards (against over-merging distinct same-named narrators)
+--------------------------------------------------------------------
+* A **conservative default threshold** (:data:`_CLUSTER_RATIO_THRESHOLD`),
+  tunable per the precision/recall tradeoff in the acceptance criteria.
+* A **death-year guard**: when both records carry ``death_year_ah`` and they
+  disagree by more than :data:`_DEATH_YEAR_TOLERANCE`, the merge is blocked even
+  on a perfect name match — two scholars a century apart are not one person.
+* A **gender guard**: two records with explicit, differing ``gender`` never merge.
+
+Identity & ordering invariants
+-------------------------------
+* The merged record's id is ``make_canonical_id(representative.name_ar_normalized)``
+  (``src.parse.identity``) — never a parallel id scheme (da#110). The
+  representative is the existing canonical record the cluster collapses onto, so
+  its id is itself a prior ``make_canonical_id`` output: clustering re-keys nothing.
+* It operates **downstream of** ``disambiguate → bio_promote`` (da#117): those
+  produce the canonical set, this clusters within it. It does not touch their
+  ordering, and is idempotent — re-running on an already-clustered table is a
+  no-op (the variant records are already gone).
+* When a mentions file is present, the absorbed-id → representative-id remap is
+  applied to ``narrator_mentions_resolved.parquet`` so the graph's NARRATED edges
+  follow the merge instead of dangling on a node that no longer exists (#109).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from rapidfuzz import fuzz
+
+from src.parse.base import safe_str, write_parquet
+from src.parse.identity import make_canonical_id
+from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
+from src.resolve.sect_affiliation import derive_sect_affiliation, normalize_corpus, primary_corpus
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = ["ClusterMetrics", "cluster_records", "cluster_assignment", "cluster_canonical_narrators"]
+
+# ---------------------------------------------------------------------------
+# Thresholds (tunable — the da#118 precision/recall tradeoff)
+# ---------------------------------------------------------------------------
+# rapidfuzz token_set_ratio at/above which two records are a merge candidate.
+# Conservative by default: token_set_ratio already discounts word order and
+# extra tokens, so a high bar still catches nasab/kunya variants while keeping
+# distinct same-prefix names apart.
+_CLUSTER_RATIO_THRESHOLD = 90.0
+
+# When both records carry a death year, a disagreement beyond this many AH years
+# blocks the merge regardless of name score (two narrators a generation+ apart
+# are not the same person). One source rounding a death year by a year is fine.
+_DEATH_YEAR_TOLERANCE = 2
+
+# Name tokens that carry no disambiguating signal (Arabic genealogical
+# connectors / honorific particles). Excluded as *blocking* keys so a block does
+# not balloon to "every name containing بن"; still scored as part of the name.
+_CONNECTOR_TOKENS = frozenset(
+    {
+        "بن",
+        "ابن",
+        "ابو",
+        "ابي",
+        "ام",
+        "ال",
+        "بنت",
+        "عن",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ClusterMetrics:
+    """Outcome of a fuzzy clustering pass over a canonical narrator table."""
+
+    input_records: int
+    output_records: int
+    merged_records: int
+    multi_member_clusters: int
+    cross_source_clusters: int
+    mentions_remapped: int = 0
+
+    def summary(self) -> str:
+        """One-line human-readable summary."""
+        return (
+            f"fuzzy-cluster: {self.input_records} → {self.output_records} canonical "
+            f"({self.merged_records} merged into {self.multi_member_clusters} clusters, "
+            f"{self.cross_source_clusters} cross-source); "
+            f"{self.mentions_remapped} mentions remapped"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Match keys & scoring
+# ---------------------------------------------------------------------------
+def _match_keys(record: dict[str, Any]) -> list[str]:
+    """Every normalized name string a record can match on: its name + aliases (da#94)."""
+    keys: list[str] = []
+    name = safe_str(record.get("name_ar_normalized"))
+    if name:
+        keys.append(name)
+    aliases = record.get("aliases")
+    if isinstance(aliases, list):
+        for a in aliases:
+            av = safe_str(a)
+            if av and av not in keys:
+                keys.append(av)
+    return keys
+
+
+def _significant_tokens(keys: list[str]) -> set[str]:
+    """Blocking tokens for a record: name tokens minus genealogical connectors."""
+    tokens: set[str] = set()
+    for key in keys:
+        for tok in key.split():
+            if len(tok) >= 2 and tok not in _CONNECTOR_TOKENS:
+                tokens.add(tok)
+    return tokens
+
+
+def _name_similarity(keys_a: list[str], keys_b: list[str]) -> float:
+    """Best token_set_ratio across the cross product of two records' match keys.
+
+    Taking the max over names + aliases means a record matches if *any* of its
+    spellings (including a da#94 variant) is a strong token-set match for any of
+    the other's — exactly the cross-source-variant recall this pass targets.
+    """
+    best = 0.0
+    for a in keys_a:
+        for b in keys_b:
+            score = fuzz.token_set_ratio(a, b)
+            if score > best:
+                best = score
+                if best >= 100.0:
+                    return best
+    return best
+
+
+def _death_years_conflict(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    """True when both carry a death year that disagree beyond the tolerance."""
+    da, db = a.get("death_year_ah"), b.get("death_year_ah")
+    if isinstance(da, int) and isinstance(db, int):
+        return abs(da - db) > _DEATH_YEAR_TOLERANCE
+    return False
+
+
+def _genders_conflict(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    """True when both carry an explicit, differing gender."""
+    ga, gb = safe_str(a.get("gender")), safe_str(b.get("gender"))
+    return bool(ga and gb and ga != gb)
+
+
+def _can_merge(a: dict[str, Any], b: dict[str, Any], *, threshold: float) -> bool:
+    """Decide whether two canonical records are the same person (precision-guarded)."""
+    if _death_years_conflict(a, b) or _genders_conflict(a, b):
+        return False
+    return _name_similarity(_match_keys(a), _match_keys(b)) >= threshold
+
+
+# ---------------------------------------------------------------------------
+# Union-find clustering
+# ---------------------------------------------------------------------------
+class _UnionFind:
+    """Minimal disjoint-set over record indices."""
+
+    def __init__(self, n: int) -> None:
+        self._parent = list(range(n))
+
+    def find(self, x: int) -> int:
+        root = x
+        while self._parent[root] != root:
+            root = self._parent[root]
+        while self._parent[x] != root:
+            self._parent[x], x = root, self._parent[x]
+        return root
+
+    def union(self, x: int, y: int) -> None:
+        rx, ry = self.find(x), self.find(y)
+        if rx != ry:
+            self._parent[ry] = rx
+
+    def groups(self) -> list[list[int]]:
+        clusters: dict[int, list[int]] = {}
+        for i in range(len(self._parent)):
+            clusters.setdefault(self.find(i), []).append(i)
+        return list(clusters.values())
+
+
+def cluster_records(
+    records: list[dict[str, Any]],
+    *,
+    threshold: float = _CLUSTER_RATIO_THRESHOLD,
+) -> list[list[int]]:
+    """Cluster canonical narrator records into same-person groups (as index lists).
+
+    Token-blocks the records, scores each candidate pair within a block with
+    rapidfuzz ``token_set_ratio`` over name + aliases, applies the death-year and
+    gender precision guards, and unions the survivors. Returns one index list per
+    cluster (singletons included), so the i-th record's cluster is recoverable.
+    Pure and deterministic — the IO wrapper and the quality test both drive it.
+    """
+    n = len(records)
+    uf = _UnionFind(n)
+
+    # Inverted index: significant token -> record indices carrying it (blocking).
+    token_index: dict[str, list[int]] = {}
+    record_keys: list[list[str]] = []
+    for i, rec in enumerate(records):
+        keys = _match_keys(rec)
+        record_keys.append(keys)
+        for tok in _significant_tokens(keys):
+            token_index.setdefault(tok, []).append(i)
+
+    # Candidate pairs = records sharing ≥1 significant token. Dedup pairs so each
+    # is scored once even when two records share several tokens.
+    seen: set[tuple[int, int]] = set()
+    for members in token_index.values():
+        for pos, i in enumerate(members):
+            for j in members[pos + 1 :]:
+                pair = (i, j) if i < j else (j, i)
+                if pair in seen:
+                    continue
+                seen.add(pair)
+                if _can_merge(records[i], records[j], threshold=threshold):
+                    uf.union(i, j)
+
+    return uf.groups()
+
+
+def cluster_assignment(
+    records: list[dict[str, Any]],
+    *,
+    threshold: float = _CLUSTER_RATIO_THRESHOLD,
+) -> dict[str, str]:
+    """Map each record's ``canonical_id`` to its cluster's representative id.
+
+    The label is the representative's id (see :func:`_choose_representative`), so
+    feeding this straight into ``quality.pairwise_quality`` against a gold map
+    measures the recall increment over the exact-name baseline (where every
+    record is its own cluster).
+    """
+    assignment: dict[str, str] = {}
+    for cluster in cluster_records(records, threshold=threshold):
+        rep = _choose_representative([records[i] for i in cluster])
+        rep_label = str(rep.get("canonical_id"))
+        for i in cluster:
+            cid = safe_str(records[i].get("canonical_id"))
+            if cid:
+                assignment[cid] = rep_label
+    return assignment
+
+
+# ---------------------------------------------------------------------------
+# Cluster merge
+# ---------------------------------------------------------------------------
+def _completeness(record: dict[str, Any]) -> int:
+    """Count of populated biographical scalar fields — a tie-break for representative."""
+    fields = (
+        "name_ar",
+        "name_en",
+        "birth_year_ah",
+        "death_year_ah",
+        "generation",
+        "gender",
+        "trustworthiness",
+        "external_id",
+    )
+    return sum(1 for f in fields if record.get(f) not in (None, ""))
+
+
+def _choose_representative(members: list[dict[str, Any]]) -> dict[str, Any]:
+    """Pick the canonical record a cluster collapses onto.
+
+    Deterministic ranking: most mentions, then most complete bio, then longest
+    normalized name, then smallest canonical_id. The winner's id (already a
+    ``make_canonical_id`` output) becomes the cluster's id, so the merge routes
+    through the identity contract and re-keys nothing.
+    """
+
+    def _rank(rec: dict[str, Any]) -> tuple[int, int, int]:
+        mc = rec.get("mention_count")
+        return (
+            mc if isinstance(mc, int) else 0,
+            _completeness(rec),
+            len(safe_str(rec.get("name_ar_normalized")) or ""),
+        )
+
+    # Rank on (mentions, completeness, name length); break a remaining tie on the
+    # smallest canonical_id so the choice is fully deterministic.
+    best_rank = max(_rank(m) for m in members)
+    top = [m for m in members if _rank(m) == best_rank]
+    return min(top, key=lambda m: safe_str(m.get("canonical_id")) or "")
+
+
+def _merge_cluster(members: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge a cluster of canonical records into one, keyed on the representative.
+
+    Unions multi-valued provenance (source_ids, source_corpora, aliases), sums
+    mention_count, and back-fills each scalar bio field from the representative
+    first then any member that has it. The non-representative members' normalized
+    names (and all members' existing aliases) become aliases of the survivor, so
+    no source spelling is lost. source_corpus + sect_affiliation are recomputed
+    from the unioned corpora (da#103).
+    """
+    rep = _choose_representative(members)
+    rep_norm = safe_str(rep.get("name_ar_normalized")) or ""
+    canonical_id = make_canonical_id(rep_norm) if rep_norm else str(rep.get("canonical_id"))
+
+    merged: dict[str, Any] = {
+        "canonical_id": canonical_id,
+        "name_ar": safe_str(rep.get("name_ar")),
+        "name_en": safe_str(rep.get("name_en")),
+        "name_ar_normalized": rep_norm or None,
+        "external_id": safe_str(rep.get("external_id")),
+    }
+
+    source_ids: list[str] = []
+    corpora: list[str] = []
+    aliases: list[str] = []
+    mention_count = 0
+    scalar_fields = (
+        "name_ar",
+        "name_en",
+        "birth_year_ah",
+        "death_year_ah",
+        "generation",
+        "gender",
+        "trustworthiness",
+        "external_id",
+    )
+
+    # Representative first so its values win the back-fill; others fill the gaps.
+    for rec in [rep, *[m for m in members if m is not rep]]:
+        mc = rec.get("mention_count")
+        mention_count += mc if isinstance(mc, int) else 0
+
+        for sid in rec.get("source_ids") or []:
+            s = safe_str(sid)
+            if s and s not in source_ids:
+                source_ids.append(s)
+
+        for corp in rec.get("source_corpora") or []:
+            nc = normalize_corpus(safe_str(corp))
+            if nc and nc not in corpora:
+                corpora.append(nc)
+
+        for field_name in scalar_fields:
+            if merged.get(field_name) in (None, "") and rec.get(field_name) not in (None, ""):
+                merged[field_name] = rec.get(field_name)
+
+        # A non-representative spelling becomes an alias; carry existing aliases.
+        rec_norm = safe_str(rec.get("name_ar_normalized"))
+        if rec_norm and rec_norm != rep_norm and rec_norm not in aliases:
+            aliases.append(rec_norm)
+        for a in rec.get("aliases") or []:
+            av = safe_str(a)
+            if av and av != rep_norm and av not in aliases:
+                aliases.append(av)
+
+    merged["aliases"] = aliases
+    merged["source_ids"] = source_ids
+    merged["mention_count"] = mention_count
+    merged["source_corpora"] = sorted(set(corpora))
+    merged["source_corpus"] = primary_corpus(corpora)
+    merged["sect_affiliation"] = derive_sect_affiliation(corpora)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Parquet IO
+# ---------------------------------------------------------------------------
+def _build_table(rows: list[dict[str, Any]]) -> pa.Table:
+    """Project merged rows onto NARRATORS_CANONICAL_SCHEMA."""
+    arrays = {f.name: [r.get(f.name) for r in rows] for f in NARRATORS_CANONICAL_SCHEMA}
+    return pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
+
+
+def _remap_mention_canonical_ids(mentions_path: Path, remap: dict[str, str]) -> int:
+    """Rewrite absorbed canonical ids on the mention rows to the cluster survivor.
+
+    A merge dissolves the absorbed records' ``nar:`` nodes; mentions backfilled
+    with one of those ids (da#99/#109) would otherwise key a NARRATED edge on a
+    node ``load_nodes`` no longer creates. Streams row-group by row-group and
+    rewrites in place (mirrors ``disambiguate._backfill_mention_canonical_ids``).
+    Idempotent and bounded-memory. Returns the count of rows remapped.
+    """
+    if not remap or not mentions_path.exists():
+        return 0
+
+    pf = pq.ParquetFile(mentions_path)
+    id_idx = NARRATOR_MENTIONS_RESOLVED_SCHEMA.get_field_index("canonical_narrator_id")
+    tmp_path = mentions_path.with_name(mentions_path.name + ".cluster.tmp")
+    writer = pq.ParquetWriter(tmp_path, NARRATOR_MENTIONS_RESOLVED_SCHEMA, compression="snappy")
+    remapped = 0
+    try:
+        for rg_idx in range(pf.metadata.num_row_groups):
+            table = pf.read_row_group(rg_idx).cast(NARRATOR_MENTIONS_RESOLVED_SCHEMA)
+            ids = table.column("canonical_narrator_id").to_pylist()
+            new_ids: list[str | None] = []
+            for cid in ids:
+                target = remap.get(cid) if cid is not None else None
+                if target is not None and target != cid:
+                    new_ids.append(target)
+                    remapped += 1
+                else:
+                    new_ids.append(cid)
+            table = table.set_column(
+                id_idx, "canonical_narrator_id", pa.array(new_ids, type=pa.string())
+            )
+            writer.write_table(table)
+    finally:
+        writer.close()
+
+    tmp_path.replace(mentions_path)
+    logger.info("cluster_mentions_remapped", path=str(mentions_path), remapped=remapped)
+    return remapped
+
+
+def cluster_canonical_narrators(
+    canonical_path: Path,
+    *,
+    mentions_path: Path | None = None,
+    threshold: float = _CLUSTER_RATIO_THRESHOLD,
+) -> ClusterMetrics:
+    """Fuzzy-cluster ``narrators_canonical.parquet`` in place; return metrics.
+
+    Reads the canonical table the exact-name pass produced, merges high-confidence
+    cross-source name variants (see module docstring), and rewrites the file. When
+    ``mentions_path`` is given, the absorbed-id → survivor-id remap is applied to
+    the mentions so the graph edges follow the merge. A no-op (file untouched)
+    when the table is missing/empty or nothing clusters.
+    """
+    if not canonical_path.exists():
+        logger.warning("cluster_canonical_missing", path=str(canonical_path))
+        return ClusterMetrics(0, 0, 0, 0, 0)
+
+    records = pq.read_table(canonical_path).to_pylist()
+    if not records:
+        return ClusterMetrics(0, 0, 0, 0, 0)
+
+    clusters = cluster_records(records, threshold=threshold)
+
+    merged_rows: list[dict[str, Any]] = []
+    remap: dict[str, str] = {}
+    multi_member = 0
+    cross_source = 0
+    for cluster in clusters:
+        members = [records[i] for i in cluster]
+        merged = _merge_cluster(members)
+        merged_rows.append(merged)
+        if len(members) > 1:
+            multi_member += 1
+            survivor_id = str(merged["canonical_id"])
+            for m in members:
+                old_id = safe_str(m.get("canonical_id"))
+                if old_id and old_id != survivor_id:
+                    remap[old_id] = survivor_id
+            if len(merged.get("source_corpora") or []) > 1:
+                cross_source += 1
+
+    write_parquet(_build_table(merged_rows), canonical_path, schema=NARRATORS_CANONICAL_SCHEMA)
+
+    remapped = (
+        _remap_mention_canonical_ids(mentions_path, remap) if mentions_path is not None else 0
+    )
+
+    metrics = ClusterMetrics(
+        input_records=len(records),
+        output_records=len(merged_rows),
+        merged_records=len(records) - len(merged_rows),
+        multi_member_clusters=multi_member,
+        cross_source_clusters=cross_source,
+        mentions_remapped=remapped,
+    )
+    logger.info("cluster_canonical_complete", summary=metrics.summary())
+    return metrics

--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -83,6 +83,16 @@ _CLUSTER_RATIO_THRESHOLD = 90.0
 # are not the same person). One source rounding a death year by a year is fine.
 _DEATH_YEAR_TOLERANCE = 2
 
+# Minimum number of *shared* significant (non-connector) name tokens required to
+# merge. token_set_ratio scores a bare given name as a perfect (100) subset of
+# every fuller name carrying it (``محمد`` ⊂ ``محمد بن اسماعيل البخاري``), and a
+# sparse bare-name record has no death-year/gender to trip the other guards — so
+# name score alone would over-merge distinct people who merely share one common
+# given name. Requiring ≥2 shared significant tokens means a pure single-token
+# subset never clusters, while a genuine variant (which shares the nasab/nisba
+# stem) still does.
+_MIN_SHARED_TOKENS = 2
+
 # Name tokens that carry no disambiguating signal (Arabic genealogical
 # connectors / honorific particles). Excluded as *blocking* keys so a block does
 # not balloon to "every name containing بن"; still scored as part of the name.
@@ -184,9 +194,23 @@ def _genders_conflict(a: dict[str, Any], b: dict[str, Any]) -> bool:
     return bool(ga and gb and ga != gb)
 
 
+def _shared_significant_token_count(a: dict[str, Any], b: dict[str, Any]) -> int:
+    """Number of significant (non-connector) name tokens the two records share."""
+    return len(_significant_tokens(_match_keys(a)) & _significant_tokens(_match_keys(b)))
+
+
 def _can_merge(a: dict[str, Any], b: dict[str, Any], *, threshold: float) -> bool:
-    """Decide whether two canonical records are the same person (precision-guarded)."""
+    """Decide whether two canonical records are the same person (precision-guarded).
+
+    A merge requires ALL of: no death-year conflict, no gender conflict, at least
+    :data:`_MIN_SHARED_TOKENS` shared significant name tokens (so a bare
+    single-token subset never clusters), and a name similarity at/above
+    ``threshold``. Pairwise and symmetric — the cluster post-validation relies on
+    that to refuse any cluster harbouring a guard-conflicting pair.
+    """
     if _death_years_conflict(a, b) or _genders_conflict(a, b):
+        return False
+    if _shared_significant_token_count(a, b) < _MIN_SHARED_TOKENS:
         return False
     return _name_similarity(_match_keys(a), _match_keys(b)) >= threshold
 
@@ -220,6 +244,38 @@ class _UnionFind:
         return list(clusters.values())
 
 
+def _safe_partition(
+    group: list[int],
+    records: list[dict[str, Any]],
+    *,
+    threshold: float,
+) -> list[list[int]]:
+    """Split a union-find group into sub-clusters with NO guard-conflicting pair.
+
+    Union-find is transitive but :func:`_can_merge` is pairwise, so a bridge
+    record can chain two endpoints that fail the guards against each other
+    (A–B ✓, B–C ✓, but A–C death-conflict): the conflicting A–C pair would
+    survive in one cluster and merge two real people. This greedily places each
+    member into the first existing sub-cluster it is ``_can_merge``-compatible
+    with *every* member of, opening a new sub-cluster otherwise. By induction
+    each sub-cluster is a clique under ``_can_merge``, so no conflicting pair can
+    co-occur. Deterministic: members are processed in ``canonical_id`` order.
+    """
+    if len(group) <= 1:
+        return [list(group)]
+
+    ordered = sorted(group, key=lambda i: safe_str(records[i].get("canonical_id")) or "")
+    subclusters: list[list[int]] = []
+    for i in ordered:
+        for sub in subclusters:
+            if all(_can_merge(records[i], records[j], threshold=threshold) for j in sub):
+                sub.append(i)
+                break
+        else:
+            subclusters.append([i])
+    return subclusters
+
+
 def cluster_records(
     records: list[dict[str, Any]],
     *,
@@ -228,21 +284,21 @@ def cluster_records(
     """Cluster canonical narrator records into same-person groups (as index lists).
 
     Token-blocks the records, scores each candidate pair within a block with
-    rapidfuzz ``token_set_ratio`` over name + aliases, applies the death-year and
-    gender precision guards, and unions the survivors. Returns one index list per
-    cluster (singletons included), so the i-th record's cluster is recoverable.
-    Pure and deterministic — the IO wrapper and the quality test both drive it.
+    rapidfuzz ``token_set_ratio`` over name + aliases, applies the precision
+    guards (death-year, gender, ≥2 shared significant tokens), and unions the
+    survivors. Each transitive union-find group is then re-partitioned into
+    cliques (:func:`_safe_partition`) so a bridge record can never chain a
+    guard-conflicting pair into one cluster. Returns one index list per cluster
+    (singletons included), so the i-th record's cluster is recoverable. Pure and
+    deterministic — the IO wrapper and the quality test both drive it.
     """
     n = len(records)
     uf = _UnionFind(n)
 
     # Inverted index: significant token -> record indices carrying it (blocking).
     token_index: dict[str, list[int]] = {}
-    record_keys: list[list[str]] = []
     for i, rec in enumerate(records):
-        keys = _match_keys(rec)
-        record_keys.append(keys)
-        for tok in _significant_tokens(keys):
+        for tok in _significant_tokens(_match_keys(rec)):
             token_index.setdefault(tok, []).append(i)
 
     # Candidate pairs = records sharing ≥1 significant token. Dedup pairs so each
@@ -258,7 +314,12 @@ def cluster_records(
                 if _can_merge(records[i], records[j], threshold=threshold):
                     uf.union(i, j)
 
-    return uf.groups()
+    # Re-partition each transitive group into guard-safe cliques (closes the
+    # bridge-bypass: A–B ✓, B–C ✓, A–C conflict must NOT yield one {A,B,C}).
+    clusters: list[list[int]] = []
+    for group in uf.groups():
+        clusters.extend(_safe_partition(group, records, threshold=threshold))
+    return clusters
 
 
 def cluster_assignment(

--- a/tests/test_resolve/test_fuzzy_cluster.py
+++ b/tests/test_resolve/test_fuzzy_cluster.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+from rapidfuzz import fuzz
 
 from src.parse.identity import make_canonical_id
 from src.resolve.fuzzy_cluster import (
@@ -138,6 +139,39 @@ def test_distinct_names_do_not_cluster() -> None:
     b = _rec("سفيان بن عيينة", source_corpora=["sanadset"], death_year_ah=198)
     clusters = cluster_records([a, b])
     assert sorted(len(g) for g in clusters) == [1, 1]
+
+
+def test_bare_single_token_subset_does_not_merge() -> None:
+    """Over-merge vector 1: a bare given name is a 100-score subset but must NOT merge.
+
+    ``token_set_ratio("محمد", "محمد بن اسماعيل البخاري") == 100`` and the sparse
+    bare-name record carries no death-year/gender to trip the other guards — so
+    only the ≥2-shared-significant-token rule keeps them apart.
+    """
+    bare = _rec("محمد", source_corpora=["sanadset"])  # one significant token
+    full = _rec("محمد بن اسماعيل البخاري", source_corpora=["itqan"])
+    assert fuzz.token_set_ratio(bare["name_ar_normalized"], full["name_ar_normalized"]) == 100.0
+    clusters = cluster_records([bare, full])
+    assert sorted(len(g) for g in clusters) == [1, 1]  # stayed split
+
+
+def test_transitive_bridge_does_not_merge_conflicting_endpoints() -> None:
+    """Over-merge vector 2: a bridge must not chain a guard-conflicting pair.
+
+    A (Bukhari, d256) –bridge– B (bare ``محمد بن اسماعيل``, no death year) –bridge–
+    C (Kufi, d320): A–B and B–C each pass, but A–C conflicts on death year. The
+    transitive union must be re-partitioned so A and C never share a cluster.
+    """
+    a = _rec("محمد بن اسماعيل البخاري", source_corpora=["itqan"], death_year_ah=256)
+    b = _rec("محمد بن اسماعيل", source_corpora=["sanadset"])  # bridge, no death year
+    c = _rec("محمد بن اسماعيل الكوفي", source_corpora=["thaqalayn"], death_year_ah=320)
+
+    clusters = cluster_records([a, b, c])
+    cluster_of = {idx: ci for ci, grp in enumerate(clusters) for idx in grp}
+    # records passed as [a, b, c] → indices 0, 1, 2.
+    assert cluster_of[0] != cluster_of[2]  # A and C never co-cluster
+    # No cluster harbours the conflicting A–C pair; B attaches to exactly one side.
+    assert sorted(len(g) for g in clusters) == [1, 2]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_resolve/test_fuzzy_cluster.py
+++ b/tests/test_resolve/test_fuzzy_cluster.py
@@ -1,0 +1,249 @@
+"""Tests for fuzzy cross-source narrator clustering (da#118).
+
+The exact-name pass (#99) collapses narrators only on byte-identical normalized
+names. These tests prove the fuzzy increment:
+
+* **recall gain** — variant-spelling records of one person across ≥2 sources that
+  the exact pass leaves split now cluster, measured via ``quality.pairwise_quality``
+  against a gold standard, at a precision floor; and
+* **precision guard** — distinct narrators with similar names but conflicting
+  death-year / gender do NOT wrongly merge.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from src.parse.identity import make_canonical_id
+from src.resolve.fuzzy_cluster import (
+    cluster_assignment,
+    cluster_canonical_narrators,
+    cluster_records,
+)
+from src.resolve.quality import pairwise_quality
+from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+
+
+def _rec(name: str, **over: Any) -> dict[str, Any]:
+    """A canonical record keyed (like the real producers) on its normalized name."""
+    norm = normalize_arabic(name)
+    base: dict[str, Any] = {f.name: None for f in NARRATORS_CANONICAL_SCHEMA}
+    base.update(
+        {
+            "canonical_id": make_canonical_id(norm),
+            "name_ar": name,
+            "name_ar_normalized": norm,
+            "aliases": [],
+            "source_ids": [],
+            "source_corpora": [],
+            "mention_count": 1,
+        }
+    )
+    base.update(over)
+    return base
+
+
+def _write_canonical(path: Path, records: list[dict[str, Any]]) -> None:
+    arrays = {f.name: [r.get(f.name) for r in records] for f in NARRATORS_CANONICAL_SCHEMA}
+    pq.write_table(pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA), path)
+
+
+# ---------------------------------------------------------------------------
+# Recall increment
+# ---------------------------------------------------------------------------
+def test_variant_spelling_across_sources_clusters() -> None:
+    """A nasab-expanded variant of one person across two sources clusters as one."""
+    # Same scholar; Itqan carries the fuller nisba, Sanadset the shorter form.
+    a = _rec("محمد بن اسماعيل البخاري", source_corpora=["itqan"], death_year_ah=256)
+    b = _rec("محمد بن اسماعيل", source_corpora=["sanadset"], death_year_ah=256)
+    # An unrelated narrator that must stay on its own.
+    c = _rec("فاطمة بنت قيس", source_corpora=["muhaddithat"])
+
+    clusters = cluster_records([a, b, c])
+    sizes = sorted(len(grp) for grp in clusters)
+    assert sizes == [1, 2]  # {a,b} merged, c alone
+
+
+def test_recall_gain_over_exact_name_baseline() -> None:
+    """pairwise_quality recall rises over the exact-name pass at precision = 1.0.
+
+    Gold: a, b are the same person (one cluster); c is distinct. The exact-name
+    baseline keeps every record its own cluster (each id maps to itself) → it
+    misses the (a,b) gold pair, so recall < 1. The fuzzy pass recovers it.
+    """
+    a = _rec("احمد بن حنبل الشيباني", source_corpora=["itqan"], death_year_ah=241)
+    b = _rec("احمد بن حنبل", source_corpora=["sanadset"], death_year_ah=241)
+    c = _rec("مالك بن انس", source_corpora=["itqan"], death_year_ah=179)
+    records = [a, b, c]
+
+    gold = {
+        a["canonical_id"]: "person-1",
+        b["canonical_id"]: "person-1",
+        c["canonical_id"]: "person-2",
+    }
+    # Exact-name baseline: each canonical id is its own cluster.
+    exact = {r["canonical_id"]: r["canonical_id"] for r in records}
+    fuzzy = cluster_assignment(records)
+
+    exact_q = pairwise_quality(exact, gold)
+    fuzzy_q = pairwise_quality(fuzzy, gold)
+
+    assert exact_q.recall < 1.0  # the exact pass under-merges the variant pair
+    assert fuzzy_q.recall > exact_q.recall  # the increment
+    assert fuzzy_q.recall == 1.0
+    assert fuzzy_q.precision == 1.0  # precision floor held — nothing over-merged
+
+
+def test_alias_drives_a_merge() -> None:
+    """A da#94 alias key, not the primary name, carries the match."""
+    # Primary names diverge, but a's Itqan alias equals b's primary spelling.
+    a = _rec(
+        "ابو عبد الله محمد البخاري",
+        aliases=[normalize_arabic("محمد بن اسماعيل البخاري")],
+        source_corpora=["itqan"],
+    )
+    b = _rec("محمد بن اسماعيل البخاري", source_corpora=["sanadset"])
+
+    clusters = cluster_records([a, b])
+    assert sorted(len(g) for g in clusters) == [2]
+
+
+# ---------------------------------------------------------------------------
+# Precision guards
+# ---------------------------------------------------------------------------
+def test_conflicting_death_years_block_merge() -> None:
+    """Two same-named narrators a generation apart must NOT merge."""
+    a = _rec("محمد بن عبد الله", source_corpora=["itqan"], death_year_ah=150)
+    b = _rec("محمد بن عبد الله", source_corpora=["sanadset"], death_year_ah=320)
+    clusters = cluster_records([a, b])
+    assert sorted(len(g) for g in clusters) == [1, 1]  # stayed apart
+
+
+def test_conflicting_gender_blocks_merge() -> None:
+    """Similar names with explicit differing gender must NOT merge."""
+    a = _rec("عبد الله بن محمد", source_corpora=["itqan"], gender="male")
+    b = _rec("عبد الله بن محمد", source_corpora=["muhaddithat"], gender="female")
+    clusters = cluster_records([a, b])
+    assert sorted(len(g) for g in clusters) == [1, 1]
+
+
+def test_distinct_names_do_not_cluster() -> None:
+    """Genuinely different narrators sharing a common token stay separate."""
+    a = _rec("سفيان الثوري", source_corpora=["itqan"], death_year_ah=161)
+    b = _rec("سفيان بن عيينة", source_corpora=["sanadset"], death_year_ah=198)
+    clusters = cluster_records([a, b])
+    assert sorted(len(g) for g in clusters) == [1, 1]
+
+
+# ---------------------------------------------------------------------------
+# Merge mechanics & identity contract
+# ---------------------------------------------------------------------------
+def test_merged_record_routes_through_make_canonical_id(tmp_path: Path) -> None:
+    """The survivor's id is make_canonical_id(rep name) — never a parallel scheme."""
+    rep = _rec(
+        "محمد بن اسماعيل البخاري",
+        source_corpora=["itqan"],
+        mention_count=10,
+        death_year_ah=256,
+        external_id="320",
+    )
+    var = _rec(
+        "محمد بن اسماعيل",
+        source_corpora=["sanadset"],
+        mention_count=2,
+        death_year_ah=256,
+    )
+    canonical = tmp_path / "narrators_canonical.parquet"
+    _write_canonical(canonical, [rep, var])
+
+    metrics = cluster_canonical_narrators(canonical)
+    assert metrics.input_records == 2
+    assert metrics.output_records == 1
+    assert metrics.merged_records == 1
+    assert metrics.cross_source_clusters == 1
+
+    rows = pq.read_table(canonical).to_pylist()
+    assert len(rows) == 1
+    merged = rows[0]
+    # Representative (more mentions) keeps the fuller name; id routes through identity.
+    assert merged["canonical_id"] == make_canonical_id(normalize_arabic("محمد بن اسماعيل البخاري"))
+    # Provenance unioned; absorbed spelling preserved as an alias; mentions summed.
+    assert sorted(merged["source_corpora"]) == ["itqan", "sanadset"]
+    assert normalize_arabic("محمد بن اسماعيل") in merged["aliases"]
+    assert merged["mention_count"] == 12
+    assert merged["external_id"] == "320"
+
+
+def test_clustering_is_idempotent(tmp_path: Path) -> None:
+    """Re-running on an already-clustered table changes nothing."""
+    a = _rec("احمد بن حنبل الشيباني", source_corpora=["itqan"], death_year_ah=241, mention_count=5)
+    b = _rec("احمد بن حنبل", source_corpora=["sanadset"], death_year_ah=241, mention_count=1)
+    canonical = tmp_path / "narrators_canonical.parquet"
+    _write_canonical(canonical, [a, b])
+
+    first = cluster_canonical_narrators(canonical)
+    assert first.merged_records == 1
+    second = cluster_canonical_narrators(canonical)
+    assert second.merged_records == 0
+    assert second.input_records == 1
+    assert second.output_records == 1
+
+
+def test_mentions_remapped_to_survivor(tmp_path: Path) -> None:
+    """Mentions backfilled with an absorbed id are rewritten to the survivor (#109)."""
+    rep = _rec("محمد بن اسماعيل البخاري", source_corpora=["itqan"], mention_count=10)
+    var = _rec("محمد بن اسماعيل", source_corpora=["sanadset"], mention_count=2)
+    survivor_id = make_canonical_id(normalize_arabic("محمد بن اسماعيل البخاري"))
+    absorbed_id = var["canonical_id"]
+
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    canonical = out_dir / "narrators_canonical.parquet"
+    _write_canonical(canonical, [rep, var])
+
+    mentions = out_dir / "narrator_mentions_resolved.parquet"
+    mrows = [
+        {f.name: None for f in NARRATOR_MENTIONS_RESOLVED_SCHEMA} | row
+        for row in (
+            {
+                "mention_id": "m1",
+                "hadith_id": "h1",
+                "source_corpus": "sanadset",
+                "position_in_chain": 0,
+                "canonical_narrator_id": absorbed_id,
+            },
+            {
+                "mention_id": "m2",
+                "hadith_id": "h2",
+                "source_corpus": "itqan",
+                "position_in_chain": 0,
+                "canonical_narrator_id": survivor_id,
+            },
+        )
+    ]
+    arrays = {f.name: [r[f.name] for r in mrows] for f in NARRATOR_MENTIONS_RESOLVED_SCHEMA}
+    pq.write_table(pa.table(arrays, schema=NARRATOR_MENTIONS_RESOLVED_SCHEMA), mentions)
+
+    metrics = cluster_canonical_narrators(canonical, mentions_path=mentions)
+    assert metrics.mentions_remapped == 1
+
+    got = {r["mention_id"]: r["canonical_narrator_id"] for r in pq.read_table(mentions).to_pylist()}
+    assert got["m1"] == survivor_id  # absorbed → survivor
+    assert got["m2"] == survivor_id  # already on survivor — untouched
+
+
+def test_empty_and_missing_inputs_are_noops(tmp_path: Path) -> None:
+    """Missing or empty canonical table → a clean no-op, not a crash."""
+    missing = tmp_path / "absent.parquet"
+    m = cluster_canonical_narrators(missing)
+    assert m.input_records == 0 and m.output_records == 0
+
+    empty = tmp_path / "narrators_canonical.parquet"
+    _write_canonical(empty, [])
+    m2 = cluster_canonical_narrators(empty)
+    assert m2.input_records == 0 and m2.merged_records == 0


### PR DESCRIPTION
Closes #118. Recall increment on the #99 exact-name cross-source pass.

## Problem
#99 collapses a narrator across sources only on a **byte-exact** normalized-name
match (`make_canonical_id(name_ar_normalized)`) — high precision, but it
under-merges true variants that survive Arabic normalization differently:
nasab/nisba expansion or truncation, kunya-only forms, an optional `ابن`/`بن`,
transliteration drift, honorifics. Those land as separate `nar:` nodes for one
real person — recall left on the table.

## Approach — `src/resolve/fuzzy_cluster.py`
A bio/canonical-level clustering pass (the analogue of `disambiguate`'s rapidfuzz
*mention* stage, but with both sides canonical narrators). It reads the
already-collapsed `narrators_canonical.parquet`, clusters high-confidence name
variants, and merges each cluster into one record. Runs **on top of**, never
replacing, the exact pass.

- **Signals:** rapidfuzz `token_set_ratio` over each record's `name_ar_normalized`
  **plus every `alias`** — the #94 Itqan name-variant feed (217,762 variants) is
  consumed as additional match keys, not just the canonical name. Token-set is
  order-/extra-token-insensitive, so `محمد بن اسماعيل` ↔ `محمد بن اسماعيل البخاري`
  scores high while a genuinely different name does not.
- **Blocking:** token inverted index (only records sharing a significant,
  non-connector name token are ever compared) → near-linear, not O(n²).

## Precision/recall guardrails (against over-merging distinct same-named narrators)
- Conservative **tunable threshold** (`_CLUSTER_RATIO_THRESHOLD = 90`) — the
  precision/recall knob the acceptance criteria call for.
- **Death-year guard:** when both records carry `death_year_ah` and they disagree
  by more than the tolerance, the merge is blocked even on a perfect name match
  (two scholars a century apart are not one person).
- **Gender guard:** two records with explicit, differing `gender` never merge.

## Identity & ordering (no re-architecture)
- Every merge routes through `identity.make_canonical_id` — never a parallel id
  scheme (da#110). The survivor is an existing canonical record, so its id is
  itself a prior `make_canonical_id` output: clustering re-keys nothing.
- Wired into `run_all` **after** `disambiguate → bio_promote` (da#117), as an
  additive step. It is idempotent (re-running on a clustered table is a no-op), so
  the disambiguate-overwrites/bio_promote-merges ordering invariant is untouched.
- When the mentions file is present, the absorbed-id → survivor remap is applied
  to `narrator_mentions_resolved.parquet` so graph NARRATED edges follow the merge
  instead of dangling on a dissolved node (#109).

## Test proof — `tests/test_resolve/test_fuzzy_cluster.py` (10 tests)
- **Recall gain:** `quality.pairwise_quality` recall rises over the exact-name
  baseline (`exact_q.recall < 1.0 < fuzzy_q.recall == 1.0`) at **precision = 1.0**.
- **Aliases (#94):** a variant matched only via an alias key clusters.
- **Precision guards:** conflicting death-year, conflicting gender, and genuinely
  distinct names that share a common token all stay split.
- **Mechanics:** survivor id routes through `make_canonical_id`; provenance
  unioned; absorbed spelling kept as an alias; mention_count summed; idempotency;
  mention remap; empty/missing no-ops.

## Verification
- `pytest tests/test_resolve/` → 152 passed, 3 skipped (pre-existing, semantic model).
- `ruff format --check` + `ruff check` clean; `mypy src/` → no issues (77 files).

## Test Plan (runtime, post-merge)
- **Live `neo4j:5`:** run the resolve pipeline over ≥2 loaded sources; assert a
  known same-person variant pair across sources collapses to one `Narrator` node
  (canonical count drops by the merged count) and its NARRATED edges resolve to
  the surviving node.

Reviewers: @Kavitha Sundaramurthy (primary), @Oyunbileg Batbayar (QA).
