### PR TITLE
fix(graph): route network edges by declared relation, not filename (da#133)

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -22,6 +22,7 @@ from src.parse.identity import (
     make_canonical_id,
     narrator_node_id,
 )
+from src.parse.schemas import EDGE_RELATION_STUDIED_UNDER
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
 from src.utils.neo4j_client import Neo4jClient
@@ -485,11 +486,17 @@ def _load_parallel_of(
 # NETWORK_EDGE_SCHEMA is reused by producers whose edges mean DIFFERENT relations.
 # muhaddithat + itqan emit teacher↔student (studentship) pairs that ARE
 # STUDIED_UNDER. Others — e.g. `mis`, whose rows are *isnad transmission* pairs (a
-# different relation type AND the opposite direction) — must NOT be globbed in
-# here, or their edges would load as wrong-type, wrong-direction STUDIED_UNDER.
-# This filename allowlist is the cheap, safe interim; the durable fix is an
-# explicit edge-relation field on NETWORK_EDGE_SCHEMA so the loader keys on the
-# data, not on a slug — tracked in da#133.
+# different relation type AND the opposite direction) — must NOT load as
+# STUDIED_UNDER, or their edges would land as wrong-type, wrong-direction edges.
+#
+# The durable routing (da#133) is the per-row ``relation`` field on
+# NETWORK_EDGE_SCHEMA: a row is loaded here iff it DECLARES STUDIED_UNDER. The
+# filename allowlist below is no longer the primary gate — it survives only as the
+# back-compat inference for a pre-da#133 file whose rows carry no ``relation`` at
+# all (a legacy studentship file → STUDIED_UNDER; anything else → skipped). Once a
+# file carries an explicit ``relation`` the allowlist is never consulted, so a new
+# studentship source needs no allowlist edit and a transmission file named like a
+# studentship one (or vice-versa) is still routed correctly by its data.
 _STUDIED_UNDER_SOURCES: frozenset[str] = frozenset({"muhaddithat", "itqan"})
 
 
@@ -497,10 +504,25 @@ def _is_studied_under_file(path: Path) -> bool:
     """True if a ``network_edges_<slug>.parquet`` belongs to a studentship source.
 
     Matches the exact slug or a chunked ``<slug>_NNN`` variant, so a future
-    sharded write still resolves but a different corpus (``mis``) never does.
+    sharded write still resolves but a different corpus (``mis``) never does. Used
+    only as the back-compat default for relation-less (pre-da#133) rows.
     """
     slug = path.stem.removeprefix("network_edges_")
     return any(slug == src or slug.startswith(f"{src}_") for src in _STUDIED_UNDER_SOURCES)
+
+
+def _row_relation(row: dict[str, Any], *, legacy_default: str | None) -> str | None:
+    """Relation a NETWORK_EDGE row declares.
+
+    Honors an explicit ``relation`` value (da#133). A row carrying none — a
+    pre-da#133 parquet — falls back to *legacy_default*: the relation the file's
+    name implied under the old filename allowlist (``None`` when the name matched
+    no studentship source, so such legacy rows are skipped rather than mislabeled).
+    """
+    rel = row.get("relation")
+    if isinstance(rel, str) and rel.strip():
+        return rel
+    return legacy_default
 
 
 _STUDIED_UNDER_QUERY = """\
@@ -547,17 +569,16 @@ def _load_studied_under(
     *,
     batch_size: int = DEFAULT_BATCH_SIZE,
 ) -> EdgeLoadResult:
-    """Load STUDIED_UNDER edges from the studentship ``network_edges_*.parquet``.
+    """Load STUDIED_UNDER edges from the ``network_edges_*.parquet`` files.
 
-    Globs ``network_edges_*`` but keeps only the studentship producers
-    (:data:`_STUDIED_UNDER_SOURCES` — muhaddithat, itqan); a NETWORK_EDGE producer
-    whose edges are a different relation (e.g. ``mis`` isnad transmission) is
-    deliberately skipped here (see da#133). Gracefully skips when no such file
-    exists.
+    Globs every ``network_edges_*`` file and keeps only the rows that DECLARE the
+    STUDIED_UNDER relation (:func:`_row_relation`, da#133). A NETWORK_EDGE producer
+    whose edges are a different relation (e.g. ``mis`` isnad transmission, declared
+    TRANSMITTED_TO) is skipped row-by-row regardless of filename. Rows in a
+    pre-da#133 file that carry no relation fall back to the filename allowlist.
+    Gracefully skips when no ``network_edges_*`` file exists.
     """
-    edge_files = [
-        p for p in _parquet_files(staging_dir, "network_edges_") if _is_studied_under_file(p)
-    ]
+    edge_files = _parquet_files(staging_dir, "network_edges_")
     if not edge_files:
         logger.info("studied_under_skipped", reason="file_not_found", staging_dir=str(staging_dir))
         return EdgeLoadResult("STUDIED_UNDER", 0, 0, 0)
@@ -567,7 +588,14 @@ def _load_studied_under(
     skipped = 0
 
     for path in edge_files:
+        # Relation a relation-less (pre-da#133) row in this file defaults to.
+        legacy_default = EDGE_RELATION_STUDIED_UNDER if _is_studied_under_file(path) else None
         for row in _read_parquet_rows(path):
+            if _row_relation(row, legacy_default=legacy_default) != EDGE_RELATION_STUDIED_UNDER:
+                # Not a studentship edge (e.g. an isnad-transmission row) — leave it
+                # off STUDIED_UNDER. Not counted as skipped: skipped tracks edges we
+                # meant to load but could not resolve, not other relations.
+                continue
             from_id = _studied_under_endpoint(
                 row.get("from_narrator_name"), row.get("from_external_id")
             )

--- a/src/parse/itqan.py
+++ b/src/parse/itqan.py
@@ -41,6 +41,7 @@ import pyarrow as pa
 
 from src.parse.base import safe_str, write_parquet
 from src.parse.schemas import (
+    EDGE_RELATION_STUDIED_UNDER,
     NARRATOR_ALIAS_SCHEMA,
     NARRATOR_BIO_SCHEMA,
     NETWORK_EDGE_SCHEMA,
@@ -239,6 +240,7 @@ def _build_edges(
                 "source": SOURCE,
                 "from_external_id": student_id,
                 "to_external_id": teacher_id,
+                "relation": EDGE_RELATION_STUDIED_UNDER,
             }
         )
 

--- a/src/parse/mis.py
+++ b/src/parse/mis.py
@@ -45,7 +45,11 @@ from typing import Any
 import pyarrow as pa
 
 from src.parse.base import generate_source_id, read_csv_robust, safe_int, safe_str, write_parquet
-from src.parse.schemas import HADITH_SCHEMA, NETWORK_EDGE_SCHEMA
+from src.parse.schemas import (
+    EDGE_RELATION_TRANSMITTED_TO,
+    HADITH_SCHEMA,
+    NETWORK_EDGE_SCHEMA,
+)
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -261,7 +265,13 @@ def _emit_edge(
     from_id: str | None = None,
     to_id: str | None = None,
 ) -> None:
-    """Append one NETWORK_EDGE row, skipping incomplete / self-loop pairs."""
+    """Append one NETWORK_EDGE row, skipping incomplete / self-loop pairs.
+
+    MIS rows are *isnad transmission* pairs, so each declares the TRANSMITTED_TO
+    relation — never STUDIED_UNDER. The graph loader keys on that field, which is
+    what keeps these edges off the STUDIED_UNDER loader once MIS is wired into the
+    production load path (da#133).
+    """
     if not from_name or not to_name or from_name == to_name:
         return
     edges.append(
@@ -272,6 +282,7 @@ def _emit_edge(
             "source": SOURCE_CORPUS,
             "from_external_id": from_id,
             "to_external_id": to_id,
+            "relation": EDGE_RELATION_TRANSMITTED_TO,
         }
     )
 

--- a/src/parse/muhaddithat.py
+++ b/src/parse/muhaddithat.py
@@ -19,7 +19,11 @@ from src.parse.base import (
     safe_str,
     write_parquet,
 )
-from src.parse.schemas import NARRATOR_BIO_SCHEMA, NETWORK_EDGE_SCHEMA
+from src.parse.schemas import (
+    EDGE_RELATION_STUDIED_UNDER,
+    NARRATOR_BIO_SCHEMA,
+    NETWORK_EDGE_SCHEMA,
+)
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
 
@@ -156,10 +160,12 @@ def _parse_network_edges(
     hadiths_path: Path,
     id_to_name: dict[str, str],
 ) -> pa.Table:
-    """Parse hadith CSV to extract isnad network edges.
+    """Parse hadith CSV to extract studentship network edges.
 
-    Each hadith row contains a sequence of narrator IDs. Consecutive pairs
-    form directed TRANSMITTED_TO edges: narrator[i] -> narrator[i+1].
+    Each hadith row contains a sequence of narrator IDs. Consecutive pairs form
+    directed STUDIED_UNDER edges (narrator[i] -> narrator[i+1]); each row declares
+    that relation so the graph loader routes it without guessing from the filename
+    (da#133).
     """
     table = _read_csv(hadiths_path)
     headers = [h.lower().strip() for h in table.column_names]
@@ -221,6 +227,7 @@ def _parse_network_edges(
                     "source": SOURCE,
                     "from_external_id": from_id,
                     "to_external_id": to_id,
+                    "relation": EDGE_RELATION_STUDIED_UNDER,
                 }
             )
 

--- a/src/parse/schemas.py
+++ b/src/parse/schemas.py
@@ -16,7 +16,21 @@ __all__ = [
     "NARRATOR_ALIAS_SCHEMA",
     "COLLECTION_SCHEMA",
     "NETWORK_EDGE_SCHEMA",
+    "EDGE_RELATION_STUDIED_UNDER",
+    "EDGE_RELATION_TRANSMITTED_TO",
+    "DEFAULT_EDGE_RELATION",
 ]
+
+# ``NETWORK_EDGE_SCHEMA.relation`` values (da#133). The graph loader routes a
+# network edge to a Neo4j relationship type by this DECLARED relation rather than
+# guessing it from the producing file's name: a studentship producer (muhaddithat,
+# itqan) emits ``STUDIED_UNDER``; an isnad-transmission producer (mis) emits
+# ``TRANSMITTED_TO``. ``DEFAULT_EDGE_RELATION`` is the back-compat value the loader
+# assumes for a row that carries no relation — a pre-da#133 parquet — which is
+# exactly what those legacy (studentship-only) files meant.
+EDGE_RELATION_STUDIED_UNDER = "STUDIED_UNDER"
+EDGE_RELATION_TRANSMITTED_TO = "TRANSMITTED_TO"
+DEFAULT_EDGE_RELATION = EDGE_RELATION_STUDIED_UNDER
 
 # ``source_id`` grammar and the graph node-id rules derived from it are the
 # canonical identity contract — see :mod:`src.parse.identity` (``<corpus>:
@@ -95,6 +109,11 @@ COLLECTION_SCHEMA = pa.schema(
     ]
 )
 
+# ``relation`` declares which graph relationship the row's narrator pair forms
+# (:data:`EDGE_RELATION_STUDIED_UNDER` vs :data:`EDGE_RELATION_TRANSMITTED_TO`) so
+# the loader keys on the data, not on the filename (da#133). It is nullable for
+# back-compat: a pre-da#133 file carries no relation and the loader falls back to
+# :data:`DEFAULT_EDGE_RELATION`. Current producers always populate it.
 NETWORK_EDGE_SCHEMA = pa.schema(
     [
         pa.field("from_narrator_name", pa.string(), nullable=False),
@@ -103,6 +122,7 @@ NETWORK_EDGE_SCHEMA = pa.schema(
         pa.field("source", pa.string(), nullable=False),
         pa.field("from_external_id", pa.string(), nullable=True),
         pa.field("to_external_id", pa.string(), nullable=True),
+        pa.field("relation", pa.string(), nullable=True),
     ]
 )
 

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -474,3 +474,97 @@ class TestLoadStudiedUnderGlob:
             "from_id": make_canonical_id(normalize_arabic("أ")),
             "to_id": make_canonical_id(normalize_arabic("ب")),
         } in batch
+
+
+class TestStudiedUnderRelationRouting:
+    """da#133: the loader routes by the declared ``relation`` field, not the
+    filename. The filename allowlist only survives as the default for legacy
+    relation-less rows (covered by :class:`TestLoadStudiedUnderGlob`)."""
+
+    def test_relation_field_includes_non_allowlisted_source(self, staging_dir: Path) -> None:
+        """A NETWORK_EDGE file whose slug is NOT in the studentship allowlist still
+        loads when its rows DECLARE STUDIED_UNDER — proving routing keys on the
+        field, not the filename, so a new studentship source needs no allowlist
+        edit."""
+        _write_network_edges(
+            staging_dir,
+            "newsource",  # deliberately not muhaddithat/itqan
+            [
+                {
+                    "from_narrator_name": "أ",
+                    "to_narrator_name": "ب",
+                    "source": "newsource",
+                    "from_external_id": "1",
+                    "to_external_id": "2",
+                    "relation": "STUDIED_UNDER",
+                }
+            ],
+        )
+        client = MockNeo4jClient()
+        client.set_read_results([{"from_exists": True, "to_exists": True}])
+        result = _load_studied_under(client, staging_dir)
+        assert result.created == 1
+
+    def test_transmitted_to_relation_excluded_despite_studentship_filename(
+        self, staging_dir: Path
+    ) -> None:
+        """A row that DECLARES TRANSMITTED_TO is kept off STUDIED_UNDER even when it
+        lives in an allowlisted (``muhaddithat``) file — the explicit relation
+        overrides the filename so an isnad-transmission row can never be
+        mislabeled."""
+        _write_network_edges(
+            staging_dir,
+            "muhaddithat",
+            [
+                {
+                    "from_narrator_name": "X",
+                    "to_narrator_name": "Y",
+                    "source": "muhaddithat",
+                    "from_external_id": "1",
+                    "to_external_id": "2",
+                    "relation": "TRANSMITTED_TO",
+                }
+            ],
+        )
+        client = MockNeo4jClient()
+        result = _load_studied_under(client, staging_dir)
+        assert result.created == 0  # the transmission row is not loaded as STUDIED_UNDER
+
+    def test_explicit_relation_routes_mixed_file(self, staging_dir: Path) -> None:
+        """Within one file, only the STUDIED_UNDER-declaring row loads; the
+        TRANSMITTED_TO-declaring row is skipped."""
+        _write_network_edges(
+            staging_dir,
+            "mis",  # not allowlisted; both rows carry explicit relations
+            [
+                {
+                    "from_narrator_name": "أ",
+                    "to_narrator_name": "ب",
+                    "source": "mis",
+                    "from_external_id": "1",
+                    "to_external_id": "2",
+                    "relation": "STUDIED_UNDER",
+                },
+                {
+                    "from_narrator_name": "X",
+                    "to_narrator_name": "Y",
+                    "source": "mis",
+                    "from_external_id": "3",
+                    "to_external_id": "4",
+                    "relation": "TRANSMITTED_TO",
+                },
+            ],
+        )
+        client = MockNeo4jClient()
+        client.set_read_results([{"from_exists": True, "to_exists": True}])
+        result = _load_studied_under(client, staging_dir)
+        assert result.created == 1
+        batch = [b for q, b in client.calls if "MERGE" in q and isinstance(b, list)][-1]
+        assert {
+            "from_id": make_canonical_id(normalize_arabic("أ")),
+            "to_id": make_canonical_id(normalize_arabic("ب")),
+        } in batch
+        assert {
+            "from_id": make_canonical_id(normalize_arabic("X")),
+            "to_id": make_canonical_id(normalize_arabic("Y")),
+        } not in batch

--- a/tests/test_parse/test_itqan_parser.py
+++ b/tests/test_parse/test_itqan_parser.py
@@ -221,6 +221,8 @@ class TestEdgeExtraction:
         assert {r["source"] for r in rows} == {"itqan"}
         # Provenance: both endpoints carry the source profile id.
         assert all(r["from_external_id"] and r["to_external_id"] for r in rows)
+        # Studentship edges declare STUDIED_UNDER for relation-keyed loading (da#133).
+        assert {r["relation"] for r in rows} == {"STUDIED_UNDER"}
 
 
 class TestAliasExtraction:

--- a/tests/test_parse/test_mis_parser.py
+++ b/tests/test_parse/test_mis_parser.py
@@ -119,6 +119,9 @@ class TestMisSequenceLayout:
         table = pq.read_table(edges_path)
         assert table.schema == NETWORK_EDGE_SCHEMA
         assert set(table.column("source").to_pylist()) == {"mis"}
+        # MIS isnad edges declare TRANSMITTED_TO so the graph loader never routes
+        # them to STUDIED_UNDER (da#133).
+        assert set(table.column("relation").to_pylist()) == {"TRANSMITTED_TO"}
 
     def test_multiplicity_preserved(self, tmp_path: Path) -> None:
         """The three isnads of hadith 1 must survive as three distinct chains."""

--- a/tests/test_parse/test_muhaddithat_parser.py
+++ b/tests/test_parse/test_muhaddithat_parser.py
@@ -62,6 +62,9 @@ class TestMuhaddithatParser:
         table = pq.read_table(edge_path)
         assert table.schema == NETWORK_EDGE_SCHEMA
         assert table.num_rows > 0
+        # Studentship edges declare STUDIED_UNDER so the loader routes them by the
+        # field, not the filename (da#133).
+        assert set(table.column("relation").to_pylist()) == {"STUDIED_UNDER"}
 
     def test_edge_count(self, tmp_path: Path) -> None:
         raw_dir = tmp_path / "raw"

--- a/tests/test_parse/test_schemas.py
+++ b/tests/test_parse/test_schemas.py
@@ -106,6 +106,7 @@ class TestSampleData:
             "source": ["lk"],
             "from_external_id": [None],
             "to_external_id": [None],
+            "relation": ["STUDIED_UNDER"],
         }
         table = pa.table(data).cast(NETWORK_EDGE_SCHEMA)
         assert table.num_rows == 1


### PR DESCRIPTION
## What & why

`load_edges._load_studied_under` globbed `network_edges_*.parquet` and routed files to **STUDIED_UNDER** by a hardcoded filename allowlist (`muhaddithat`, `itqan`). `NETWORK_EDGE_SCHEMA` had no relation/type field, so a non-allowlisted producer — notably **mis** (#132), whose rows are *isnad transmission* (`TRANSMITTED_TO`, opposite direction) — would have loaded as wrong-type, wrong-direction STUDIED_UNDER once wired into the production load path. This is the blocker the architect (Jean-Claude) carved out in #133.

## Change

- **`NETWORK_EDGE_SCHEMA`** gains an explicit, nullable **`relation`** field plus value constants (`EDGE_RELATION_STUDIED_UNDER`, `EDGE_RELATION_TRANSMITTED_TO`, `DEFAULT_EDGE_RELATION`).
- **Producers declare their relation**: `muhaddithat` + `itqan` → `STUDIED_UNDER`; `mis` → `TRANSMITTED_TO`.
- **Loader routes by the declared field** per-row, not by filename. The filename allowlist is demoted to a **back-compat default** consulted *only* for pre-#133 rows that carry no `relation` (legacy studentship file → STUDIED_UNDER; anything else → skipped). Once a row carries an explicit relation the allowlist is never consulted, so:
  - a new studentship source needs no allowlist edit, and
  - a transmission row can never be mislabeled even in a studentship-named file.
- Fixed the stale `muhaddithat._parse_network_edges` docstring that claimed TRANSMITTED_TO (it loads as STUDIED_UNDER).

## Tests

- `TestStudiedUnderRelationRouting`: non-allowlisted slug declaring STUDIED_UNDER **loads**; a `TRANSMITTED_TO` row in a `muhaddithat`-named file is **excluded**; a mixed-relation file splits correctly.
- Per-producer relation-stamping assertions (mis → TRANSMITTED_TO; muhaddithat/itqan → STUDIED_UNDER).
- Existing filename-fallback tests (incl. the original mis-exclusion proof) retained and green.

Full suite: **827 passed, 5 skipped**. `ruff format`/`ruff check`/`mypy src/` clean.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
