### PR TITLE
test(resolve): da#138 fuzzy-cluster precision harness + nasab-reversal guard

### DIFF
--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -33,6 +33,17 @@ Precision guards (against over-merging distinct same-named narrators)
   disagree by more than :data:`_DEATH_YEAR_TOLERANCE`, the merge is blocked even
   on a perfect name match — two scholars a century apart are not one person.
 * A **gender guard**: two records with explicit, differing ``gender`` never merge.
+* A **token-order guard** (da#138): ``token_set_ratio`` is order-*insensitive*, so
+  a pure nasab reversal of two **different** people — ``محمد بن عبد الله``
+  (Muḥammad son of ʿAbdullāh) ↔ ``عبد الله بن محمد`` (ʿAbdullāh son of Muḥammad) —
+  scores a perfect 100 and, with no death-year/gender to corroborate, would
+  falsely merge. The guard requires the shared significant tokens to appear in the
+  **same relative order** in the two matched spellings. A genuine variant only
+  *adds or drops* tokens (kunya/nisba/nasab expansion), which preserves the order
+  of the shared tokens, so recall is untouched; only a reordering is rejected.
+  This precision defect — and the validation harness that quantified its
+  false-merge rate — is the da#138 tech-debt work; raising the numeric threshold
+  cannot fix a perfect-100 reversal score and would only cost recall.
 
 Identity & ordering invariants
 -------------------------------
@@ -162,22 +173,45 @@ def _significant_tokens(keys: list[str]) -> set[str]:
     return tokens
 
 
-def _name_similarity(keys_a: list[str], keys_b: list[str]) -> float:
-    """Best token_set_ratio across the cross product of two records' match keys.
+def _significant_token_sequence(key: str) -> list[str]:
+    """Significant (non-connector) tokens of a single name string, in name order.
 
-    Taking the max over names + aliases means a record matches if *any* of its
-    spellings (including a da#94 variant) is a strong token-set match for any of
-    the other's — exactly the cross-source-variant recall this pass targets.
+    The ordered counterpart of :func:`_significant_tokens` — the token-order guard
+    compares relative order, so it needs the sequence, not the set.
     """
-    best = 0.0
+    return [tok for tok in key.split() if len(tok) >= 2 and tok not in _CONNECTOR_TOKENS]
+
+
+def _token_order_consistent(a: str, b: str) -> bool:
+    """True when the tokens shared by names ``a`` and ``b`` keep the same order.
+
+    A genuine variant only adds/removes tokens, so the shared tokens stay in the
+    same relative order; a nasab reversal of two different people permutes them.
+    Fewer than two shared significant tokens is left to :data:`_MIN_SHARED_TOKENS`
+    — this guard only adjudicates the high-overlap case a reversal can exploit.
+    """
+    seq_a = _significant_token_sequence(a)
+    seq_b = _significant_token_sequence(b)
+    shared = set(seq_a) & set(seq_b)
+    if len(shared) < 2:
+        return True
+    return [t for t in seq_a if t in shared] == [t for t in seq_b if t in shared]
+
+
+def _name_match(keys_a: list[str], keys_b: list[str], *, threshold: float) -> bool:
+    """True when some key pair is a strong AND token-order-consistent match.
+
+    A pair counts only if its ``token_set_ratio`` clears ``threshold`` *and* it
+    survives the da#138 token-order guard. Taking the best over the cross product
+    of each record's match keys (its name + da#94 aliases) keeps the alias-driven
+    recall — a record matches if *any* of its spellings is both a strong and
+    order-consistent match for any of the other's.
+    """
     for a in keys_a:
         for b in keys_b:
-            score = fuzz.token_set_ratio(a, b)
-            if score > best:
-                best = score
-                if best >= 100.0:
-                    return best
-    return best
+            if fuzz.token_set_ratio(a, b) >= threshold and _token_order_consistent(a, b):
+                return True
+    return False
 
 
 def _death_years_conflict(a: dict[str, Any], b: dict[str, Any]) -> bool:
@@ -204,15 +238,17 @@ def _can_merge(a: dict[str, Any], b: dict[str, Any], *, threshold: float) -> boo
 
     A merge requires ALL of: no death-year conflict, no gender conflict, at least
     :data:`_MIN_SHARED_TOKENS` shared significant name tokens (so a bare
-    single-token subset never clusters), and a name similarity at/above
-    ``threshold``. Pairwise and symmetric — the cluster post-validation relies on
-    that to refuse any cluster harbouring a guard-conflicting pair.
+    single-token subset never clusters), and a matched key pair that clears
+    ``threshold`` *and* is token-order-consistent (so a nasab reversal of two
+    different people does not merge — da#138). Pairwise and symmetric — the cluster
+    post-validation relies on that to refuse any cluster harbouring a
+    guard-conflicting pair.
     """
     if _death_years_conflict(a, b) or _genders_conflict(a, b):
         return False
     if _shared_significant_token_count(a, b) < _MIN_SHARED_TOKENS:
         return False
-    return _name_similarity(_match_keys(a), _match_keys(b)) >= threshold
+    return _name_match(_match_keys(a), _match_keys(b), threshold=threshold)
 
 
 # ---------------------------------------------------------------------------

--- a/src/resolve/quality.py
+++ b/src/resolve/quality.py
@@ -35,6 +35,17 @@ class ClusterQuality:
     predicted_pairs: int
     gold_pairs: int
 
+    @property
+    def false_merge_rate(self) -> float:
+        """Fraction of predicted same-narrator pairs that are wrong (over-merges).
+
+        The complement of precision (``1 - precision``) — the direct measure of
+        clustering *over-merging*, surfaced by name so the da#138 precision harness
+        and any future CI report share one definition. ``0.0`` when no pairs were
+        predicted (nothing was merged, so nothing was mis-merged).
+        """
+        return 1.0 - self.precision if self.predicted_pairs else 0.0
+
     def summary(self) -> str:
         """One-line human-readable summary."""
         return (

--- a/tests/test_resolve/fixtures/cluster_precision_gold.json
+++ b/tests/test_resolve/fixtures/cluster_precision_gold.json
@@ -1,0 +1,25 @@
+{
+  "_README": "Labeled gold set for the da#138 fuzzy-cluster PRECISION harness. Each entry is one canonical narrator record (as the exact-name pass would emit it) with a hand-assigned `gold_person`: records sharing a `gold_person` are the SAME real narrator and SHOULD cluster; distinct `gold_person` values must stay apart. The set deliberately mixes legitimate cross-source variants (recall) with the precision traps that over-merging fuzzy clustering falls into (death-year-distinguished homonyms; the da#138 nasab-reversal pair whose token_set_ratio is a perfect 100). No two DISTINCT-person records share a normalized name — byte-identical names already collapse in the exact-name pass before fuzzy clustering runs, so they are not a fuzzy false-merge. `name_ar` is normalized by the harness via normalize_arabic, exactly as the real producers key make_canonical_id.",
+  "records": [
+    {"name_ar": "محمد بن اسماعيل البخاري", "gold_person": "bukhari", "death_year_ah": 256, "mention_count": 10, "source_corpora": ["itqan"]},
+    {"name_ar": "محمد بن اسماعيل", "gold_person": "bukhari", "death_year_ah": 256, "mention_count": 3, "source_corpora": ["sanadset"]},
+
+    {"name_ar": "احمد بن حنبل الشيباني", "gold_person": "ahmad", "death_year_ah": 241, "mention_count": 8, "source_corpora": ["itqan"]},
+    {"name_ar": "احمد بن حنبل", "gold_person": "ahmad", "death_year_ah": 241, "mention_count": 2, "source_corpora": ["sanadset"]},
+
+    {"name_ar": "مالك بن انس الاصبحي", "gold_person": "malik", "death_year_ah": 179, "mention_count": 6, "source_corpora": ["itqan"]},
+    {"name_ar": "مالك بن انس", "gold_person": "malik", "death_year_ah": 179, "mention_count": 4, "source_corpora": ["thaqalayn"]},
+
+    {"name_ar": "ابو حفص العدوي القرشي", "gold_person": "umar", "aliases": ["عمر بن الخطاب"], "mention_count": 5, "source_corpora": ["itqan"]},
+    {"name_ar": "عمر بن الخطاب", "gold_person": "umar", "mention_count": 7, "source_corpora": ["sanadset"]},
+
+    {"name_ar": "سفيان الثوري", "gold_person": "thawri", "death_year_ah": 161, "mention_count": 4, "source_corpora": ["itqan"]},
+    {"name_ar": "سفيان بن عيينة", "gold_person": "uyayna", "death_year_ah": 198, "mention_count": 3, "source_corpora": ["sanadset"]},
+
+    {"name_ar": "يحيى بن سعيد القطان", "gold_person": "yahya_qattan", "death_year_ah": 198, "mention_count": 3, "source_corpora": ["itqan"]},
+    {"name_ar": "يحيى بن سعيد الانصاري", "gold_person": "yahya_ansari", "death_year_ah": 143, "mention_count": 2, "source_corpora": ["sanadset"]},
+
+    {"name_ar": "محمد بن عبد الله", "gold_person": "muhammad_b_abdullah", "mention_count": 2, "source_corpora": ["itqan"]},
+    {"name_ar": "عبد الله بن محمد", "gold_person": "abdullah_b_muhammad", "mention_count": 2, "source_corpora": ["thaqalayn"]}
+  ]
+}

--- a/tests/test_resolve/test_cluster_precision.py
+++ b/tests/test_resolve/test_cluster_precision.py
@@ -1,0 +1,142 @@
+"""Precision-validation harness for fuzzy cross-source narrator clustering (da#138).
+
+The fuzzy pass (``src.resolve.fuzzy_cluster``) trades a little precision for recall:
+it merges high-confidence name variants of one narrator that the exact-name pass
+leaves split. The risk is *over-merging* — collapsing two genuinely different
+people into one canonical narrator. ``test_fuzzy_cluster`` already proves a handful
+of individual guards; this module is the aggregate **precision guard**: a labeled
+gold set of narrator records run end-to-end through ``cluster_assignment`` and
+scored with ``quality.pairwise_quality``, asserting precision stays at its
+documented baseline so a future change that loosens clustering is caught here.
+
+Findings that motivated the harness (measured on ``cluster_precision_gold.json``):
+
+* Before da#138 the clustering **falsely merged a nasab reversal** — ``محمد بن عبد
+  الله`` (Muḥammad b. ʿAbdullāh) and ``عبد الله بن محمد`` (ʿAbdullāh b. Muḥammad),
+  two different people — because ``rapidfuzz.token_set_ratio`` is order-insensitive
+  and scores that pair a perfect ``100``. With no death-year/gender metadata to
+  corroborate, the merge went through: precision ``0.667`` / **false-merge rate
+  ``0.333``** on this set. Raising the numeric threshold cannot fix a 100 score and
+  would only cost recall, so the fix is the token-order guard, not a higher bar.
+* With the da#138 token-order guard in place the same set scores precision
+  ``1.000`` (**false-merge rate ``0.000``**) at recall ``1.000`` — the legitimate
+  cross-source variants still merge. The sensitivity test below re-introduces the
+  regression to prove this harness would catch it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.parse.identity import make_canonical_id
+from src.resolve import fuzzy_cluster
+from src.resolve.fuzzy_cluster import cluster_assignment
+from src.resolve.quality import pairwise_quality
+from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+
+# The documented precision floor for the labeled gold set. The fuzzy pass must not
+# over-merge any distinct narrator in the set — every predicted same-narrator pair
+# must be a true one (false-merge rate 0.0). A drop here means a change loosened
+# clustering precision; investigate before lowering this number.
+PRECISION_BASELINE = 1.0
+
+# Recall floor on the same set: a precision guard is worthless if it is satisfied
+# by refusing every merge, so we also pin recall — the legitimate cross-source
+# variants in the fixture must still cluster.
+RECALL_FLOOR = 1.0
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "cluster_precision_gold.json"
+
+
+def _load_gold() -> tuple[list[dict[str, Any]], dict[str, str]]:
+    """Build canonical records + the gold ``canonical_id -> person`` map from JSON.
+
+    Each fixture entry becomes a full ``NARRATORS_CANONICAL_SCHEMA`` record keyed,
+    like the real producers, on ``make_canonical_id(normalize_arabic(name_ar))`` so
+    the harness exercises the genuine identity contract. Distinct people never share
+    a normalized name (asserted), so canonical ids are unique and the gold map is
+    lossless.
+    """
+    raw = json.loads(_FIXTURE.read_text(encoding="utf-8"))
+    records: list[dict[str, Any]] = []
+    gold: dict[str, str] = {}
+    for entry in raw["records"]:
+        norm = normalize_arabic(entry["name_ar"])
+        canonical_id = make_canonical_id(norm)
+        record: dict[str, Any] = {f.name: None for f in NARRATORS_CANONICAL_SCHEMA}
+        record.update(
+            {
+                "canonical_id": canonical_id,
+                "name_ar": entry["name_ar"],
+                "name_ar_normalized": norm,
+                "aliases": [normalize_arabic(a) for a in entry.get("aliases", [])],
+                "source_ids": [],
+                "source_corpora": entry.get("source_corpora", []),
+                "mention_count": entry.get("mention_count", 1),
+            }
+        )
+        for field in ("death_year_ah", "gender", "external_id"):
+            if field in entry:
+                record[field] = entry[field]
+        records.append(record)
+        gold[canonical_id] = entry["gold_person"]
+    return records, gold
+
+
+def test_gold_fixture_is_well_formed() -> None:
+    """The fixture has no distinct-person name collisions and ≥1 true merge pair."""
+    records, gold = _load_gold()
+    ids = [r["canonical_id"] for r in records]
+    assert len(ids) == len(set(ids)), "distinct records collide on canonical_id"
+    # At least one gold cluster has >1 member, else recall is vacuous.
+    person_counts: dict[str, int] = {}
+    for person in gold.values():
+        person_counts[person] = person_counts.get(person, 0) + 1
+    assert any(n > 1 for n in person_counts.values())
+
+
+def test_clustering_precision_meets_baseline() -> None:
+    """End-to-end: clustering the gold set over-merges nothing (precision floor)."""
+    records, gold = _load_gold()
+    predicted = cluster_assignment(records)
+    quality = pairwise_quality(predicted, gold)
+
+    assert quality.precision >= PRECISION_BASELINE, (
+        f"clustering precision regressed: {quality.summary()} "
+        f"(false-merge rate {quality.false_merge_rate:.3f})"
+    )
+    # Precision floor of 1.0 means zero false merges — keep the two phrasings in sync.
+    assert quality.false_merge_rate <= 1.0 - PRECISION_BASELINE
+    # And the guard is not met by under-merging: the real variants still cluster.
+    assert quality.recall >= RECALL_FLOOR, f"recall regressed: {quality.summary()}"
+
+
+def test_nasab_reversal_does_not_false_merge() -> None:
+    """The da#138 trap pair (reversed nasab, different people) stays in two clusters."""
+    records, _ = _load_gold()
+    forward = make_canonical_id(normalize_arabic("محمد بن عبد الله"))
+    reversed_ = make_canonical_id(normalize_arabic("عبد الله بن محمد"))
+    predicted = cluster_assignment(records)
+    assert predicted[forward] != predicted[reversed_]
+
+
+def test_harness_detects_a_precision_regression(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disabling the da#138 token-order guard must drop the harness's precision.
+
+    This is the harness's own meta-test: if a future refactor silently removed the
+    order guard, ``test_clustering_precision_meets_baseline`` must start failing.
+    We simulate that removal by neutralizing ``_token_order_consistent`` and confirm
+    precision falls below the baseline and the false-merge rate rises — i.e. the
+    reversed-nasab pair gets wrongly merged again.
+    """
+    records, gold = _load_gold()
+    monkeypatch.setattr(fuzzy_cluster, "_token_order_consistent", lambda a, b: True)
+
+    regressed = pairwise_quality(cluster_assignment(records), gold)
+    assert regressed.precision < PRECISION_BASELINE
+    assert regressed.false_merge_rate > 0.0


### PR DESCRIPTION
## What & why (da#138 — W1 tech-debt intake 1/1)

Validate the **precision** of cross-source fuzzy narrator clustering
(`src/resolve/fuzzy_cluster`) and guard it against regression.

### Finding
Built a labeled gold set and ran it end-to-end through `cluster_assignment` +
`quality.pairwise_quality`. The clustering **falsely merged a nasab reversal** —
`محمد بن عبد الله` (Muhammad b. Abdullah) and `عبد الله بن محمد` (Abdullah b.
Muhammad), two different people — because `rapidfuzz.token_set_ratio` is
order-insensitive and scores that pair a perfect **100**. With no
death-year/gender metadata to corroborate, the merge went through:
**precision 0.667 / false-merge rate 0.333** on the set.

Raising the numeric threshold cannot fix a 100 score and would only cost recall,
so the fix is a guard, not a higher bar (per the brief: tighten only if evidence
supports, don't degrade recall blindly).

### Fix (recall-preserving)
A **token-order guard**: a merge requires the shared significant tokens to appear
in the **same relative order** in the two matched spellings. A genuine variant
only adds/drops tokens (kunya/nisba/nasab expansion), which preserves order; only
a reordering is rejected. Post-fix the gold set scores **precision 1.000
(false-merge rate 0.000) at recall 1.000** — legitimate cross-source variants
still merge.

### Changes
- `fuzzy_cluster.py`: `_significant_token_sequence`, `_token_order_consistent`,
  `_name_match`; `_can_merge` now routes through `_name_match`; dropped the
  now-dead `_name_similarity`; documented the guard.
- `quality.py`: `ClusterQuality.false_merge_rate` (`1 - precision`) as the shared
  over-merge metric.
- `tests/`: `cluster_precision_gold.json` labeled fixture +
  `test_cluster_precision.py` harness (precision floor, recall floor,
  reversal-stays-split, and a self-test that re-introduces the regression to
  prove the harness catches it).

## Test Plan
- `ENVIRONMENT=test uv run pytest tests/` → **833 passed, 5 skipped** (incl. the
  4 new harness tests and the 17 existing fuzzy_cluster/quality tests).
- `ruff@0.15.11 format --check` + `check` → clean; `mypy` → clean.
- pre-commit + pre-push hook stages → all Passed.
- Measured precision: pre-fix 0.667 (false-merge 0.333) → post-fix 1.000
  (false-merge 0.000), recall held at 1.000.

Closes #138
