### PR TITLE
fix(mis): parse current Mendeley v2 three-file graph export (#144)

### DIFF
--- a/src/acquire/mis.py
+++ b/src/acquire/mis.py
@@ -8,19 +8,24 @@ multi-isnad source for the platform: where most corpora give one chain per
 hadith, MIS preserves the parallel asanid (the ``ح`` / *tahwil* split) that make
 Sahih Muslim valuable for chain modelling.
 
-The dataset ships as two Excel workbooks under the Mendeley file set:
+The current dataset (v2) ships as **three** Excel workbooks under the Mendeley
+file set — a graph export (content + nodes + edges):
 
-* ``Hadith_SahihMuslim_CoreInfo.xlsx``               — one row per hadith
-  (book, hadith number, matn, narrator sequence, isnad count).
-* ``Hadith_SahihMuslim_DetailsInfo_Sanad_Narrators.xlsx`` — one row per
-  (hadith, sanad, narrator) position — the data the parser walks into per-sanad
-  chains.
+* ``1_Hadith_SahihMuslim_HadithContent.xlsx``         — one row per hadith
+  (``BookNo``, ``HadithNo``, matn, ``SanadCount``). The parser's "core" file.
+* ``2_Hadith_SahihMuslim_Narrators=Nodes for Graph.xlsx`` — narrator *node*
+  list (id ↔ name, generation, gender). Downloaded but not consumed for staging.
+* ``3_Hadith_SahihMuslim_Isnad=Edges for Graph.xlsx`` — one row per directed
+  transmission *edge* (``source*`` → ``target*`` narrator, keyed by
+  ``(BookNo, HadithNo, SanadNo)``). The parser's "detail" file.
 
-Reachability: ``data.mendeley.com`` serves the file set over HTTPS with **no
-auth / no API key** — the same keyless-public mechanism this repo already proves
-for ``sanadset`` (Mendeley ``5xth87zwb5``). The file ids are resolved at runtime
-from the dataset files API rather than hardcoded, so a new dataset version is
-picked up without a code change.
+We download every ``.xlsx`` in the file set, so all three arrive; the parser
+selects the content + edges workbooks by filename token. Reachability:
+``data.mendeley.com`` serves the file set over HTTPS with **no auth / no API
+key** — the same keyless-public mechanism this repo already proves for
+``sanadset`` (Mendeley ``5xth87zwb5``). The file ids are resolved at runtime from
+the dataset files API rather than hardcoded, so a new dataset version is picked
+up without a code change.
 
 Licensing: Mendeley Data's default license for this dataset is **CC BY 4.0**
 (attribution) — redistribution-safe with credit to the depositors.

--- a/src/parse/mis.py
+++ b/src/parse/mis.py
@@ -20,17 +20,28 @@ Two output files (both tagged ``sect=sunni`` / ``source_corpus=mis``):
 
 Input shape
 -----------
-Two Mendeley workbooks (``.xlsx``; ``.csv`` exports are also accepted for tests):
+Mendeley workbooks (``.xlsx``; ``.csv`` exports are also accepted for tests). The
+current dataset (DOI ``10.17632/gzprcr93zn.2``) ships a **three-file graph
+export** — the parser uses two of them:
 
-* **CoreInfo** — one row per hadith: a hadith number, an (optional) book number,
-  the matn text, and an (optional) narrator-sequence string.
-* **DetailsInfo (Sanad/Narrators)** — the per-position detail the chains are
-  walked from. Two layouts are supported:
-    - *sequence layout* (primary): ``(hadith, isnad/sanad, position, narrator)``
-      — grouped by ``(hadith, isnad)`` and walked into consecutive-pair edges, so
-      each sanad of a hadith becomes its own chain;
-    - *edge layout*: explicit ``(from_narrator, to_narrator[, hadith][, isnad])``
-      rows — each row is already one edge.
+* **HadithContent** (``1_Hadith_SahihMuslim_HadithContent.xlsx``) — one row per
+  hadith: ``HadithNo``, ``BookNo``, the matn (``HadithText_Mushakkal`` /
+  ``…_GhairMushakkal``), and per-hadith ``SanadCount``. This is the "core" file.
+* **Isnad=Edges** (``3_Hadith_SahihMuslim_Isnad=Edges for Graph.xlsx``, sheet
+  ``2-Relationship``) — one row per **edge**: a ``(BookNo, HadithNo, SanadNo)``
+  key plus ``sourceNarrator{ID,NameEn}`` → ``targetNarrator{ID,NameEn}``. Each
+  row is already one directed transmission edge; ``SanadNo`` discriminates the
+  parallel asanid, so the multi-isnad multiplicity survives row-for-row.
+* The third file (``2_…Narrators=Nodes for Graph.xlsx``) is a narrator *node*
+  list (id ↔ name) and is **not** consumed for staging — the edge file carries
+  the narrator names inline. The detail-file selector deliberately resolves to
+  the *Edges* workbook even though the *Nodes* filename also contains
+  "narrator".
+
+An older two-file layout (``CoreInfo`` + ``DetailsInfo_Sanad_Narrators`` in
+either a per-position *sequence* layout or an explicit *edge* layout) is still
+accepted — its filename tokens and column candidates are retained below so both
+the legacy and current dataset shapes parse.
 
 Column names are matched case/spacing/underscore-insensitively (the upstream
 spreadsheets are not perfectly normalized), with documented candidate sets.
@@ -62,7 +73,19 @@ COLLECTION_SLUG = "sahih_muslim"
 # --- column-name candidate sets (matched on the alnum-normalized header) -------
 _HADITH_NO_KEYS = ("hadithno", "hadithnumber", "hadithid", "hadith", "serialno", "sno", "no", "id")
 _BOOK_KEYS = ("bookno", "booknumber", "book", "bookname", "kitab")
-_MATN_KEYS = ("matn", "matntext", "matnarabic", "hadithtext", "text", "arabictext", "matnar")
+_MATN_KEYS = (
+    # current dataset (vocalized preferred, then un-vocalized)
+    "hadithtextmushakkal",
+    "hadithtextghairmushakkal",
+    # legacy / generic
+    "matn",
+    "matntext",
+    "matnarabic",
+    "hadithtext",
+    "text",
+    "arabictext",
+    "matnar",
+)
 _ISNAD_TEXT_KEYS = ("narratorsequence", "isnadtext", "sanadtext", "chain", "narrators")
 
 _SANAD_KEYS = (
@@ -100,6 +123,10 @@ _NARRATOR_NAME_KEYS = (
 )
 _NARRATOR_ID_KEYS = ("narratorid", "narratorno", "nid", "rawiid", "rawino", "rawi")
 _FROM_KEYS = (
+    # current dataset: explicit source/target narrator NAME columns
+    "sourcenarratornameen",
+    "sourcenarratorname",
+    # legacy / generic
     "fromnarrator",
     "sourcenarrator",
     "from",
@@ -108,14 +135,34 @@ _FROM_KEYS = (
     "teacher",
     "fromname",
 )
-_TO_KEYS = ("tonarrator", "targetnarrator", "to", "target", "successor", "student", "toname")
+_TO_KEYS = (
+    "targetnarratornameen",
+    "targetnarratorname",
+    "tonarrator",
+    "targetnarrator",
+    "to",
+    "target",
+    "successor",
+    "student",
+    "toname",
+)
+# External narrator-id columns for the explicit edge layout — kept distinct from
+# the name keys so the canonical ``from``/``to`` stays a name while the stable
+# numeric id flows into ``{from,to}_external_id`` for downstream disambiguation.
+_FROM_ID_KEYS = ("sourcenarratorid", "fromnarratorid", "fromid", "sourceid")
+_TO_ID_KEYS = ("targetnarratorid", "tonarratorid", "toid", "targetid")
 
 # Filename tokens (matched case-insensitively, in priority order) that identify
 # each workbook. CoreInfo never contains a DetailsInfo token and vice versa, so
 # the two selections never collide.
 _DATA_SUFFIXES = (".xlsx", ".xls", ".csv")
-_CORE_TOKENS = ("coreinfo", "core")
-_DETAIL_TOKENS = ("detailsinfo", "sanad", "narrator", "details")
+# Current dataset: core = "…HadithContent…"; detail = "…Isnad=Edges…". Legacy:
+# core = "…CoreInfo…"; detail = "…DetailsInfo_Sanad_Narrators…". The detail
+# tokens put "edges"/"isnad" ahead of "narrator" so the current file set resolves
+# to the *Edges* workbook and never to the *Narrators=Nodes* node list (which
+# also contains "narrator").
+_CORE_TOKENS = ("coreinfo", "hadithcontent", "content", "core")
+_DETAIL_TOKENS = ("isnadedges", "edges", "isnad", "detailsinfo", "sanad", "narrator", "details")
 
 
 def _norm_header(value: Any) -> str:
@@ -356,6 +403,8 @@ def _parse_edges_explicit(
     """
     hadith_col = _pick(keys, _HADITH_NO_KEYS)
     sanad_col = _pick(keys, _SANAD_KEYS)
+    from_id_col = _pick(keys, _FROM_ID_KEYS)
+    to_id_col = _pick(keys, _TO_ID_KEYS)
 
     edges: list[dict[str, str | None]] = []
     seen_isnads: dict[str, set[str]] = defaultdict(set)
@@ -367,7 +416,14 @@ def _parse_edges_explicit(
         if hadith_no:
             sanad_no = (safe_str(row.get(sanad_col)) if sanad_col else None) or str(idx)
             seen_isnads[hadith_no].add(sanad_no)
-        _emit_edge(edges, safe_str(row.get(from_col)), safe_str(row.get(to_col)), hadith_id)
+        _emit_edge(
+            edges,
+            safe_str(row.get(from_col)),
+            safe_str(row.get(to_col)),
+            hadith_id,
+            from_id=safe_str(row.get(from_id_col)) if from_id_col else None,
+            to_id=safe_str(row.get(to_id_col)) if to_id_col else None,
+        )
 
     isnad_counts = {hadith_no: len(sanads) for hadith_no, sanads in seen_isnads.items()}
     return edges, isnad_counts

--- a/tests/test_parse/test_mis_parser.py
+++ b/tests/test_parse/test_mis_parser.py
@@ -177,6 +177,154 @@ class TestMisEdgeLayout:
         ]
 
 
+def _make_current_mendeley_data(raw_dir: Path) -> None:
+    """The **current** Mendeley v2 three-file graph export (da#144).
+
+    Mirrors the real dataset shape:
+      * ``1_…HadithContent.xlsx``        — core hadith rows (HadithContent cols).
+      * ``2_…Narrators=Nodes for Graph.xlsx`` — narrator NODE list (decoy: its
+        filename contains "narrator", so it must NOT be picked as the detail file).
+      * ``3_…Isnad=Edges for Graph.xlsx`` — explicit ``source*``/``target*`` edge
+        rows keyed by ``(BookNo, HadithNo, SanadNo)``.
+
+    Hadith 1 carries TWO sanads (1, 2) that share endpoints but diverge in the
+    middle; hadith 2 a single sanad. The chain-specific edges only survive if the
+    parallel asanid are kept apart.
+    """
+    mis_dir = raw_dir / "mis"
+    mis_dir.mkdir(parents=True)
+
+    _write_xlsx(
+        mis_dir / "1_Hadith_SahihMuslim_HadithContent.xlsx",
+        [
+            "BookNo",
+            "BookTitleEnAr",
+            "HadithNo",
+            "ChapterNo",
+            "UnitNo",
+            "HadithText_Mushakkal",
+            "HadithText_GhairMushakkal",
+            "SanadCount",
+        ],
+        [
+            [2, "Sahih Muslim", 1, 1, 1, "مَتْنٌ مُشَكَّل", "متن", 2],
+            [2, "Sahih Muslim", 2, 1, 2, "مَتْنٌ ثَانٍ", "متن ثان", 1],
+        ],
+    )
+
+    # Decoy node list — filename contains "narrator" but is NOT the edge file.
+    _write_xlsx(
+        mis_dir / "2_Hadith_SahihMuslim_Narrators=Nodes for Graph.xlsx",
+        ["Label", "NarratorID_Mapped", "NarratorNameEn-Mapped"],
+        [["A (0)", 1, "A"], ["B (0)", 2, "B"]],
+    )
+
+    # (BookNo, HadithNo, SanadNo, sourceNarratorID, sourceNarratorNameEn,
+    #  targetNarratorID, targetNarratorNameEn)
+    edge_rows: list[list[object]] = [
+        # hadith 1, sanad 1: A -> B -> C
+        [2, 1, 1, 10, "A", 11, "B"],
+        [2, 1, 1, 11, "B", 12, "C"],
+        # hadith 1, sanad 2: A -> D -> C  (chain-specific A->D, D->C)
+        [2, 1, 2, 10, "A", 13, "D"],
+        [2, 1, 2, 13, "D", 12, "C"],
+        # hadith 2, single sanad: X -> Y
+        [2, 2, 1, 20, "X", 21, "Y"],
+    ]
+    _write_xlsx(
+        mis_dir / "3_Hadith_SahihMuslim_Isnad=Edges for Graph.xlsx",
+        [
+            "BookNo",
+            "HadithNo",
+            "SanadNo",
+            "sourceNarratorID",
+            "sourceNarratorNameEn",
+            "targetNarratorID",
+            "targetNarratorNameEn",
+        ],
+        edge_rows,
+    )
+
+
+class TestMisCurrentMendeleyShape:
+    """da#144 — parse the current three-file Mendeley graph export."""
+
+    def test_selects_content_and_edges_not_nodes(self, tmp_path: Path) -> None:
+        """The detail file resolves to the *Edges* workbook, never the *Nodes* one."""
+        from src.parse.mis import _CORE_TOKENS, _DETAIL_TOKENS, _find_file
+
+        _make_current_mendeley_data(tmp_path / "raw")
+        mis_dir = tmp_path / "raw" / "mis"
+        core = _find_file(mis_dir, _CORE_TOKENS)
+        detail = _find_file(mis_dir, _DETAIL_TOKENS)
+        assert core is not None and "HadithContent" in core.name
+        assert detail is not None and "Edges" in detail.name
+        assert "Nodes" not in detail.name  # the decoy must lose
+
+    def test_hadith_schema_matn_and_tagging(self, tmp_path: Path) -> None:
+        _make_current_mendeley_data(tmp_path / "raw")
+        hadiths_path, _ = run(tmp_path / "raw", tmp_path / "staging")
+
+        table = pq.read_table(hadiths_path)
+        assert table.schema == HADITH_SCHEMA
+        assert table.num_rows == 2
+        assert set(table.column("source_corpus").to_pylist()) == {"mis"}
+        assert set(table.column("sect").to_pylist()) == {"sunni"}
+        # The vocalized HadithText_Mushakkal column feeds matn_ar.
+        assert table.column("matn_ar").to_pylist() == ["مَتْنٌ مُشَكَّل", "مَتْنٌ ثَانٍ"]
+        for sid in table.column("source_id").to_pylist():
+            assert validate_source_id(sid) == [], sid
+            assert sid.startswith("mis:sahih_muslim:")
+        # BookNo flows into the source_id grammar.
+        assert "mis:sahih_muslim:2:1" in table.column("source_id").to_pylist()
+
+    def test_edge_schema_relation_and_external_ids(self, tmp_path: Path) -> None:
+        _make_current_mendeley_data(tmp_path / "raw")
+        _, edges_path = run(tmp_path / "raw", tmp_path / "staging")
+
+        table = pq.read_table(edges_path)
+        assert table.schema == NETWORK_EDGE_SCHEMA
+        assert set(table.column("source").to_pylist()) == {"mis"}
+        # isnad-transmission edges → TRANSMITTED_TO, never STUDIED_UNDER (da#133).
+        assert set(table.column("relation").to_pylist()) == {"TRANSMITTED_TO"}
+        # The source/target narrator IDs flow into the external-id columns.
+        assert all(v is not None for v in table.column("from_external_id").to_pylist())
+        assert all(v is not None for v in table.column("to_external_id").to_pylist())
+        ab = next(
+            r
+            for r in table.to_pylist()
+            if r["from_narrator_name"] == "A" and r["to_narrator_name"] == "B"
+        )
+        assert ab["from_external_id"] == "10"
+        assert ab["to_external_id"] == "11"
+
+    def test_multiplicity_preserved_across_sanads(self, tmp_path: Path) -> None:
+        """Hadith 1's two sanads survive as distinct chains (A->D, D->C exist)."""
+        _make_current_mendeley_data(tmp_path / "raw")
+        _, edges_path = run(tmp_path / "raw", tmp_path / "staging")
+        rows = pq.read_table(edges_path).to_pylist()
+
+        # 2 (sanad 1) + 2 (sanad 2) + 1 (hadith 2) = 5 edges.
+        assert len(rows) == 5
+        h1_id = "mis:sahih_muslim:2:1"
+        h1_pairs = {
+            (r["from_narrator_name"], r["to_narrator_name"])
+            for r in rows
+            if r["hadith_id"] == h1_id
+        }
+        assert h1_pairs == {("A", "B"), ("B", "C"), ("A", "D"), ("D", "C")}
+        # Chain-specific edges that only exist because the asanid were not collapsed.
+        assert ("A", "D") in h1_pairs
+        assert ("D", "C") in h1_pairs
+
+    def test_edges_join_to_hadith_source_id(self, tmp_path: Path) -> None:
+        _make_current_mendeley_data(tmp_path / "raw")
+        hadiths_path, edges_path = run(tmp_path / "raw", tmp_path / "staging")
+        hadith_ids = set(pq.read_table(hadiths_path).column("source_id").to_pylist())
+        edge_hadith_ids = set(pq.read_table(edges_path).column("hadith_id").to_pylist())
+        assert edge_hadith_ids <= hadith_ids
+
+
 class TestMisErrors:
     def test_missing_source_dir_raises(self, tmp_path: Path) -> None:
         (tmp_path / "raw").mkdir()


### PR DESCRIPTION
Closes #144

## Problem
The upstream Multi-IsnadSet dataset (Mendeley DOI `10.17632/gzprcr93zn.2`) was restructured into a **three-file graph export**, breaking the `mis` adapter, which assumed the old two-file `CoreInfo` + `DetailsInfo_Sanad_Narrators` layout. The current file set is:

| file | role |
|------|------|
| `1_Hadith_SahihMuslim_HadithContent.xlsx` | core hadith rows |
| `2_Hadith_SahihMuslim_Narrators=Nodes for Graph.xlsx` | narrator node list (not consumed) |
| `3_Hadith_SahihMuslim_Isnad=Edges for Graph.xlsx` | explicit edge rows |

Three independent drift points each broke the parse:
1. **Core file unmatched** — `1_…HadithContent.xlsx` contains no `core` token, so `_find_file` raised `FileNotFoundError` before any parse.
2. **Wrong detail file** — the *Nodes* filename contains `narrator`, so the detail selector picked the node list instead of the *Edges* file.
3. **Unresolved edge columns** — columns are now `sourceNarratorNameEn`/`targetNarratorNameEn` (+ ID variants); the exact-match picker resolved neither, collapsing to the sequence layout and erroring.

## Fix
- Added `hadithcontent`/`content` core tokens and `edges`/`isnad` detail tokens **ahead of** `narrator`, so content + edges workbooks are selected and the node list is ignored.
- Added `source/target NarratorNameEn` name candidates, plus a new from/to external-id pair so the numeric narrator IDs flow into `{from,to}_external_id` for downstream disambiguation.
- Matn now reads from the vocalized `HadithText_Mushakkal` column.
- Updated both acquire + parse docstrings to the real current shape.

`mis` stays an **isnad-transmission** producer: every edge declares `TRANSMITTED_TO`, keeping it off the `STUDIED_UNDER` allowlist (da#133). `SanadNo` discriminates the parallel asanid, so multi-isnad multiplicity is preserved row-for-row. The legacy two-file layout still parses (tokens/candidates retained, its tests still green).

## Test Plan
- **Live trace** against the real downloaded v2 dataset: **7748 hadiths, 63642 edges, 3586 multi-isnad hadiths** (max 24 asanid/hadith); `source_corpus=mis`, `sect=sunni`, `relation` all `TRANSMITTED_TO`, every edge `hadith_id` joins to a hadith node, all `from/to_external_id` populated. Sample `source_id`: `mis:sahih_muslim:2:1`.
- **Unit tests** (`tests/test_parse/test_mis_parser.py`, new `TestMisCurrentMendeleyShape`): fixtures built in the real three-file shape (including the `Nodes` decoy) assert detail resolves to the *Edges* file (not *Nodes*), schema/tagging, matn from `HadithText_Mushakkal`, `TRANSMITTED_TO`, external IDs, multi-sanad multiplicity, and edge→hadith join. The fixture columns/filenames were taken directly from the live dataset headers.
- `ruff format --check` + `ruff check` (v0.15.11) clean; `mypy` clean on changed files; full `tests/test_parse/` (247) + `tests/test_acquire/test_mis.py` + `tests/integration/test_mis_lightup.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
