### PR TITLE
feat(staging-load): produce + load the real narrator graph + fix chain-edge curated wiring (da#141)

### DIFF
--- a/docs/narrator-graph-load.md
+++ b/docs/narrator-graph-load.md
@@ -6,7 +6,7 @@ graph — `Narrator` + `NARRATED` + `STUDIED_UNDER` + `APPEARS_IN` +
 
 It is the narrator-graph successor to the da#73 [first-light slice](first-light-slice.md),
 which proved only the hadith + `APPEARS_IN` path on one collection. The gap
-#601 found was: staging held 47 Hadith + 47 `APPEARS_IN` and a **zero narrator
+`#601` found was: staging held 47 Hadith + 47 `APPEARS_IN` and a **zero narrator
 graph** (0 `Narrator`, 0 `NARRATED`, 0 `STUDIED_UNDER`) — the W4-retro
 "data-first core shipped" was local/CI/harness only, never reflected on staging.
 

--- a/docs/narrator-graph-load.md
+++ b/docs/narrator-graph-load.md
@@ -19,7 +19,10 @@ acquire -> parse -> resolve.run_all -> graph.load_all -> verify
 ## The produce step (reproducible)
 
 The default source set is **bounded but REAL** (not toy fixtures), so the whole
-produce → load → verify path runs locally in ~10 min:
+produce → load → verify path runs locally end-to-end (the fuzzy-cluster step
+over the full ~47k `lk` narrators is the long pole — several minutes, longer
+under CPU contention; it is the da#118 recall pass and does not affect load
+correctness):
 
 | Source        | Sect       | What it contributes |
 |---------------|------------|---------------------|

--- a/docs/narrator-graph-load.md
+++ b/docs/narrator-graph-load.md
@@ -1,0 +1,114 @@
+# Narrator-graph produce + load (da#141)
+
+The **data half** of `main#601` criterion #1: produce and load the REAL narrator
+graph — `Narrator` + `NARRATED` + `STUDIED_UNDER` + `APPEARS_IN` +
+`TRANSMITTED_TO`, **both sects** — onto staging Neo4j.
+
+It is the narrator-graph successor to the da#73 [first-light slice](first-light-slice.md),
+which proved only the hadith + `APPEARS_IN` path on one collection. The gap
+#601 found was: staging held 47 Hadith + 47 `APPEARS_IN` and a **zero narrator
+graph** (0 `Narrator`, 0 `NARRATED`, 0 `STUDIED_UNDER`) — the W4-retro
+"data-first core shipped" was local/CI/harness only, never reflected on staging.
+
+The driver is `scripts/narrator_graph/run.py`:
+
+```
+acquire -> parse -> resolve.run_all -> graph.load_all -> verify
+```
+
+## The produce step (reproducible)
+
+The default source set is **bounded but REAL** (not toy fixtures), so the whole
+produce → load → verify path runs locally in ~10 min:
+
+| Source        | Sect       | What it contributes |
+|---------------|------------|---------------------|
+| `muhaddithat` | both (neutral) | Cross-tradition female narrators. No isnad text, so its narrators reach canonical via `bio_promote` (**bio-only promoted**, tagged `neutral`); its studentship pairs → `STUDIED_UNDER`. |
+| `lk` (LK-Hadith-Corpus) | sunni | 6 Sunni books with isnad chains → hadiths + narrator mentions → `NER`/`disambiguate` → canonical narrators → `NARRATED` + `TRANSMITTED_TO` + `APPEARS_IN`. |
+
+Together they exercise **every** narrator-graph edge type AND both sects
+(`lk` sunni mention-derived + `muhaddithat` neutral bio-only narrators), the
+da#120 disambiguate→bio_promote ordering, and the da#133 per-row `relation`
+`STUDIED_UNDER` routing.
+
+```bash
+# Produce only (acquire + parse + resolve); no Neo4j. Writes data/curated/.
+uv run python scripts/narrator_graph/run.py --produce-only
+```
+
+Widen the set with `--sources` for the full staging load — e.g. add
+`thaqalayn` (Shia Four Books, for Shia hadith coverage + cross-sect
+`PARALLEL_OF`) or `itqan` (the 100k-narrator rijal DB).
+
+## Local verification (the `neo4j:5` container)
+
+```bash
+# 1. Local Neo4j (WSL2 docker now works — memory: wsl2-no-local-docker RESOLVED).
+docker run -d --name da141-neo4j -e NEO4J_AUTH=neo4j/testpassword123 \
+    -e NEO4J_PLUGINS='["apoc"]' -p 7688:7687 neo4j:5
+
+# 2. Produce + load + verify against it.
+NEO4J_URI=bolt://localhost:7688 NEO4J_USER=neo4j NEO4J_PASSWORD=testpassword123 \
+    uv run python scripts/narrator_graph/run.py
+```
+
+The driver loads, then runs Cypher counts and asserts the required invariants
+(non-zero `Narrator` / `STUDIED_UNDER` / `NARRATED` / `APPEARS_IN`, a bio-only
+promoted narrator present, both sects present). It exits non-zero if any fails
+(`--no-assert` to report-only).
+
+### Verified counts (default `muhaddithat` + `lk` set, 2026-06-13)
+
+Loaded into a local `neo4j:5` container; **idempotent** on re-load (`MERGE` on
+`id` — a second load creates 0 new nodes/edges, counts unchanged):
+
+| Node / edge | Count | Note |
+|-------------|-------|------|
+| `Narrator`  | 47,199 | sunni 47,086 (`lk`, mention-derived) + neutral 113 (`muhaddithat`, **bio-only promoted**) |
+| `Hadith`    | 34,088 | `lk` |
+| `Collection`| 6 | `lk` books |
+| `NARRATED`        | 33,977 | first narrator per chain → hadith |
+| `TRANSMITTED_TO`  | 52,182 | consecutive narrator pairs |
+| `APPEARS_IN`      | 33,981 | incl. **39 with a null in-book ordinal** — proves the ip#84/da#77 null-safe MERGE |
+| `STUDIED_UNDER`   | 186 | `muhaddithat` studentship; both-sect neutral narrators; 0 missing endpoints |
+| `GRADED_BY`       | 33,478 | `lk` grades |
+| `PARALLEL_OF`     | 0 | none in a single-sect set — appears once a Shia hadith source (e.g. `thaqalayn`) is added |
+
+> **Loader fix shipped with this work (da#141):** `load_all_edges` read
+> `narrator_mentions_resolved.parquet` from **staging**, but `resolve.run_all`
+> writes it to **curated**. The chain edges silently fell back to the raw,
+> canonical-id-less staging mentions → **0 `NARRATED` / `TRANSMITTED_TO`** on a
+> real orchestrated load (exactly the #601 staging gap). The fix wires
+> `curated_dir` into both chain-edge loaders; covered by
+> `TestChainEdgesReadResolvedFromCurated` in `tests/test_graph/test_load_edges.py`
+> and by the live counts above.
+
+## Staging load — GATED
+
+> **Do NOT load live staging from a dev worktree.** This write pairs with the
+> ingest-platform worker bring-up (ip#83) and is the gated `#601` run the
+> team-lead coordinates.
+
+Staging Neo4j (`bolt://neo4j:7687`) is reachable only **inside the cluster**
+(prior loads — da#73 — used `docker exec cypher-shell` on the box). Run the
+driver from a box that resolves it, with the staging credentials in the env:
+
+```bash
+export NEO4J_URI=bolt://neo4j:7687          # staging bolt endpoint (cluster-internal)
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=<the deployed NEO4J_PASSWORD secret>
+
+# Produce on the box (or copy a produced data/ dir over), then load + verify.
+uv run python scripts/narrator_graph/run.py
+```
+
+The loader is idempotent (`MERGE` on `id`), so re-running over the existing 47
+da#73 hadiths is safe — they `MERGE`, not duplicate. Expect the verify block to
+report the counts above (plus the pre-existing 47 riyadussalihin `APPEARS_IN`).
+
+### Acceptance for the gated run
+
+`main#601` criterion #1 is met when, on **staging**, the verify block reports:
+non-zero `Narrator`, `STUDIED_UNDER`, and `NARRATED`, both sects present, and a
+bio-only promoted narrator — i.e. the same invariants the local run asserts,
+now live on the staging Neo4j.

--- a/scripts/narrator_graph/run.py
+++ b/scripts/narrator_graph/run.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Produce + load the REAL narrator graph — da#141 (main#601 criterion #1).
+
+The data half of the Phase-4 #601 end-state. Where the da#73 first-light slice
+(``scripts/first_light/run_slice.py``) proved only the hadith + ``APPEARS_IN``
+path on one collection, this driver produces and loads the **full narrator
+graph** — ``Narrator`` + ``NARRATED`` + ``STUDIED_UNDER`` + ``APPEARS_IN`` +
+``TRANSMITTED_TO``, **both sects** — end-to-end from REAL sources (not toy
+fixtures):
+
+    acquire -> parse -> resolve.run_all -> graph.load_all -> verify
+
+Default source set (bounded but REAL, so the whole path runs locally against a
+``neo4j:5`` container in ~10 min):
+
+* ``muhaddithat`` — cross-tradition (both-sects) female narrators. No isnad
+  text, so its narrators reach the canonical table via ``bio_promote``
+  (**bio-only promoted** narrators, tagged ``neutral``) and its studentship
+  pairs become ``STUDIED_UNDER`` edges. Open-licensed GitHub CSV; tiny.
+* ``lk`` (LK-Hadith-Corpus) — 6 Sunni books with isnad chains. Produces hadiths
+  + narrator mentions, which ``NER`` -> ``disambiguate`` resolve to canonical
+  narrators and the loader turns into ``NARRATED`` + ``TRANSMITTED_TO`` +
+  ``APPEARS_IN``. Open GitHub CSV.
+
+Together they exercise every narrator-graph edge type AND both sects (``lk``
+sunni mention-derived narrators + ``muhaddithat`` neutral bio-only narrators),
+the da#120 disambiguate-before-bio_promote ordering, and the da#133 per-row
+``relation`` STUDIED_UNDER routing.
+
+Widen the set with ``--sources`` for the full staging load — e.g. add
+``thaqalayn`` (Shia Four Books, for Shia hadith coverage + cross-sect
+``PARALLEL_OF``) or ``itqan`` (the 100k-narrator rijal DB). See
+``docs/narrator-graph-load.md`` for the gated staging-load runbook.
+
+Modes
+-----
+* default            : acquire + parse + resolve + load + verify.
+* ``--produce-only`` : acquire + parse + resolve; skip Neo4j (no DB connection).
+* ``--skip-resolve`` : reuse an existing ``<data>/curated`` (skip the slow
+  resolve) and go straight to load + verify.
+
+The Neo4j target is whatever ``get_settings().neo4j`` resolves to
+(``NEO4J_URI`` / ``NEO4J_USER`` / ``NEO4J_PASSWORD``). Loading **staging** is a
+GATED run (it pairs with the ingest-platform worker bring-up) — do it from the
+runbook, never casually from a dev worktree.
+
+Examples
+--------
+    # Local: produce from the default real sources, load a local neo4j, verify.
+    NEO4J_URI=bolt://localhost:7688 NEO4J_USER=neo4j NEO4J_PASSWORD=... \
+        uv run python scripts/narrator_graph/run.py
+
+    # Produce only (no DB); inspect the curated parquet.
+    uv run python scripts/narrator_graph/run.py --produce-only
+
+    # Re-load already-produced data without re-resolving.
+    uv run python scripts/narrator_graph/run.py --skip-resolve
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Bounded-but-real default set: both sects, every narrator-graph edge type.
+DEFAULT_SOURCES = ("muhaddithat", "lk")
+
+# Verification queries, run (and printed) after a load. Each returns one row.
+VERIFY_QUERIES: dict[str, str] = {
+    "narrators_total": "MATCH (n:Narrator) RETURN count(n) AS v",
+    "narrators_by_sect": (
+        "MATCH (n:Narrator) RETURN n.sect_affiliation AS sect, count(n) AS v ORDER BY v DESC"
+    ),
+    "narrators_by_corpus": (
+        "MATCH (n:Narrator) RETURN n.source_corpus AS corpus, count(n) AS v ORDER BY v DESC"
+    ),
+    # A bio-only promoted narrator: muhaddithat has no isnad text, so any
+    # muhaddithat Narrator node came through bio_promote, not a mention.
+    "bio_only_promoted_sample": (
+        "MATCH (n:Narrator {source_corpus: 'muhaddithat'}) "
+        "RETURN n.id AS id, n.name_ar AS name_ar, n.sect_affiliation AS sect LIMIT 1"
+    ),
+    "studied_under_edges": "MATCH (:Narrator)-[r:STUDIED_UNDER]->(:Narrator) RETURN count(r) AS v",
+    "narrated_edges": "MATCH (:Narrator)-[r:NARRATED]->(:Hadith) RETURN count(r) AS v",
+    "transmitted_to_edges": (
+        "MATCH (:Narrator)-[r:TRANSMITTED_TO]->(:Narrator) RETURN count(r) AS v"
+    ),
+    "appears_in_edges": "MATCH (:Hadith)-[r:APPEARS_IN]->(:Collection) RETURN count(r) AS v",
+    # The ip#84 / da#77 null-safe MERGE: APPEARS_IN edges whose in-book ordinal
+    # is null must still be created (a null property in the MERGE pattern would
+    # abort the load). lk supplies the positional ordinal, so this is reported
+    # rather than asserted; it is asserted when a null-ordinal source (e.g.
+    # sunnah_scraped) is in the set.
+    "appears_in_null_ordinal": (
+        "MATCH (:Hadith)-[r:APPEARS_IN]->(:Collection) "
+        "WHERE r.hadith_number_in_book IS NULL RETURN count(r) AS v"
+    ),
+    "parallel_of_edges": "MATCH (:Hadith)-[r:PARALLEL_OF]->(:Hadith) RETURN count(r) AS v",
+}
+
+
+def _produce(sources: tuple[str, ...], raw: Path, staging: Path, curated: Path) -> None:
+    """Acquire + parse each source, then run the full resolve pipeline."""
+    from src.adapters import get_adapter
+    from src.resolve import run_all as resolve_all
+
+    for slug in sources:
+        adapter = get_adapter(slug)
+        print(f"[acquire] {slug} ({adapter.license_note.split('.')[0]})")
+        adapter.acquire(raw)
+        print(f"[parse]   {slug}")
+        adapter.parse(raw, staging)
+
+    print("[resolve] NER -> disambiguate -> bio_promote -> cluster -> dedup + parallels")
+    resolve_all(raw, staging, curated)
+
+    canonical = curated / "narrators_canonical.parquet"
+    if not canonical.exists():
+        print(f"ERROR: resolve produced no {canonical}", file=sys.stderr)
+        sys.exit(1)
+
+    import pyarrow.parquet as pq
+
+    rows = pq.read_table(canonical).num_rows
+    print(f"[produce] {rows} canonical narrators in {canonical}")
+
+
+def _load_and_verify(staging: Path, curated: Path, *, strict_assert: bool) -> int:
+    """Load the produced graph into the configured Neo4j and verify counts.
+
+    Returns a process exit code (0 = all required edge/node types non-empty).
+    """
+    from src.graph import load_all
+    from src.utils.neo4j_client import Neo4jClient
+
+    queries_dir = REPO_ROOT / "queries"
+    with Neo4jClient() as client:
+        summary = load_all(
+            client,
+            staging,
+            curated,
+            queries_dir,
+            strict=False,
+            # The validation queries assume a fuller multi-source graph; the
+            # produce+load+verify here reports its own counts below instead.
+            skip_validation=True,
+        )
+
+        print("\n=== Load Summary ===")
+        print(f"  Nodes loaded : {summary.total_nodes}")
+        print(f"  Edges loaded : {summary.total_edges}")
+        for nr in summary.node_results:
+            print(f"    node {nr.node_type:12s}: created={nr.created} merged={nr.merged}")
+        for er in summary.edge_results:
+            print(
+                f"    edge {er.edge_type:14s}: created={er.created} "
+                f"missing_endpoints={er.missing_endpoints}"
+            )
+
+        print("\n=== Verification (Cypher counts) ===")
+        results: dict[str, list[dict[str, object]]] = {}
+        for name, cypher in VERIFY_QUERIES.items():
+            rows = client.execute_read(cypher)
+            results[name] = rows
+            if len(rows) == 1 and "v" in rows[0]:
+                print(f"  {name:26s}: {rows[0]['v']}")
+            else:
+                print(f"  {name:26s}: {rows}")
+
+    # Required non-empty invariants for the narrator graph (both sects).
+    def _scalar(name: str) -> int:
+        rows = results.get(name) or []
+        return int(rows[0]["v"]) if rows and "v" in rows[0] else 0
+
+    checks = {
+        "Narrator nodes > 0": _scalar("narrators_total") > 0,
+        "STUDIED_UNDER edges > 0": _scalar("studied_under_edges") > 0,
+        "NARRATED edges > 0": _scalar("narrated_edges") > 0,
+        "APPEARS_IN edges > 0": _scalar("appears_in_edges") > 0,
+        "bio-only promoted narrator present": bool(results.get("bio_only_promoted_sample")),
+        "both sects present (>= 2 sect tags)": len(results.get("narrators_by_sect") or []) >= 2,
+    }
+    print("\n=== Required invariants ===")
+    failed = [name for name, ok in checks.items() if not ok]
+    for name, ok in checks.items():
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+
+    if failed and strict_assert:
+        print(f"\nFAILED invariants: {failed}", file=sys.stderr)
+        return 1
+    print("\n=== narrator-graph slice complete ===")
+    return 0
+
+
+def main() -> None:
+    """Run the da#141 produce + load + verify driver."""
+    parser = argparse.ArgumentParser(description="da#141 produce + load the real narrator graph")
+    parser.add_argument(
+        "--sources",
+        nargs="+",
+        default=list(DEFAULT_SOURCES),
+        help=f"Adapter slugs to produce from (default: {' '.join(DEFAULT_SOURCES)})",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=REPO_ROOT / "data",
+        help="Root data dir holding raw/ staging/ curated/ (default: ./data)",
+    )
+    parser.add_argument(
+        "--produce-only",
+        action="store_true",
+        help="Acquire + parse + resolve only; skip the Neo4j load (no DB connection)",
+    )
+    parser.add_argument(
+        "--skip-resolve",
+        action="store_true",
+        help="Reuse an existing curated/ (skip acquire/parse/resolve); load + verify only",
+    )
+    parser.add_argument(
+        "--no-assert",
+        action="store_true",
+        help="Report verification counts but do not exit non-zero on an empty required type",
+    )
+    args = parser.parse_args()
+
+    raw = args.data_dir / "raw"
+    staging = args.data_dir / "staging"
+    curated = args.data_dir / "curated"
+    for d in (raw, staging, curated):
+        d.mkdir(parents=True, exist_ok=True)
+
+    print(f"=== narrator-graph slice (da#141) — data_dir={args.data_dir} ===")
+    print(f"    sources: {', '.join(args.sources)}")
+
+    if not args.skip_resolve:
+        _produce(tuple(args.sources), raw, staging, curated)
+    else:
+        print("[skip-resolve] reusing existing curated/ + staging/")
+
+    if args.produce_only:
+        print("\n[produce-only] skipping Neo4j load.")
+        return
+
+    exit_code = _load_and_verify(staging, curated, strict_assert=not args.no_assert)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -131,20 +131,45 @@ def _build_chain_pairs(
     return pairs
 
 
+def _resolved_mentions_files(staging_dir: Path, curated_dir: Path | None) -> list[Path]:
+    """Locate the mention files the chain edges (NARRATED / TRANSMITTED_TO) read.
+
+    The chain edges key on ``canonical_narrator_id`` — and the only mentions that
+    carry it are the RESOLVED ones, which ``resolve.run_all`` writes to the
+    **curated** (output) dir as ``narrator_mentions_resolved.parquet``, NOT to
+    staging (``src/resolve/ner.py`` / ``disambiguate.py``). Prefer that curated
+    file; fall back to a resolved file that happens to sit in staging, then to
+    the raw per-source ``narrator_mentions_*`` (pre-resolve — no canonical id, so
+    it yields no edges, but it keeps strict-mode file-presence checks satisfied).
+
+    Wiring curated_dir here is what fixes the orchestrated load emitting zero
+    NARRATED/TRANSMITTED_TO edges on real data (da#141 / main#601 criterion #1):
+    before this, both loaders globbed staging only and silently fell back to the
+    raw mentions.
+    """
+    if curated_dir is not None:
+        files = _parquet_files(curated_dir, "narrator_mentions_resolved")
+        if files:
+            return files
+    files = _parquet_files(staging_dir, "narrator_mentions_resolved")
+    if files:
+        return files
+    return _parquet_files(staging_dir, "narrator_mentions_")
+
+
 def _load_transmitted_to(
     client: Neo4jClient,
     staging_dir: Path,
     *,
+    curated_dir: Path | None = None,
     strict: bool = True,
     batch_size: int = DEFAULT_BATCH_SIZE,
 ) -> EdgeLoadResult:
     """Load TRANSMITTED_TO edges from narrator_mentions_resolved.parquet."""
-    files = _parquet_files(staging_dir, "narrator_mentions_resolved")
-    if not files:
-        files = _parquet_files(staging_dir, "narrator_mentions_")
+    files = _resolved_mentions_files(staging_dir, curated_dir)
     if not files:
         if strict:
-            msg = f"No narrator_mentions files in {staging_dir}"
+            msg = f"No narrator_mentions files in {curated_dir or staging_dir}"
             raise FileNotFoundError(msg)
         logger.warning("transmitted_to_files_missing", dir=str(staging_dir))
         return EdgeLoadResult("TRANSMITTED_TO", 0, 0, 0)
@@ -222,16 +247,15 @@ def _load_narrated(
     client: Neo4jClient,
     staging_dir: Path,
     *,
+    curated_dir: Path | None = None,
     strict: bool = True,
     batch_size: int = DEFAULT_BATCH_SIZE,
 ) -> EdgeLoadResult:
     """Load NARRATED edges — first narrator (position 0) in each chain -> hadith."""
-    files = _parquet_files(staging_dir, "narrator_mentions_resolved")
-    if not files:
-        files = _parquet_files(staging_dir, "narrator_mentions_")
+    files = _resolved_mentions_files(staging_dir, curated_dir)
     if not files:
         if strict:
-            msg = f"No narrator_mentions files in {staging_dir}"
+            msg = f"No narrator_mentions files in {curated_dir or staging_dir}"
             raise FileNotFoundError(msg)
         logger.warning("narrated_files_missing", dir=str(staging_dir))
         return EdgeLoadResult("NARRATED", 0, 0, 0)
@@ -718,7 +742,7 @@ def _load_graded_by(
 def load_all_edges(
     client: Neo4jClient,
     staging_dir: Path,
-    curated_dir: Path,  # noqa: ARG001
+    curated_dir: Path,
     *,
     strict: bool = True,
     batch_size: int = DEFAULT_BATCH_SIZE,
@@ -732,8 +756,10 @@ def load_all_edges(
     staging_dir:
         Directory containing staging Parquet files.
     curated_dir:
-        Directory containing curated reference data (unused for edges
-        currently but kept for API symmetry with ``load_all_nodes``).
+        Directory containing curated artifacts — notably
+        ``narrator_mentions_resolved.parquet`` (the canonical-id-bearing mentions
+        that ``resolve.run_all`` writes here, not to staging). The chain edges
+        (NARRATED / TRANSMITTED_TO) read it from here.
     strict:
         If ``True``, raise on missing required files. If ``False``,
         skip gracefully.
@@ -742,8 +768,16 @@ def load_all_edges(
     """
     results: list[EdgeLoadResult] = []
 
-    results.append(_load_transmitted_to(client, staging_dir, strict=strict, batch_size=batch_size))
-    results.append(_load_narrated(client, staging_dir, strict=strict, batch_size=batch_size))
+    results.append(
+        _load_transmitted_to(
+            client, staging_dir, curated_dir=curated_dir, strict=strict, batch_size=batch_size
+        )
+    )
+    results.append(
+        _load_narrated(
+            client, staging_dir, curated_dir=curated_dir, strict=strict, batch_size=batch_size
+        )
+    )
     results.append(_load_appears_in(client, staging_dir, strict=strict, batch_size=batch_size))
     results.append(_load_parallel_of(client, staging_dir, strict=strict, batch_size=batch_size))
     results.append(_load_studied_under(client, staging_dir, batch_size=batch_size))

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -192,6 +192,67 @@ class TestLoadNarrated:
         assert narrated_result.created == 1
 
 
+class TestChainEdgesReadResolvedFromCurated:
+    """Regression for da#141 / main#601 criterion #1 — NARRATED/TRANSMITTED_TO = 0.
+
+    ``resolve.run_all`` writes ``narrator_mentions_resolved.parquet`` (the only
+    mentions carrying ``canonical_narrator_id``, which both chain edges key on)
+    to the **curated** dir, not staging. ``load_all_edges`` used to glob staging
+    only, so on a real orchestrated load the chain edges silently fell back to
+    the raw, canonical-id-less staging mentions and created ZERO edges — exactly
+    the staging gap #601 found. These assert the loaders read the resolved file
+    from ``curated_dir`` even when staging holds no resolved mentions at all.
+    """
+
+    def _resolved_chain_rows(self) -> list[dict[str, object]]:
+        return [
+            {
+                "mention_id": "m1",
+                "hadith_id": "h1",
+                "position_in_chain": 0,
+                "canonical_narrator_id": "nar:1",
+            },
+            {
+                "mention_id": "m2",
+                "hadith_id": "h1",
+                "position_in_chain": 1,
+                "canonical_narrator_id": "nar:2",
+            },
+        ]
+
+    def test_transmitted_to_reads_resolved_from_curated(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        mock_client.set_read_results(
+            [{"from_id": "nar:1", "to_id": "nar:2", "from_exists": True, "to_exists": True}]
+        )
+        # Resolved mentions live in CURATED (the resolve-output dir); staging has none.
+        write_narrator_mentions_resolved(curated_dir, self._resolved_chain_rows())
+
+        results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        tt_result = next(r for r in results if r.edge_type == "TRANSMITTED_TO")
+        assert tt_result.created == 1, "TRANSMITTED_TO must read resolved mentions from curated_dir"
+
+    def test_narrated_reads_resolved_from_curated(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        mock_client.set_read_results(
+            [
+                {
+                    "narrator_id": "nar:1",
+                    "hadith_id": "hdt:h1",
+                    "narrator_exists": True,
+                    "hadith_exists": True,
+                }
+            ]
+        )
+        write_narrator_mentions_resolved(curated_dir, self._resolved_chain_rows())
+
+        results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        narrated_result = next(r for r in results if r.edge_type == "NARRATED")
+        assert narrated_result.created == 1, "NARRATED must read resolved mentions from curated_dir"
+
+
 class TestLoadAppearsIn:
     def test_hadith_to_collection_edges(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path


### PR DESCRIPTION
## What & why

The **data half** of `main#601` criterion #1 (da#141): produce + load the REAL narrator graph — `Narrator` + `NARRATED` + `STUDIED_UNDER` + `APPEARS_IN` + `TRANSMITTED_TO`, **both sects** — and fix the loader gap that left it empty on a real orchestrated load.

`#601` found staging held 47 Hadith + 47 `APPEARS_IN` and a **zero narrator graph** (0 Narrator / NARRATED / STUDIED_UNDER). This delivers the reproducible produce+load+verify path and the loader fix; the **live staging write is the gated `#601` run** the team-lead coordinates (pairs with ip#83 worker bring-up) — not done from this worktree.

## Changes

- **`scripts/narrator_graph/run.py`** — reproducible `acquire → parse → resolve.run_all → graph.load_all → verify` driver over REAL sources (successor to the da#73 first-light slice). Default set `muhaddithat` + `lk`: both sects, every narrator-graph edge type. Asserts the required non-zero node/edge types, a bio-only promoted narrator, and both sects.
- **fix `src/graph/load_edges.py`** — `load_all_edges` read `narrator_mentions_resolved.parquet` from **staging**, but `resolve.run_all` writes it to **curated**. The chain edges (`NARRATED` / `TRANSMITTED_TO`) silently fell back to the raw, canonical-id-less staging mentions → **0 edges** on a real orchestrated load (exactly the #601 gap; uncovered by tests because the lk light-up never runs resolve). Wire `curated_dir` into both loaders via `_resolved_mentions_files` (curated-resolved → staging-resolved → raw fallback).
- **test** — `TestChainEdgesReadResolvedFromCurated`: regression that writes resolved mentions to curated-only and asserts both chain edges load.
- **`docs/narrator-graph-load.md`** — produce/local-verify/**gated staging** runbook.

## Local verification (real data → `neo4j:5` container)

Produced from real sources (`muhaddithat` open GitHub CSV + `lk` LK-Hadith-Corpus), loaded into a local `neo4j:5`, **idempotent** on re-load (re-load created 0 new nodes/edges):

| Node / edge | Count |
|-------------|-------|
| `Narrator` | **47,199** — sunni 47,086 (`lk`, mention-derived) + neutral 113 (`muhaddithat`, **bio-only promoted**) |
| `STUDIED_UNDER` | **186** (0 missing endpoints) |
| `NARRATED` | **33,977** |
| `TRANSMITTED_TO` | **52,182** |
| `APPEARS_IN` | **33,981** — incl. **39 null in-book ordinal** (proves the ip#84/da#77 null-safe MERGE) |
| `GRADED_BY` | 33,478 |
| `Hadith` / `Collection` | 34,088 / 6 |

All 6 required invariants PASS (non-zero Narrator/STUDIED_UNDER/NARRATED/APPEARS_IN, bio-only promoted narrator present, both sects). `784 passed, 5 skipped` (non-integration); `ruff`/`mypy` clean.

## What the gated staging run needs

Run `scripts/narrator_graph/run.py` from inside the cluster (where `bolt://neo4j:7687` resolves) with the staging `NEO4J_PASSWORD`, per `docs/narrator-graph-load.md`. Acceptance: the same invariants, live on staging.

## Notes
- Produced parquet is gitignored (reproducible via the driver), per repo convention.
- The `lk` `mis`-style heavy sources / fuzzy-cluster runtime are noted in the doc; cluster is the da#118 recall pass and does not affect load correctness.

Closes #141
