### PR TITLE
fix(graph): da#148 integrity sweep — TRANSMITTED_TO self-loops + normalized grade display

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -120,10 +120,27 @@ def _build_chain_pairs(
     resolved = [m for m in sorted_mentions if m.get("canonical_narrator_id")]
     pairs: list[dict[str, Any]] = []
     for i in range(len(resolved) - 1):
+        from_id = resolved[i]["canonical_narrator_id"]
+        to_id = resolved[i + 1]["canonical_narrator_id"]
+        # Drop self-loops: two ADJACENT mentions that resolve to the same
+        # canonical narrator (a repeated narrator in the raw chain, or two
+        # mentions the disambiguator collapsed onto one node) would otherwise
+        # MERGE a TRANSMITTED_TO edge from a narrator to itself (da#148 — 8 live
+        # self-loops). The network-edge producers already guard this
+        # (``muhaddithat._parse_network_edges`` skips ``from_id == to_id``,
+        # ``mis`` skips ``from_name == to_name``); applying it on the
+        # chain-derived path keeps a re-load self-loop-free everywhere.
+        if from_id == to_id:
+            logger.debug(
+                "transmitted_to_self_loop_skipped",
+                narrator_id=from_id,
+                hadith_id=resolved[i].get("hadith_id", ""),
+            )
+            continue
         pairs.append(
             {
-                "from_id": resolved[i]["canonical_narrator_id"],
-                "to_id": resolved[i + 1]["canonical_narrator_id"],
+                "from_id": from_id,
+                "to_id": to_id,
                 "position": resolved[i].get("position_in_chain", i),
                 "hadith_id": resolved[i].get("hadith_id", ""),
             }

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -40,6 +40,7 @@ from src.parse.identity import (
     grading_node_id,
     hadith_node_id,
 )
+from src.utils.grade import normalize_grade
 from src.utils.logging import get_logger
 from src.utils.neo4j_client import Neo4jClient
 
@@ -202,6 +203,7 @@ SET n.matn_ar      = row.matn_ar,
     n.isnad_raw_ar = row.isnad_raw_ar,
     n.isnad_raw_en = row.isnad_raw_en,
     n.grade        = row.grade,
+    n.grade_normalized = row.grade_normalized,
     n.source_corpus = row.source_corpus,
     n.sect         = row.sect,
     n.collection_name = row.collection_name
@@ -247,6 +249,10 @@ def _load_hadiths(
                     "isnad_raw_ar": _val(row, "isnad_raw_ar"),
                     "isnad_raw_en": _val(row, "isnad_raw_en"),
                     "grade": _val(row, "grade"),
+                    # Normalized display grade alongside the verbatim raw value: a
+                    # corpus may store the grade as raw Arabic / mixed script,
+                    # which is not a stable key to filter or display on (da#148).
+                    "grade_normalized": normalize_grade(_val(row, "grade")),
                     "source_corpus": _val(row, "source_corpus", ""),
                     "sect": _val(row, "sect", ""),
                     "collection_name": _val(row, "collection_name", ""),
@@ -440,6 +446,7 @@ MERGE (n:Grading {id: row.id})
 SET n.hadith_id          = row.hadith_id,
     n.scholar_name       = row.scholar_name,
     n.grade              = row.grade,
+    n.grade_normalized   = row.grade_normalized,
     n.methodology_school = row.methodology_school,
     n.era                = row.era
 """
@@ -488,6 +495,10 @@ def _load_gradings(
                     "hadith_id": hadith_node_id(sid),
                     "scholar_name": _val(row, "collection_name", "unknown"),
                     "grade": grade,
+                    # Normalized display grade (da#148): the raw ``grade`` may be
+                    # Arabic / mixed-script free text; map it onto the HadithGrade
+                    # vocabulary so the UI and queries have a stable key.
+                    "grade_normalized": normalize_grade(grade),
                     "methodology_school": None,
                     "era": None,
                 }

--- a/src/utils/grade.py
+++ b/src/utils/grade.py
@@ -1,0 +1,63 @@
+"""Hadith authenticity-grade normalization.
+
+Source corpora record a hadith's grade as free text in whatever script the
+upstream used: Arabic (``صحيح``), transliterated English (``Sahih``,
+``Da'if``), or descriptive English (``authentic``, ``weak``). The graph stores
+that raw string verbatim so the original is never lost, but a raw Arabic /
+mixed-script value is not a stable key to filter, facet, or display on. This
+module maps any of those raw forms onto the canonical :class:`HadithGrade`
+vocabulary so a normalized *display* field can sit alongside the raw one
+(da#148 integrity sweep — "grade stored as raw Arabic, needs normalized
+display").
+
+The function is deliberately conservative: anything it does not recognise maps
+to :data:`HadithGrade.UNKNOWN` rather than guessing, so a normalized value is
+always a real enum member.
+"""
+
+from __future__ import annotations
+
+from src.models.enums import HadithGrade
+from src.utils.arabic import normalize_arabic
+
+__all__ = ["normalize_grade"]
+
+# Match order matters: the ``li-ghayrihi`` ("…by virtue of corroboration")
+# qualifiers are checked before the bare grade so ``صحيح لغيره`` does not match
+# the plain ``sahih`` rule first. Each entry is ``(needles, grade)`` — the raw
+# value matches if ANY needle is a substring of the normalized text. Arabic
+# needles are pre-normalized with :func:`normalize_arabic` (the same pipeline
+# applied to the input) so diacritics/alif/taa-marbuta variants all collapse.
+_GRADE_RULES: list[tuple[tuple[str, ...], HadithGrade]] = [
+    (
+        (normalize_arabic("صحيح لغيره"), "sahih li ghayrihi", "sahih li-ghayrihi"),
+        HadithGrade.SAHIH_LI_GHAYRIHI,
+    ),
+    (
+        (normalize_arabic("حسن لغيره"), "hasan li ghayrihi", "hasan li-ghayrihi"),
+        HadithGrade.HASAN_LI_GHAYRIHI,
+    ),
+    ((normalize_arabic("موضوع"), "mawdu", "fabricat"), HadithGrade.MAWDU),
+    ((normalize_arabic("ضعيف"), "daif", "da'if", "weak"), HadithGrade.DAIF),
+    ((normalize_arabic("صحيح"), "sahih", "authentic"), HadithGrade.SAHIH),
+    ((normalize_arabic("حسن"), "hasan", "good"), HadithGrade.HASAN),
+]
+
+
+def normalize_grade(raw: str | None) -> str:
+    """Map a raw grade string (Arabic or English, any corpus) to a HadithGrade.
+
+    Returns the :class:`HadithGrade` *value* (a ``str``) so it can be written
+    straight onto a node property. An empty / non-string / unrecognised value
+    yields :data:`HadithGrade.UNKNOWN` — the raw field still carries the
+    original, so nothing is lost.
+    """
+    if not raw or not isinstance(raw, str):
+        return HadithGrade.UNKNOWN.value
+    # Normalize the Arabic side and lowercase the Latin side so one pass of
+    # substring checks covers both scripts.
+    text = normalize_arabic(raw).lower()
+    for needles, grade in _GRADE_RULES:
+        if any(needle and needle in text for needle in needles):
+            return grade.value
+    return HadithGrade.UNKNOWN.value

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -91,6 +91,20 @@ class TestBuildChainPairs:
         assert pairs[1]["from_id"] == "nar:2"
         assert pairs[1]["to_id"] == "nar:3"
 
+    def test_adjacent_duplicate_narrator_skipped(self) -> None:
+        # Two adjacent mentions resolving to the same narrator must not produce a
+        # self-loop TRANSMITTED_TO edge (da#148 — 8 live self-loops).
+        mentions = [
+            {"canonical_narrator_id": "nar:1", "position_in_chain": 0, "hadith_id": "h1"},
+            {"canonical_narrator_id": "nar:1", "position_in_chain": 1, "hadith_id": "h1"},
+            {"canonical_narrator_id": "nar:2", "position_in_chain": 2, "hadith_id": "h1"},
+        ]
+        pairs = _build_chain_pairs(mentions)
+        # nar:1->nar:1 dropped; only nar:1->nar:2 survives.
+        assert len(pairs) == 1
+        assert pairs[0] == {"from_id": "nar:1", "to_id": "nar:2", "position": 1, "hadith_id": "h1"}
+        assert all(p["from_id"] != p["to_id"] for p in pairs)
+
 
 class TestLoadTransmittedTo:
     def test_creates_edges_from_resolved_mentions(

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -334,6 +334,32 @@ class TestLoadGradings:
         assert grading_result.node_type == "Grading"
         assert grading_result.created + grading_result.merged == 2
 
+    def test_grading_carries_normalized_display_grade(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """Raw Arabic grade is preserved and a normalized display grade added (da#148)."""
+        write_hadiths(
+            staging_dir,
+            [
+                {"source_id": "h-1", "grade": "صحيح"},  # raw Arabic
+                {"source_id": "h-2", "grade": "Da'if"},
+            ],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        grading_batches = [
+            batch
+            for _query, batch in mock_client.calls
+            if isinstance(batch, list)
+            and batch
+            and "id" in batch[0]
+            and batch[0]["id"].startswith("grd:")
+        ]
+        assert len(grading_batches) >= 1
+        by_hadith = {r["hadith_id"]: r for r in grading_batches[0]}
+        assert by_hadith["hdt:h-1"]["grade"] == "صحيح"  # raw preserved
+        assert by_hadith["hdt:h-1"]["grade_normalized"] == "sahih"
+        assert by_hadith["hdt:h-2"]["grade_normalized"] == "daif"
+
 
 class TestLoadHistoricalEvents:
     def test_valid_events(

--- a/tests/test_utils/test_grade.py
+++ b/tests/test_utils/test_grade.py
@@ -1,0 +1,48 @@
+"""Tests for src.utils.grade — raw grade -> HadithGrade normalization (da#148)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models.enums import HadithGrade
+from src.utils.grade import normalize_grade
+
+
+class TestNormalizeGrade:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # Arabic forms (with and without diacritics).
+            ("صحيح", HadithGrade.SAHIH.value),
+            ("صَحِيح", HadithGrade.SAHIH.value),
+            ("حسن", HadithGrade.HASAN.value),
+            ("ضعيف", HadithGrade.DAIF.value),
+            ("موضوع", HadithGrade.MAWDU.value),
+            ("صحيح لغيره", HadithGrade.SAHIH_LI_GHAYRIHI.value),
+            ("حسن لغيره", HadithGrade.HASAN_LI_GHAYRIHI.value),
+            # English / transliterated forms.
+            ("Sahih", HadithGrade.SAHIH.value),
+            ("HASAN", HadithGrade.HASAN.value),
+            ("Da'if", HadithGrade.DAIF.value),
+            ("Daif", HadithGrade.DAIF.value),
+            ("weak", HadithGrade.DAIF.value),
+            ("authentic", HadithGrade.SAHIH.value),
+            ("fabricated", HadithGrade.MAWDU.value),
+            ("Sahih li ghayrihi", HadithGrade.SAHIH_LI_GHAYRIHI.value),
+        ],
+    )
+    def test_known_grades(self, raw: str, expected: str) -> None:
+        assert normalize_grade(raw) == expected
+
+    @pytest.mark.parametrize("raw", [None, "", "   ", "no-clear-grade", 42])
+    def test_unknown_or_empty_maps_to_unknown(self, raw: object) -> None:
+        assert normalize_grade(raw) == HadithGrade.UNKNOWN.value  # type: ignore[arg-type]
+
+    def test_li_ghayrihi_wins_over_bare_grade(self) -> None:
+        # The qualified form must not be matched as the bare grade first.
+        assert normalize_grade("صحيح لغيره") == HadithGrade.SAHIH_LI_GHAYRIHI.value
+        assert normalize_grade("حسن لغيره") == HadithGrade.HASAN_LI_GHAYRIHI.value
+
+    def test_return_value_is_always_a_valid_enum_member(self) -> None:
+        for raw in ["صحيح", "weak", "garbage", "", None]:
+            assert normalize_grade(raw) in {g.value for g in HadithGrade}  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Producer/load-layer fixes from the da#148 graph-integrity sweep. Scoped to the
items with a clean, testable producer fix so a re-load stays clean (not one-off
DB pokes). Broader, data-decision items are split into a tracked follow-up
below.

Addresses #148.

## What shipped

**Finding #3 — TRANSMITTED_TO self-loops (8 live `a→a`).**
`_build_chain_pairs` (the chain-derived TRANSMITTED_TO producer) now drops a
pair whose two **adjacent** mentions resolve to the same canonical narrator (a
repeated narrator in the raw chain, or two mentions the disambiguator collapsed
onto one node). This mirrors the guard the network-edge producers already apply
(`muhaddithat._parse_network_edges` skips `from_id == to_id`; `mis` skips
`from_name == to_name`) — the chain path was the one place missing it.

**Grade raw-Arabic → normalized display field.**
New `src/utils/grade.normalize_grade()` maps a raw grade string (Arabic
`صحيح`, transliterated `Da'if`, or descriptive `weak`) onto the `HadithGrade`
vocabulary. The **Grading** and **Hadith** node loaders now write a
`grade_normalized` property *alongside* the verbatim `grade`, so the UI and
Cypher filters get a stable key while the original is never lost. Unrecognised
input maps to `unknown` rather than guessing.

## Investigated — not a producer bug

**Finding #5 — 15 `lk`-involved STUDIED_UNDER edges.** The issue suspected an
isnad-transmission producer leaking into the studentship relation. There is **no
`lk` network-edges producer**: only `muhaddithat`/`itqan` emit STUDIED_UNDER
(they declare `relation=STUDIED_UNDER`) and `mis` emits TRANSMITTED_TO. The 15
edges are genuine `muhaddithat`/`itqan` studentship edges whose endpoints
**name-resolve** (`make_canonical_id(normalize_arabic(name))`) onto narrators
also present in the `lk` corpus — correct cross-corpus identity merge, not a
relation leak. No producer change needed; recorded here so the follow-up does
not re-investigate.

## Test Plan

- `tests/test_utils/test_grade.py` — `normalize_grade` table: Arabic (±
  diacritics) + English/transliterated forms, `li-ghayrihi` precedence over the
  bare grade, empty/None/garbage → `unknown`, result always a valid enum member.
- `tests/test_graph/test_load_edges.py::...::test_adjacent_duplicate_narrator_skipped`
  — adjacent duplicate narrator drops the self-loop, surviving pair intact, no
  `from==to` pairs emitted.
- `tests/test_graph/test_load_nodes.py::...::test_grading_carries_normalized_display_grade`
  — Grading node keeps raw `صحيح` and adds `grade_normalized == "sahih"`;
  `Da'if → daif`.
- Full suite green under the pre-push hook: `ENVIRONMENT=test uv run pytest
  tests/ -m "not integration"` → 808 passed, 5 skipped. ruff (check+format) and
  mypy-strict clean on changed files.

## Follow-up

Filing/needs a tracked issue (deferred — each needs a data decision or upstream
producer work, not a clean load-layer fix):

- **#1 — 86 null `hadith_number_in_book`.** The in-book ordinal is null for
  scraped sources that only carry the collection-wide ref (cf. the
  `hadith_number` collection-ref-vs-in-book-ordinal split). Needs per-scraper
  ordinal derivation where available + an explicit-null contract where genuinely
  unknown. Not safe to fabricate at the load layer.
- **#2 — 51 Hadith with no NARRATED.** Mention/NER coverage gap upstream of the
  load layer (no resolved chain → no position-0 narrator → no NARRATED). Needs
  producer-side mention extraction, not a load guard.
- **#4 — 8 orphan `muhaddithat` bio-only narrators** (Abu Bakr, Fāṭimah, …).
  Owner decision: link (mention-linking) or drop. Expected artifact of
  bio-promotion without mention-linking.
- **Grade normalization parity:** the ingest-platform streaming path
  (`workers/ingest`) does not yet emit `grade_normalized`; a cross-repo parity
  follow-up should mirror this so batch and stream converge.
- **Collection metadata gap** (blank Arabic name / riyadussalihin) — data
  enrichment, separate from these load-layer fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
