### PR TITLE
fix(da#146): segment voweled lk isnad chains into per-narrator mentions

### DIFF
--- a/src/parse/narrator_extraction.py
+++ b/src/parse/narrator_extraction.py
@@ -20,8 +20,10 @@ _EN_DELIMITERS: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
-# Trailing punctuation to strip from extracted names.
-_TRAILING_PUNCT_RE: re.Pattern[str] = re.compile(r"[.,;:!?()]+$")
+# Trailing punctuation to strip from extracted names. Includes the Arabic comma
+# (، U+060C) and semicolon (؛ U+061B), which routinely terminate a narrator span
+# in voweled isnads (da#146) and would otherwise pollute the exact-match key.
+_TRAILING_PUNCT_RE: re.Pattern[str] = re.compile(r"[.,;:!?()،؛\s]+$")
 
 
 @dataclass(frozen=True)

--- a/src/utils/arabic.py
+++ b/src/utils/arabic.py
@@ -48,15 +48,55 @@ _ARABIC_CHAR_RE: re.Pattern[str] = re.compile(r"[\u0600-\u06FF]")
 # Transmission phrase patterns
 # ---------------------------------------------------------------------------
 
+# Optional run of Arabic diacritics (tashkeel U+064B–U+065F, superscript alef
+# U+0670) and tatweel/kashida (U+0640). Real isnad text is fully voweled
+# (e.g. ``حَدَّثَنَا``), so a bare keyword like ``حدثنا`` will never match unless
+# we tolerate diacritics interleaved *between* the base letters. Without this
+# the extractor found zero transmission phrases on every voweled chain and fell
+# back to emitting the whole isnad as a single un-segmented "narrator" (da#146).
+_OPT_DIAC: str = r"[\u064b-\u065f\u0670\u0640]*"
+
+# Base transmission terms keyed to their canonical label. Written with the
+# classical hamza-bearing forms (أ/إ) so they match raw, un-normalized isnad
+# text; positions returned therefore index into the caller's original string.
+# Singular (-ني) and 3rd-person (سمع) variants are included alongside the plural
+# (-نا) forms because real chains alternate between them ("حدثني" / "أخبرني" /
+# "سمع فلانٌ") — omitting them under-segments the chain (da#146).
+_TRANSMISSION_TERMS: dict[str, str] = {
+    "حدثنا": "haddathana",
+    "حدثني": "haddathani",
+    "أخبرنا": "akhbarana",
+    "أخبرني": "akhbarani",
+    "أنبأنا": "anba_ana",
+    "أنبأني": "anba_ani",
+    "سمعت": "samitu",
+    "سمع": "samia",
+    "عن": "an",
+    "قال": "qala",
+    "ناولني": "nawalani",
+    "كتب إلي": "kataba_ilayya",
+}
+
+
+def _compile_diacritic_tolerant(term: str) -> re.Pattern[str]:
+    """Compile *term* into a regex that tolerates interleaved diacritics.
+
+    Each base letter is followed by an optional diacritics/tatweel run, and
+    inter-word whitespace is matched flexibly. The compiled pattern matches the
+    fully-voweled form found in real isnads while preserving match positions in
+    the original (un-normalized) text.
+    """
+    parts: list[str] = []
+    for ch in term:
+        if ch.isspace():
+            parts.append(r"\s+")
+        else:
+            parts.append(re.escape(ch) + _OPT_DIAC)
+    return re.compile("".join(parts))
+
+
 TRANSMISSION_PATTERNS: dict[re.Pattern[str], str] = {
-    re.compile(r"حدثنا"): "haddathana",
-    re.compile(r"أخبرنا"): "akhbarana",
-    re.compile(r"سمعت"): "samitu",
-    re.compile(r"عن"): "an",
-    re.compile(r"قال"): "qala",
-    re.compile(r"أنبأنا"): "anba_ana",
-    re.compile(r"ناولني"): "nawalani",
-    re.compile(r"كتب\s+إلي"): "kataba_ilayya",
+    _compile_diacritic_tolerant(term): label for term, label in _TRANSMISSION_TERMS.items()
 }
 
 # ---------------------------------------------------------------------------
@@ -118,12 +158,27 @@ def extract_transmission_phrases(text: str) -> list[tuple[int, int, str]]:
     """Find transmission formula positions in *text*.
 
     Returns a list of ``(start, end, label)`` tuples for each non-overlapping
-    match found via :data:`TRANSMISSION_PATTERNS`.
+    match found via :data:`TRANSMISSION_PATTERNS`, in ascending start order.
+
+    Overlapping matches are resolved by preferring the longer (more specific)
+    term: e.g. where both ``سمعت`` (samitu) and the bare ``سمع`` (samia) match at
+    the same position, only ``سمعت`` is kept. This keeps segment boundaries in
+    :func:`src.parse.narrator_extraction._extract_arabic` clean when overlapping
+    variants are present in the pattern set.
     """
-    results: list[tuple[int, int, str]] = []
+    matches: list[tuple[int, int, str]] = []
     for pattern, label in TRANSMISSION_PATTERNS.items():
         for match in pattern.finditer(text):
-            results.append((match.start(), match.end(), label))
-    # Sort by start position for deterministic output
-    results.sort(key=lambda t: t[0])
+            matches.append((match.start(), match.end(), label))
+
+    # Sort by start asc, then by span length desc so that at any shared start the
+    # longer match is considered first and shorter overlapping ones are dropped.
+    matches.sort(key=lambda t: (t[0], -(t[1] - t[0])))
+
+    results: list[tuple[int, int, str]] = []
+    last_end = -1
+    for start, end, label in matches:
+        if start >= last_end:
+            results.append((start, end, label))
+            last_end = end
     return results

--- a/tests/test_parse/test_narrator_extraction.py
+++ b/tests/test_parse/test_narrator_extraction.py
@@ -59,6 +59,51 @@ class TestArabicExtraction:
         assert len(spans) >= 1
 
 
+class TestDa146VoweledSegmentation:
+    """Regression tests for da#146: fully-voweled (diacritized) Arabic isnads.
+
+    Real lk-corpus chains are fully voweled (``حَدَّثَنَا ...``). Before da#146 the
+    diacritic-free transmission patterns never matched, so the whole chain
+    collapsed into a single un-segmented "narrator" mention. These tests pin the
+    fixed behaviour: a voweled chain splits into one mention per narrator.
+    """
+
+    # Sahih al-Bukhari hadith 1 isnad — five named narrators in the chain.
+    _BUKHARI_H1_ISNAD = (
+        "حَدَّثَنَا الْحُمَيْدِيُّ عَبْدُاللَّهِ بْنُ الزُّبَيْرِ، قَالَ حَدَّثَنَا "
+        "سُفْيَانُ، قَالَ حَدَّثَنَا يَحْيَى بْنُ سَعِيدٍ الأَنْصَارِيُّ، قَالَ "
+        "أَخْبَرَنِي مُحَمَّدُ بْنُ إِبْرَاهِيمَ التَّيْمِيُّ، أَنَّهُ سَمِعَ "
+        "عَلْقَمَةَ بْنَ وَقَّاصٍ اللَّيْثِيَّ"
+    )
+
+    def test_voweled_chain_does_not_collapse_to_blob(self) -> None:
+        """The whole voweled chain must not become one giant mention."""
+        spans = extract_narrator_mentions(self._BUKHARI_H1_ISNAD, "ar")
+        assert len(spans) >= 4
+        # No single span should swallow the entire chain.
+        assert all(len(s.name) < len(self._BUKHARI_H1_ISNAD) // 2 for s in spans)
+
+    def test_positions_sequential_and_unique(self) -> None:
+        spans = extract_narrator_mentions(self._BUKHARI_H1_ISNAD, "ar")
+        positions = [s.position for s in spans]
+        assert positions == list(range(len(spans)))
+
+    def test_first_narrator_segmented(self) -> None:
+        """The first narrator after ``حدثنا`` is isolated (al-Humaydi)."""
+        spans = extract_narrator_mentions(self._BUKHARI_H1_ISNAD, "ar")
+        # Normalized form of الحميدي عبدالله بن الزبير, comma stripped.
+        assert spans[0].name.startswith("الحميدي")
+        assert "،" not in spans[0].name
+        assert spans[0].transmission_method == "haddathana"
+
+    def test_singular_variant_segments(self) -> None:
+        """``أخبرني`` / ``سمع`` (singular/3rd-person) also split the chain."""
+        spans = extract_narrator_mentions(self._BUKHARI_H1_ISNAD, "ar")
+        methods = {s.transmission_method for s in spans}
+        assert "akhbarani" in methods
+        assert "samia" in methods
+
+
 class TestEdgeCases:
     def test_empty_string(self) -> None:
         assert extract_narrator_mentions("", "en") == []

--- a/tests/test_resolve/test_lk_segmentation_e2e.py
+++ b/tests/test_resolve/test_lk_segmentation_e2e.py
@@ -1,0 +1,120 @@
+"""End-to-end regression for da#146: a voweled lk-corpus chain must resolve to
+*multiple* canonical narrators, not a single un-segmented blob.
+
+Flow exercised: lk CSV (fully voweled Arabic isnad)
+  → :func:`src.parse.lk_corpus.run`        (narrator_mentions_lk.parquet)
+  → :func:`src.resolve.ner.run`            (narrator_mentions_resolved.parquet)
+  → :func:`src.resolve.disambiguate.run`   (narrators_canonical.parquet)
+
+Before da#146 the diacritic-free transmission patterns never matched the voweled
+chain, so each whole chain became one mention → one "narrator". This test pins
+that a single chain now yields several distinct canonical narrators.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from src.parse.lk_corpus import LK_COLUMNS
+from src.parse.lk_corpus import run as lk_run
+from src.parse.schemas import NARRATOR_BIO_SCHEMA
+from src.resolve import disambiguate, ner
+
+# Sahih al-Bukhari hadith 1 — five+ named narrators in a fully-voweled isnad.
+_BUKHARI_H1_ISNAD_AR = (
+    "حَدَّثَنَا الْحُمَيْدِيُّ عَبْدُاللَّهِ بْنُ الزُّبَيْرِ، قَالَ حَدَّثَنَا "
+    "سُفْيَانُ، قَالَ حَدَّثَنَا يَحْيَى بْنُ سَعِيدٍ الأَنْصَارِيُّ، قَالَ "
+    "أَخْبَرَنِي مُحَمَّدُ بْنُ إِبْرَاهِيمَ التَّيْمِيُّ، أَنَّهُ سَمِعَ "
+    "عَلْقَمَةَ بْنَ وَقَّاصٍ اللَّيْثِيَّ"
+)
+
+
+def _write_lk_csv(path: Path) -> None:
+    """Write a one-row lk CSV (16-column layout) with a voweled Arabic isnad."""
+    row = {c: "" for c in LK_COLUMNS}
+    row.update(
+        {
+            "Chapter_Number": "1",
+            "Chapter_English": "Revelation",
+            "Chapter_Arabic": "بدء الوحي",
+            "Section_Number": "1",
+            "Hadith_number": "1",
+            "English_Hadith": "Narrated Umar: Actions are by intentions",
+            "English_Isnad": "Narrated 'Umar bin Al-Khattab:",
+            "English_Matn": "Actions are by intentions",
+            "Arabic_Isnad": _BUKHARI_H1_ISNAD_AR,
+            "Arabic_Matn": "إنما الأعمال بالنيات",
+            "Arabic_Hadith": _BUKHARI_H1_ISNAD_AR,
+            "English_Grade": "Sahih",
+            "Arabic_Grade": "صحيح",
+        }
+    )
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=LK_COLUMNS)
+        writer.writeheader()
+        writer.writerow(row)
+
+
+def _seed_bio_candidate(staging_dir: Path) -> None:
+    """Write a minimal narrators_bio parquet so disambiguate has candidates.
+
+    ``disambiguate.run`` early-returns when no biographical candidates exist;
+    one Sufyan bio both unblocks the run and provides an exact-match target for
+    the segmented ``سفيان`` mention.
+    """
+    fields = {f.name: None for f in NARRATOR_BIO_SCHEMA}
+    fields.update(
+        {
+            "bio_id": "bio:test:sufyan",
+            "source": "test",
+            "name_ar": "سفيان",
+            "name_ar_normalized": "سفيان",
+            "name_en": "Sufyan",
+            "death_year_ah": 198,
+        }
+    )
+    arrays = {f.name: pa.array([fields[f.name]], type=f.type) for f in NARRATOR_BIO_SCHEMA}
+    table = pa.table(arrays, schema=NARRATOR_BIO_SCHEMA)
+    pq.write_table(table, staging_dir / "narrators_bio_test.parquet")
+
+
+def test_voweled_lk_chain_yields_multiple_canonical_narrators(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    (raw_dir / "lk").mkdir(parents=True)
+    staging_dir = tmp_path / "staging"
+    output_dir = tmp_path / "output"
+    staging_dir.mkdir()
+    output_dir.mkdir()
+
+    _write_lk_csv(raw_dir / "lk" / "albukhari.csv")
+
+    # 1) Parse — the lk parser must emit several mention rows for the one chain.
+    lk_run(raw_dir, staging_dir)
+    mentions = pq.read_table(staging_dir / "narrator_mentions_lk.parquet")
+    ar_mentions = [
+        mentions.column("name_ar")[i].as_py()
+        for i in range(mentions.num_rows)
+        if mentions.column("name_ar")[i].as_py()
+    ]
+    assert len(ar_mentions) >= 4, f"chain not segmented: {ar_mentions}"
+    # No mention should be the whole chain (the pre-da#146 blob failure mode).
+    assert all(len(m) < len(_BUKHARI_H1_ISNAD_AR) // 2 for m in ar_mentions)
+
+    # 2) NER consolidation.
+    ner.run(staging_dir, output_dir)
+    resolved = pq.read_table(output_dir / "narrator_mentions_resolved.parquet")
+    assert resolved.num_rows >= 4
+
+    # 3) Disambiguate — must materialize multiple canonical narrators, not 0/1.
+    _seed_bio_candidate(staging_dir)
+    disambiguate.run(staging_dir, output_dir)
+    canonical = pq.read_table(output_dir / "narrators_canonical.parquet")
+    assert canonical.num_rows >= 4
+
+    # The seeded Sufyan bio should have matched the segmented سفيان mention.
+    names_en = {canonical.column("name_en")[i].as_py() for i in range(canonical.num_rows)}
+    assert "Sufyan" in names_en

--- a/tests/test_utils/test_arabic.py
+++ b/tests/test_utils/test_arabic.py
@@ -223,3 +223,26 @@ class TestExtractTransmissionPhrases:
         assert isinstance(start, int)
         assert isinstance(end, int)
         assert label == "haddathana"
+
+    def test_matches_diacritized_term(self) -> None:
+        """Fully-voweled terms must match (da#146) — bare patterns alone do not."""
+        # حَدَّثَنَا (voweled) vs the bare keyword حدثنا.
+        results = extract_transmission_phrases("حَدَّثَنَا سُفْيَانُ")
+        labels = [label for _, _, label in results]
+        assert "haddathana" in labels
+
+    def test_overlapping_variants_resolve_to_longer(self) -> None:
+        """``سمعت`` must win over the bare ``سمع`` at a shared position."""
+        results = extract_transmission_phrases("سمعت فلانا")
+        # Exactly one transmission phrase at the start, labelled samitu.
+        starts = [s for s, _, _ in results]
+        assert starts == sorted(starts)
+        assert results[0][2] == "samitu"
+        # No duplicate/overlapping samia span at the same start.
+        assert not any(label == "samia" and start == 0 for start, _, label in results)
+
+    def test_singular_variants_recognized(self) -> None:
+        results = extract_transmission_phrases("حدثني فلان أخبرني فلان")
+        labels = {label for _, _, label in results}
+        assert "haddathani" in labels
+        assert "akhbarani" in labels


### PR DESCRIPTION
## Summary

67% of lk-corpus narrators (`source_corpus="lk"`, ~31,525 rows) were **un-segmented isnad chain strings**: each whole Arabic chain became one "narrator" node, blocking the narrator surface (ig#1024) and Phase-5 criterion #1 (main#665).

### Root cause

`src.utils.arabic.extract_transmission_phrases` matched **diacritic-free** keyword patterns (`حدثنا`, `عن`, `قال` …) against **fully-voweled** isnad text (`حَدَّثَنَا …`). The patterns never matched real data, so it returned **zero** transmission phrases on every voweled chain. `_extract_arabic` then took its `if not phrases:` branch and emitted the *entire chain* as a single mention at `position 0`. The toy test fixtures used un-voweled Arabic (`حدثنا عمر بن الخطاب`), which *did* match — masking the bug.

Verified on the real Bukhari h1 isnad: raw → `phrases == []` → 1 blob mention; after normalization → 6 phrases.

### Fix (surgical — entirely in `extract_transmission_phrases`, positions preserved)

- **Diacritic-tolerant patterns**: each transmission term is compiled to tolerate an optional tashkeel/tatweel run between base letters, so voweled chains match while match positions still index into the caller's **raw** string — `_extract_arabic`'s slice logic is unchanged, and the fix benefits every Arabic source (thaqalayn, open_hadith), not just lk.
- **Singular/3rd-person variants** added (`حدثني`, `أخبرني`, `أنبأني`, `سمع`) that real chains alternate to, with **overlap resolution** (`سمعت` wins over the bare `سمع` at a shared start; longer match preferred).
- **Trailing Arabic comma/semicolon** (`،`/`؛`) stripped from extracted names so the exact-match disambiguation key isn't polluted.

A single voweled Bukhari h1 chain now yields **6 narrator mentions** (was 1 blob), which the existing `disambiguate` stage resolves into multiple canonical narrators. No change was needed in `lk_corpus.py` or `_extract_arabic` — they were already correct given a working phrase finder.

## Test Plan

- `tests/test_utils/test_arabic.py` — voweled-term matching, overlap-resolution (`سمعت` not double-counted), singular-variant recognition.
- `tests/test_parse/test_narrator_extraction.py::TestDa146VoweledSegmentation` — a fully-voweled chain segments into ≥4 mentions with sequential positions and clean (comma-free) names.
- `tests/test_resolve/test_lk_segmentation_e2e.py` — **end-to-end**: voweled lk CSV → `lk_corpus.run` → `ner.run` → `disambiguate.run`; asserts ≥4 mention rows and ≥4 canonical narrators from one chain (was 1), with the seeded bio exact-matching the segmented `سفيان`.
- Full suite: **837 passed, 5 skipped**. `ruff format`/`ruff check` clean; `mypy` clean on changed sources.

## Follow-up

This is the deterministic-splitter slice (the tractable, tested keystone). What real Arabic NER would add beyond this:

- **Name-boundary precision**: deterministic splitting still captures connective words into a span (e.g. `أَنَّهُ`/`يَقُولُ` trailing a name) — a stopword/honorific filter or a model-based NER would yield cleaner narrator surface forms. Tracked as a refinement, not a blocker.
- **`عن` substring false-positives**: `عن` can match inside a token; a morphology-aware tokenizer would avoid spurious splits.
- **Kunya/laqab joining** (`أبو …`, `ابن …`) across transmission boundaries.

Closes #146
