### PR TITLE
Phase 5 Wave 1 → main (noorinalabs-data-acquisition)

### DIFF
--- a/src/acquire/mis.py
+++ b/src/acquire/mis.py
@@ -8,19 +8,24 @@ multi-isnad source for the platform: where most corpora give one chain per
 hadith, MIS preserves the parallel asanid (the ``ح`` / *tahwil* split) that make
 Sahih Muslim valuable for chain modelling.
 
-The dataset ships as two Excel workbooks under the Mendeley file set:
+The current dataset (v2) ships as **three** Excel workbooks under the Mendeley
+file set — a graph export (content + nodes + edges):
 
-* ``Hadith_SahihMuslim_CoreInfo.xlsx``               — one row per hadith
-  (book, hadith number, matn, narrator sequence, isnad count).
-* ``Hadith_SahihMuslim_DetailsInfo_Sanad_Narrators.xlsx`` — one row per
-  (hadith, sanad, narrator) position — the data the parser walks into per-sanad
-  chains.
+* ``1_Hadith_SahihMuslim_HadithContent.xlsx``         — one row per hadith
+  (``BookNo``, ``HadithNo``, matn, ``SanadCount``). The parser's "core" file.
+* ``2_Hadith_SahihMuslim_Narrators=Nodes for Graph.xlsx`` — narrator *node*
+  list (id ↔ name, generation, gender). Downloaded but not consumed for staging.
+* ``3_Hadith_SahihMuslim_Isnad=Edges for Graph.xlsx`` — one row per directed
+  transmission *edge* (``source*`` → ``target*`` narrator, keyed by
+  ``(BookNo, HadithNo, SanadNo)``). The parser's "detail" file.
 
-Reachability: ``data.mendeley.com`` serves the file set over HTTPS with **no
-auth / no API key** — the same keyless-public mechanism this repo already proves
-for ``sanadset`` (Mendeley ``5xth87zwb5``). The file ids are resolved at runtime
-from the dataset files API rather than hardcoded, so a new dataset version is
-picked up without a code change.
+We download every ``.xlsx`` in the file set, so all three arrive; the parser
+selects the content + edges workbooks by filename token. Reachability:
+``data.mendeley.com`` serves the file set over HTTPS with **no auth / no API
+key** — the same keyless-public mechanism this repo already proves for
+``sanadset`` (Mendeley ``5xth87zwb5``). The file ids are resolved at runtime from
+the dataset files API rather than hardcoded, so a new dataset version is picked
+up without a code change.
 
 Licensing: Mendeley Data's default license for this dataset is **CC BY 4.0**
 (attribution) — redistribution-safe with credit to the depositors.

--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -120,10 +120,27 @@ def _build_chain_pairs(
     resolved = [m for m in sorted_mentions if m.get("canonical_narrator_id")]
     pairs: list[dict[str, Any]] = []
     for i in range(len(resolved) - 1):
+        from_id = resolved[i]["canonical_narrator_id"]
+        to_id = resolved[i + 1]["canonical_narrator_id"]
+        # Drop self-loops: two ADJACENT mentions that resolve to the same
+        # canonical narrator (a repeated narrator in the raw chain, or two
+        # mentions the disambiguator collapsed onto one node) would otherwise
+        # MERGE a TRANSMITTED_TO edge from a narrator to itself (da#148 — 8 live
+        # self-loops). The network-edge producers already guard this
+        # (``muhaddithat._parse_network_edges`` skips ``from_id == to_id``,
+        # ``mis`` skips ``from_name == to_name``); applying it on the
+        # chain-derived path keeps a re-load self-loop-free everywhere.
+        if from_id == to_id:
+            logger.debug(
+                "transmitted_to_self_loop_skipped",
+                narrator_id=from_id,
+                hadith_id=resolved[i].get("hadith_id", ""),
+            )
+            continue
         pairs.append(
             {
-                "from_id": resolved[i]["canonical_narrator_id"],
-                "to_id": resolved[i + 1]["canonical_narrator_id"],
+                "from_id": from_id,
+                "to_id": to_id,
                 "position": resolved[i].get("position_in_chain", i),
                 "hadith_id": resolved[i].get("hadith_id", ""),
             }

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -40,6 +40,7 @@ from src.parse.identity import (
     grading_node_id,
     hadith_node_id,
 )
+from src.utils.grade import normalize_grade
 from src.utils.logging import get_logger
 from src.utils.neo4j_client import Neo4jClient
 
@@ -202,6 +203,7 @@ SET n.matn_ar      = row.matn_ar,
     n.isnad_raw_ar = row.isnad_raw_ar,
     n.isnad_raw_en = row.isnad_raw_en,
     n.grade        = row.grade,
+    n.grade_normalized = row.grade_normalized,
     n.source_corpus = row.source_corpus,
     n.sect         = row.sect,
     n.collection_name = row.collection_name
@@ -247,6 +249,10 @@ def _load_hadiths(
                     "isnad_raw_ar": _val(row, "isnad_raw_ar"),
                     "isnad_raw_en": _val(row, "isnad_raw_en"),
                     "grade": _val(row, "grade"),
+                    # Normalized display grade alongside the verbatim raw value: a
+                    # corpus may store the grade as raw Arabic / mixed script,
+                    # which is not a stable key to filter or display on (da#148).
+                    "grade_normalized": normalize_grade(_val(row, "grade")),
                     "source_corpus": _val(row, "source_corpus", ""),
                     "sect": _val(row, "sect", ""),
                     "collection_name": _val(row, "collection_name", ""),
@@ -440,6 +446,7 @@ MERGE (n:Grading {id: row.id})
 SET n.hadith_id          = row.hadith_id,
     n.scholar_name       = row.scholar_name,
     n.grade              = row.grade,
+    n.grade_normalized   = row.grade_normalized,
     n.methodology_school = row.methodology_school,
     n.era                = row.era
 """
@@ -488,6 +495,10 @@ def _load_gradings(
                     "hadith_id": hadith_node_id(sid),
                     "scholar_name": _val(row, "collection_name", "unknown"),
                     "grade": grade,
+                    # Normalized display grade (da#148): the raw ``grade`` may be
+                    # Arabic / mixed-script free text; map it onto the HadithGrade
+                    # vocabulary so the UI and queries have a stable key.
+                    "grade_normalized": normalize_grade(grade),
                     "methodology_school": None,
                     "era": None,
                 }

--- a/src/parse/mis.py
+++ b/src/parse/mis.py
@@ -20,17 +20,28 @@ Two output files (both tagged ``sect=sunni`` / ``source_corpus=mis``):
 
 Input shape
 -----------
-Two Mendeley workbooks (``.xlsx``; ``.csv`` exports are also accepted for tests):
+Mendeley workbooks (``.xlsx``; ``.csv`` exports are also accepted for tests). The
+current dataset (DOI ``10.17632/gzprcr93zn.2``) ships a **three-file graph
+export** — the parser uses two of them:
 
-* **CoreInfo** — one row per hadith: a hadith number, an (optional) book number,
-  the matn text, and an (optional) narrator-sequence string.
-* **DetailsInfo (Sanad/Narrators)** — the per-position detail the chains are
-  walked from. Two layouts are supported:
-    - *sequence layout* (primary): ``(hadith, isnad/sanad, position, narrator)``
-      — grouped by ``(hadith, isnad)`` and walked into consecutive-pair edges, so
-      each sanad of a hadith becomes its own chain;
-    - *edge layout*: explicit ``(from_narrator, to_narrator[, hadith][, isnad])``
-      rows — each row is already one edge.
+* **HadithContent** (``1_Hadith_SahihMuslim_HadithContent.xlsx``) — one row per
+  hadith: ``HadithNo``, ``BookNo``, the matn (``HadithText_Mushakkal`` /
+  ``…_GhairMushakkal``), and per-hadith ``SanadCount``. This is the "core" file.
+* **Isnad=Edges** (``3_Hadith_SahihMuslim_Isnad=Edges for Graph.xlsx``, sheet
+  ``2-Relationship``) — one row per **edge**: a ``(BookNo, HadithNo, SanadNo)``
+  key plus ``sourceNarrator{ID,NameEn}`` → ``targetNarrator{ID,NameEn}``. Each
+  row is already one directed transmission edge; ``SanadNo`` discriminates the
+  parallel asanid, so the multi-isnad multiplicity survives row-for-row.
+* The third file (``2_…Narrators=Nodes for Graph.xlsx``) is a narrator *node*
+  list (id ↔ name) and is **not** consumed for staging — the edge file carries
+  the narrator names inline. The detail-file selector deliberately resolves to
+  the *Edges* workbook even though the *Nodes* filename also contains
+  "narrator".
+
+An older two-file layout (``CoreInfo`` + ``DetailsInfo_Sanad_Narrators`` in
+either a per-position *sequence* layout or an explicit *edge* layout) is still
+accepted — its filename tokens and column candidates are retained below so both
+the legacy and current dataset shapes parse.
 
 Column names are matched case/spacing/underscore-insensitively (the upstream
 spreadsheets are not perfectly normalized), with documented candidate sets.
@@ -62,7 +73,19 @@ COLLECTION_SLUG = "sahih_muslim"
 # --- column-name candidate sets (matched on the alnum-normalized header) -------
 _HADITH_NO_KEYS = ("hadithno", "hadithnumber", "hadithid", "hadith", "serialno", "sno", "no", "id")
 _BOOK_KEYS = ("bookno", "booknumber", "book", "bookname", "kitab")
-_MATN_KEYS = ("matn", "matntext", "matnarabic", "hadithtext", "text", "arabictext", "matnar")
+_MATN_KEYS = (
+    # current dataset (vocalized preferred, then un-vocalized)
+    "hadithtextmushakkal",
+    "hadithtextghairmushakkal",
+    # legacy / generic
+    "matn",
+    "matntext",
+    "matnarabic",
+    "hadithtext",
+    "text",
+    "arabictext",
+    "matnar",
+)
 _ISNAD_TEXT_KEYS = ("narratorsequence", "isnadtext", "sanadtext", "chain", "narrators")
 
 _SANAD_KEYS = (
@@ -100,6 +123,10 @@ _NARRATOR_NAME_KEYS = (
 )
 _NARRATOR_ID_KEYS = ("narratorid", "narratorno", "nid", "rawiid", "rawino", "rawi")
 _FROM_KEYS = (
+    # current dataset: explicit source/target narrator NAME columns
+    "sourcenarratornameen",
+    "sourcenarratorname",
+    # legacy / generic
     "fromnarrator",
     "sourcenarrator",
     "from",
@@ -108,14 +135,34 @@ _FROM_KEYS = (
     "teacher",
     "fromname",
 )
-_TO_KEYS = ("tonarrator", "targetnarrator", "to", "target", "successor", "student", "toname")
+_TO_KEYS = (
+    "targetnarratornameen",
+    "targetnarratorname",
+    "tonarrator",
+    "targetnarrator",
+    "to",
+    "target",
+    "successor",
+    "student",
+    "toname",
+)
+# External narrator-id columns for the explicit edge layout — kept distinct from
+# the name keys so the canonical ``from``/``to`` stays a name while the stable
+# numeric id flows into ``{from,to}_external_id`` for downstream disambiguation.
+_FROM_ID_KEYS = ("sourcenarratorid", "fromnarratorid", "fromid", "sourceid")
+_TO_ID_KEYS = ("targetnarratorid", "tonarratorid", "toid", "targetid")
 
 # Filename tokens (matched case-insensitively, in priority order) that identify
 # each workbook. CoreInfo never contains a DetailsInfo token and vice versa, so
 # the two selections never collide.
 _DATA_SUFFIXES = (".xlsx", ".xls", ".csv")
-_CORE_TOKENS = ("coreinfo", "core")
-_DETAIL_TOKENS = ("detailsinfo", "sanad", "narrator", "details")
+# Current dataset: core = "…HadithContent…"; detail = "…Isnad=Edges…". Legacy:
+# core = "…CoreInfo…"; detail = "…DetailsInfo_Sanad_Narrators…". The detail
+# tokens put "edges"/"isnad" ahead of "narrator" so the current file set resolves
+# to the *Edges* workbook and never to the *Narrators=Nodes* node list (which
+# also contains "narrator").
+_CORE_TOKENS = ("coreinfo", "hadithcontent", "content", "core")
+_DETAIL_TOKENS = ("isnadedges", "edges", "isnad", "detailsinfo", "sanad", "narrator", "details")
 
 
 def _norm_header(value: Any) -> str:
@@ -356,6 +403,8 @@ def _parse_edges_explicit(
     """
     hadith_col = _pick(keys, _HADITH_NO_KEYS)
     sanad_col = _pick(keys, _SANAD_KEYS)
+    from_id_col = _pick(keys, _FROM_ID_KEYS)
+    to_id_col = _pick(keys, _TO_ID_KEYS)
 
     edges: list[dict[str, str | None]] = []
     seen_isnads: dict[str, set[str]] = defaultdict(set)
@@ -367,7 +416,14 @@ def _parse_edges_explicit(
         if hadith_no:
             sanad_no = (safe_str(row.get(sanad_col)) if sanad_col else None) or str(idx)
             seen_isnads[hadith_no].add(sanad_no)
-        _emit_edge(edges, safe_str(row.get(from_col)), safe_str(row.get(to_col)), hadith_id)
+        _emit_edge(
+            edges,
+            safe_str(row.get(from_col)),
+            safe_str(row.get(to_col)),
+            hadith_id,
+            from_id=safe_str(row.get(from_id_col)) if from_id_col else None,
+            to_id=safe_str(row.get(to_id_col)) if to_id_col else None,
+        )
 
     isnad_counts = {hadith_no: len(sanads) for hadith_no, sanads in seen_isnads.items()}
     return edges, isnad_counts

--- a/src/parse/narrator_extraction.py
+++ b/src/parse/narrator_extraction.py
@@ -20,8 +20,10 @@ _EN_DELIMITERS: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
-# Trailing punctuation to strip from extracted names.
-_TRAILING_PUNCT_RE: re.Pattern[str] = re.compile(r"[.,;:!?()]+$")
+# Trailing punctuation to strip from extracted names. Includes the Arabic comma
+# (، U+060C) and semicolon (؛ U+061B), which routinely terminate a narrator span
+# in voweled isnads (da#146) and would otherwise pollute the exact-match key.
+_TRAILING_PUNCT_RE: re.Pattern[str] = re.compile(r"[.,;:!?()،؛\s]+$")
 
 
 @dataclass(frozen=True)

--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -33,6 +33,17 @@ Precision guards (against over-merging distinct same-named narrators)
   disagree by more than :data:`_DEATH_YEAR_TOLERANCE`, the merge is blocked even
   on a perfect name match — two scholars a century apart are not one person.
 * A **gender guard**: two records with explicit, differing ``gender`` never merge.
+* A **token-order guard** (da#138): ``token_set_ratio`` is order-*insensitive*, so
+  a pure nasab reversal of two **different** people — ``محمد بن عبد الله``
+  (Muḥammad son of ʿAbdullāh) ↔ ``عبد الله بن محمد`` (ʿAbdullāh son of Muḥammad) —
+  scores a perfect 100 and, with no death-year/gender to corroborate, would
+  falsely merge. The guard requires the shared significant tokens to appear in the
+  **same relative order** in the two matched spellings. A genuine variant only
+  *adds or drops* tokens (kunya/nisba/nasab expansion), which preserves the order
+  of the shared tokens, so recall is untouched; only a reordering is rejected.
+  This precision defect — and the validation harness that quantified its
+  false-merge rate — is the da#138 tech-debt work; raising the numeric threshold
+  cannot fix a perfect-100 reversal score and would only cost recall.
 
 Identity & ordering invariants
 -------------------------------
@@ -162,22 +173,45 @@ def _significant_tokens(keys: list[str]) -> set[str]:
     return tokens
 
 
-def _name_similarity(keys_a: list[str], keys_b: list[str]) -> float:
-    """Best token_set_ratio across the cross product of two records' match keys.
+def _significant_token_sequence(key: str) -> list[str]:
+    """Significant (non-connector) tokens of a single name string, in name order.
 
-    Taking the max over names + aliases means a record matches if *any* of its
-    spellings (including a da#94 variant) is a strong token-set match for any of
-    the other's — exactly the cross-source-variant recall this pass targets.
+    The ordered counterpart of :func:`_significant_tokens` — the token-order guard
+    compares relative order, so it needs the sequence, not the set.
     """
-    best = 0.0
+    return [tok for tok in key.split() if len(tok) >= 2 and tok not in _CONNECTOR_TOKENS]
+
+
+def _token_order_consistent(a: str, b: str) -> bool:
+    """True when the tokens shared by names ``a`` and ``b`` keep the same order.
+
+    A genuine variant only adds/removes tokens, so the shared tokens stay in the
+    same relative order; a nasab reversal of two different people permutes them.
+    Fewer than two shared significant tokens is left to :data:`_MIN_SHARED_TOKENS`
+    — this guard only adjudicates the high-overlap case a reversal can exploit.
+    """
+    seq_a = _significant_token_sequence(a)
+    seq_b = _significant_token_sequence(b)
+    shared = set(seq_a) & set(seq_b)
+    if len(shared) < 2:
+        return True
+    return [t for t in seq_a if t in shared] == [t for t in seq_b if t in shared]
+
+
+def _name_match(keys_a: list[str], keys_b: list[str], *, threshold: float) -> bool:
+    """True when some key pair is a strong AND token-order-consistent match.
+
+    A pair counts only if its ``token_set_ratio`` clears ``threshold`` *and* it
+    survives the da#138 token-order guard. Taking the best over the cross product
+    of each record's match keys (its name + da#94 aliases) keeps the alias-driven
+    recall — a record matches if *any* of its spellings is both a strong and
+    order-consistent match for any of the other's.
+    """
     for a in keys_a:
         for b in keys_b:
-            score = fuzz.token_set_ratio(a, b)
-            if score > best:
-                best = score
-                if best >= 100.0:
-                    return best
-    return best
+            if fuzz.token_set_ratio(a, b) >= threshold and _token_order_consistent(a, b):
+                return True
+    return False
 
 
 def _death_years_conflict(a: dict[str, Any], b: dict[str, Any]) -> bool:
@@ -204,15 +238,17 @@ def _can_merge(a: dict[str, Any], b: dict[str, Any], *, threshold: float) -> boo
 
     A merge requires ALL of: no death-year conflict, no gender conflict, at least
     :data:`_MIN_SHARED_TOKENS` shared significant name tokens (so a bare
-    single-token subset never clusters), and a name similarity at/above
-    ``threshold``. Pairwise and symmetric — the cluster post-validation relies on
-    that to refuse any cluster harbouring a guard-conflicting pair.
+    single-token subset never clusters), and a matched key pair that clears
+    ``threshold`` *and* is token-order-consistent (so a nasab reversal of two
+    different people does not merge — da#138). Pairwise and symmetric — the cluster
+    post-validation relies on that to refuse any cluster harbouring a
+    guard-conflicting pair.
     """
     if _death_years_conflict(a, b) or _genders_conflict(a, b):
         return False
     if _shared_significant_token_count(a, b) < _MIN_SHARED_TOKENS:
         return False
-    return _name_similarity(_match_keys(a), _match_keys(b)) >= threshold
+    return _name_match(_match_keys(a), _match_keys(b), threshold=threshold)
 
 
 # ---------------------------------------------------------------------------

--- a/src/resolve/quality.py
+++ b/src/resolve/quality.py
@@ -35,6 +35,17 @@ class ClusterQuality:
     predicted_pairs: int
     gold_pairs: int
 
+    @property
+    def false_merge_rate(self) -> float:
+        """Fraction of predicted same-narrator pairs that are wrong (over-merges).
+
+        The complement of precision (``1 - precision``) — the direct measure of
+        clustering *over-merging*, surfaced by name so the da#138 precision harness
+        and any future CI report share one definition. ``0.0`` when no pairs were
+        predicted (nothing was merged, so nothing was mis-merged).
+        """
+        return 1.0 - self.precision if self.predicted_pairs else 0.0
+
     def summary(self) -> str:
         """One-line human-readable summary."""
         return (

--- a/src/utils/arabic.py
+++ b/src/utils/arabic.py
@@ -48,15 +48,55 @@ _ARABIC_CHAR_RE: re.Pattern[str] = re.compile(r"[\u0600-\u06FF]")
 # Transmission phrase patterns
 # ---------------------------------------------------------------------------
 
+# Optional run of Arabic diacritics (tashkeel U+064B–U+065F, superscript alef
+# U+0670) and tatweel/kashida (U+0640). Real isnad text is fully voweled
+# (e.g. ``حَدَّثَنَا``), so a bare keyword like ``حدثنا`` will never match unless
+# we tolerate diacritics interleaved *between* the base letters. Without this
+# the extractor found zero transmission phrases on every voweled chain and fell
+# back to emitting the whole isnad as a single un-segmented "narrator" (da#146).
+_OPT_DIAC: str = r"[\u064b-\u065f\u0670\u0640]*"
+
+# Base transmission terms keyed to their canonical label. Written with the
+# classical hamza-bearing forms (أ/إ) so they match raw, un-normalized isnad
+# text; positions returned therefore index into the caller's original string.
+# Singular (-ني) and 3rd-person (سمع) variants are included alongside the plural
+# (-نا) forms because real chains alternate between them ("حدثني" / "أخبرني" /
+# "سمع فلانٌ") — omitting them under-segments the chain (da#146).
+_TRANSMISSION_TERMS: dict[str, str] = {
+    "حدثنا": "haddathana",
+    "حدثني": "haddathani",
+    "أخبرنا": "akhbarana",
+    "أخبرني": "akhbarani",
+    "أنبأنا": "anba_ana",
+    "أنبأني": "anba_ani",
+    "سمعت": "samitu",
+    "سمع": "samia",
+    "عن": "an",
+    "قال": "qala",
+    "ناولني": "nawalani",
+    "كتب إلي": "kataba_ilayya",
+}
+
+
+def _compile_diacritic_tolerant(term: str) -> re.Pattern[str]:
+    """Compile *term* into a regex that tolerates interleaved diacritics.
+
+    Each base letter is followed by an optional diacritics/tatweel run, and
+    inter-word whitespace is matched flexibly. The compiled pattern matches the
+    fully-voweled form found in real isnads while preserving match positions in
+    the original (un-normalized) text.
+    """
+    parts: list[str] = []
+    for ch in term:
+        if ch.isspace():
+            parts.append(r"\s+")
+        else:
+            parts.append(re.escape(ch) + _OPT_DIAC)
+    return re.compile("".join(parts))
+
+
 TRANSMISSION_PATTERNS: dict[re.Pattern[str], str] = {
-    re.compile(r"حدثنا"): "haddathana",
-    re.compile(r"أخبرنا"): "akhbarana",
-    re.compile(r"سمعت"): "samitu",
-    re.compile(r"عن"): "an",
-    re.compile(r"قال"): "qala",
-    re.compile(r"أنبأنا"): "anba_ana",
-    re.compile(r"ناولني"): "nawalani",
-    re.compile(r"كتب\s+إلي"): "kataba_ilayya",
+    _compile_diacritic_tolerant(term): label for term, label in _TRANSMISSION_TERMS.items()
 }
 
 # ---------------------------------------------------------------------------
@@ -118,12 +158,27 @@ def extract_transmission_phrases(text: str) -> list[tuple[int, int, str]]:
     """Find transmission formula positions in *text*.
 
     Returns a list of ``(start, end, label)`` tuples for each non-overlapping
-    match found via :data:`TRANSMISSION_PATTERNS`.
+    match found via :data:`TRANSMISSION_PATTERNS`, in ascending start order.
+
+    Overlapping matches are resolved by preferring the longer (more specific)
+    term: e.g. where both ``سمعت`` (samitu) and the bare ``سمع`` (samia) match at
+    the same position, only ``سمعت`` is kept. This keeps segment boundaries in
+    :func:`src.parse.narrator_extraction._extract_arabic` clean when overlapping
+    variants are present in the pattern set.
     """
-    results: list[tuple[int, int, str]] = []
+    matches: list[tuple[int, int, str]] = []
     for pattern, label in TRANSMISSION_PATTERNS.items():
         for match in pattern.finditer(text):
-            results.append((match.start(), match.end(), label))
-    # Sort by start position for deterministic output
-    results.sort(key=lambda t: t[0])
+            matches.append((match.start(), match.end(), label))
+
+    # Sort by start asc, then by span length desc so that at any shared start the
+    # longer match is considered first and shorter overlapping ones are dropped.
+    matches.sort(key=lambda t: (t[0], -(t[1] - t[0])))
+
+    results: list[tuple[int, int, str]] = []
+    last_end = -1
+    for start, end, label in matches:
+        if start >= last_end:
+            results.append((start, end, label))
+            last_end = end
     return results

--- a/src/utils/grade.py
+++ b/src/utils/grade.py
@@ -1,0 +1,63 @@
+"""Hadith authenticity-grade normalization.
+
+Source corpora record a hadith's grade as free text in whatever script the
+upstream used: Arabic (``صحيح``), transliterated English (``Sahih``,
+``Da'if``), or descriptive English (``authentic``, ``weak``). The graph stores
+that raw string verbatim so the original is never lost, but a raw Arabic /
+mixed-script value is not a stable key to filter, facet, or display on. This
+module maps any of those raw forms onto the canonical :class:`HadithGrade`
+vocabulary so a normalized *display* field can sit alongside the raw one
+(da#148 integrity sweep — "grade stored as raw Arabic, needs normalized
+display").
+
+The function is deliberately conservative: anything it does not recognise maps
+to :data:`HadithGrade.UNKNOWN` rather than guessing, so a normalized value is
+always a real enum member.
+"""
+
+from __future__ import annotations
+
+from src.models.enums import HadithGrade
+from src.utils.arabic import normalize_arabic
+
+__all__ = ["normalize_grade"]
+
+# Match order matters: the ``li-ghayrihi`` ("…by virtue of corroboration")
+# qualifiers are checked before the bare grade so ``صحيح لغيره`` does not match
+# the plain ``sahih`` rule first. Each entry is ``(needles, grade)`` — the raw
+# value matches if ANY needle is a substring of the normalized text. Arabic
+# needles are pre-normalized with :func:`normalize_arabic` (the same pipeline
+# applied to the input) so diacritics/alif/taa-marbuta variants all collapse.
+_GRADE_RULES: list[tuple[tuple[str, ...], HadithGrade]] = [
+    (
+        (normalize_arabic("صحيح لغيره"), "sahih li ghayrihi", "sahih li-ghayrihi"),
+        HadithGrade.SAHIH_LI_GHAYRIHI,
+    ),
+    (
+        (normalize_arabic("حسن لغيره"), "hasan li ghayrihi", "hasan li-ghayrihi"),
+        HadithGrade.HASAN_LI_GHAYRIHI,
+    ),
+    ((normalize_arabic("موضوع"), "mawdu", "fabricat"), HadithGrade.MAWDU),
+    ((normalize_arabic("ضعيف"), "daif", "da'if", "weak"), HadithGrade.DAIF),
+    ((normalize_arabic("صحيح"), "sahih", "authentic"), HadithGrade.SAHIH),
+    ((normalize_arabic("حسن"), "hasan", "good"), HadithGrade.HASAN),
+]
+
+
+def normalize_grade(raw: str | None) -> str:
+    """Map a raw grade string (Arabic or English, any corpus) to a HadithGrade.
+
+    Returns the :class:`HadithGrade` *value* (a ``str``) so it can be written
+    straight onto a node property. An empty / non-string / unrecognised value
+    yields :data:`HadithGrade.UNKNOWN` — the raw field still carries the
+    original, so nothing is lost.
+    """
+    if not raw or not isinstance(raw, str):
+        return HadithGrade.UNKNOWN.value
+    # Normalize the Arabic side and lowercase the Latin side so one pass of
+    # substring checks covers both scripts.
+    text = normalize_arabic(raw).lower()
+    for needles, grade in _GRADE_RULES:
+        if any(needle and needle in text for needle in needles):
+            return grade.value
+    return HadithGrade.UNKNOWN.value

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -91,6 +91,20 @@ class TestBuildChainPairs:
         assert pairs[1]["from_id"] == "nar:2"
         assert pairs[1]["to_id"] == "nar:3"
 
+    def test_adjacent_duplicate_narrator_skipped(self) -> None:
+        # Two adjacent mentions resolving to the same narrator must not produce a
+        # self-loop TRANSMITTED_TO edge (da#148 — 8 live self-loops).
+        mentions = [
+            {"canonical_narrator_id": "nar:1", "position_in_chain": 0, "hadith_id": "h1"},
+            {"canonical_narrator_id": "nar:1", "position_in_chain": 1, "hadith_id": "h1"},
+            {"canonical_narrator_id": "nar:2", "position_in_chain": 2, "hadith_id": "h1"},
+        ]
+        pairs = _build_chain_pairs(mentions)
+        # nar:1->nar:1 dropped; only nar:1->nar:2 survives.
+        assert len(pairs) == 1
+        assert pairs[0] == {"from_id": "nar:1", "to_id": "nar:2", "position": 1, "hadith_id": "h1"}
+        assert all(p["from_id"] != p["to_id"] for p in pairs)
+
 
 class TestLoadTransmittedTo:
     def test_creates_edges_from_resolved_mentions(

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -334,6 +334,32 @@ class TestLoadGradings:
         assert grading_result.node_type == "Grading"
         assert grading_result.created + grading_result.merged == 2
 
+    def test_grading_carries_normalized_display_grade(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """Raw Arabic grade is preserved and a normalized display grade added (da#148)."""
+        write_hadiths(
+            staging_dir,
+            [
+                {"source_id": "h-1", "grade": "صحيح"},  # raw Arabic
+                {"source_id": "h-2", "grade": "Da'if"},
+            ],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        grading_batches = [
+            batch
+            for _query, batch in mock_client.calls
+            if isinstance(batch, list)
+            and batch
+            and "id" in batch[0]
+            and batch[0]["id"].startswith("grd:")
+        ]
+        assert len(grading_batches) >= 1
+        by_hadith = {r["hadith_id"]: r for r in grading_batches[0]}
+        assert by_hadith["hdt:h-1"]["grade"] == "صحيح"  # raw preserved
+        assert by_hadith["hdt:h-1"]["grade_normalized"] == "sahih"
+        assert by_hadith["hdt:h-2"]["grade_normalized"] == "daif"
+
 
 class TestLoadHistoricalEvents:
     def test_valid_events(

--- a/tests/test_parse/test_mis_parser.py
+++ b/tests/test_parse/test_mis_parser.py
@@ -177,6 +177,154 @@ class TestMisEdgeLayout:
         ]
 
 
+def _make_current_mendeley_data(raw_dir: Path) -> None:
+    """The **current** Mendeley v2 three-file graph export (da#144).
+
+    Mirrors the real dataset shape:
+      * ``1_…HadithContent.xlsx``        — core hadith rows (HadithContent cols).
+      * ``2_…Narrators=Nodes for Graph.xlsx`` — narrator NODE list (decoy: its
+        filename contains "narrator", so it must NOT be picked as the detail file).
+      * ``3_…Isnad=Edges for Graph.xlsx`` — explicit ``source*``/``target*`` edge
+        rows keyed by ``(BookNo, HadithNo, SanadNo)``.
+
+    Hadith 1 carries TWO sanads (1, 2) that share endpoints but diverge in the
+    middle; hadith 2 a single sanad. The chain-specific edges only survive if the
+    parallel asanid are kept apart.
+    """
+    mis_dir = raw_dir / "mis"
+    mis_dir.mkdir(parents=True)
+
+    _write_xlsx(
+        mis_dir / "1_Hadith_SahihMuslim_HadithContent.xlsx",
+        [
+            "BookNo",
+            "BookTitleEnAr",
+            "HadithNo",
+            "ChapterNo",
+            "UnitNo",
+            "HadithText_Mushakkal",
+            "HadithText_GhairMushakkal",
+            "SanadCount",
+        ],
+        [
+            [2, "Sahih Muslim", 1, 1, 1, "مَتْنٌ مُشَكَّل", "متن", 2],
+            [2, "Sahih Muslim", 2, 1, 2, "مَتْنٌ ثَانٍ", "متن ثان", 1],
+        ],
+    )
+
+    # Decoy node list — filename contains "narrator" but is NOT the edge file.
+    _write_xlsx(
+        mis_dir / "2_Hadith_SahihMuslim_Narrators=Nodes for Graph.xlsx",
+        ["Label", "NarratorID_Mapped", "NarratorNameEn-Mapped"],
+        [["A (0)", 1, "A"], ["B (0)", 2, "B"]],
+    )
+
+    # (BookNo, HadithNo, SanadNo, sourceNarratorID, sourceNarratorNameEn,
+    #  targetNarratorID, targetNarratorNameEn)
+    edge_rows: list[list[object]] = [
+        # hadith 1, sanad 1: A -> B -> C
+        [2, 1, 1, 10, "A", 11, "B"],
+        [2, 1, 1, 11, "B", 12, "C"],
+        # hadith 1, sanad 2: A -> D -> C  (chain-specific A->D, D->C)
+        [2, 1, 2, 10, "A", 13, "D"],
+        [2, 1, 2, 13, "D", 12, "C"],
+        # hadith 2, single sanad: X -> Y
+        [2, 2, 1, 20, "X", 21, "Y"],
+    ]
+    _write_xlsx(
+        mis_dir / "3_Hadith_SahihMuslim_Isnad=Edges for Graph.xlsx",
+        [
+            "BookNo",
+            "HadithNo",
+            "SanadNo",
+            "sourceNarratorID",
+            "sourceNarratorNameEn",
+            "targetNarratorID",
+            "targetNarratorNameEn",
+        ],
+        edge_rows,
+    )
+
+
+class TestMisCurrentMendeleyShape:
+    """da#144 — parse the current three-file Mendeley graph export."""
+
+    def test_selects_content_and_edges_not_nodes(self, tmp_path: Path) -> None:
+        """The detail file resolves to the *Edges* workbook, never the *Nodes* one."""
+        from src.parse.mis import _CORE_TOKENS, _DETAIL_TOKENS, _find_file
+
+        _make_current_mendeley_data(tmp_path / "raw")
+        mis_dir = tmp_path / "raw" / "mis"
+        core = _find_file(mis_dir, _CORE_TOKENS)
+        detail = _find_file(mis_dir, _DETAIL_TOKENS)
+        assert core is not None and "HadithContent" in core.name
+        assert detail is not None and "Edges" in detail.name
+        assert "Nodes" not in detail.name  # the decoy must lose
+
+    def test_hadith_schema_matn_and_tagging(self, tmp_path: Path) -> None:
+        _make_current_mendeley_data(tmp_path / "raw")
+        hadiths_path, _ = run(tmp_path / "raw", tmp_path / "staging")
+
+        table = pq.read_table(hadiths_path)
+        assert table.schema == HADITH_SCHEMA
+        assert table.num_rows == 2
+        assert set(table.column("source_corpus").to_pylist()) == {"mis"}
+        assert set(table.column("sect").to_pylist()) == {"sunni"}
+        # The vocalized HadithText_Mushakkal column feeds matn_ar.
+        assert table.column("matn_ar").to_pylist() == ["مَتْنٌ مُشَكَّل", "مَتْنٌ ثَانٍ"]
+        for sid in table.column("source_id").to_pylist():
+            assert validate_source_id(sid) == [], sid
+            assert sid.startswith("mis:sahih_muslim:")
+        # BookNo flows into the source_id grammar.
+        assert "mis:sahih_muslim:2:1" in table.column("source_id").to_pylist()
+
+    def test_edge_schema_relation_and_external_ids(self, tmp_path: Path) -> None:
+        _make_current_mendeley_data(tmp_path / "raw")
+        _, edges_path = run(tmp_path / "raw", tmp_path / "staging")
+
+        table = pq.read_table(edges_path)
+        assert table.schema == NETWORK_EDGE_SCHEMA
+        assert set(table.column("source").to_pylist()) == {"mis"}
+        # isnad-transmission edges → TRANSMITTED_TO, never STUDIED_UNDER (da#133).
+        assert set(table.column("relation").to_pylist()) == {"TRANSMITTED_TO"}
+        # The source/target narrator IDs flow into the external-id columns.
+        assert all(v is not None for v in table.column("from_external_id").to_pylist())
+        assert all(v is not None for v in table.column("to_external_id").to_pylist())
+        ab = next(
+            r
+            for r in table.to_pylist()
+            if r["from_narrator_name"] == "A" and r["to_narrator_name"] == "B"
+        )
+        assert ab["from_external_id"] == "10"
+        assert ab["to_external_id"] == "11"
+
+    def test_multiplicity_preserved_across_sanads(self, tmp_path: Path) -> None:
+        """Hadith 1's two sanads survive as distinct chains (A->D, D->C exist)."""
+        _make_current_mendeley_data(tmp_path / "raw")
+        _, edges_path = run(tmp_path / "raw", tmp_path / "staging")
+        rows = pq.read_table(edges_path).to_pylist()
+
+        # 2 (sanad 1) + 2 (sanad 2) + 1 (hadith 2) = 5 edges.
+        assert len(rows) == 5
+        h1_id = "mis:sahih_muslim:2:1"
+        h1_pairs = {
+            (r["from_narrator_name"], r["to_narrator_name"])
+            for r in rows
+            if r["hadith_id"] == h1_id
+        }
+        assert h1_pairs == {("A", "B"), ("B", "C"), ("A", "D"), ("D", "C")}
+        # Chain-specific edges that only exist because the asanid were not collapsed.
+        assert ("A", "D") in h1_pairs
+        assert ("D", "C") in h1_pairs
+
+    def test_edges_join_to_hadith_source_id(self, tmp_path: Path) -> None:
+        _make_current_mendeley_data(tmp_path / "raw")
+        hadiths_path, edges_path = run(tmp_path / "raw", tmp_path / "staging")
+        hadith_ids = set(pq.read_table(hadiths_path).column("source_id").to_pylist())
+        edge_hadith_ids = set(pq.read_table(edges_path).column("hadith_id").to_pylist())
+        assert edge_hadith_ids <= hadith_ids
+
+
 class TestMisErrors:
     def test_missing_source_dir_raises(self, tmp_path: Path) -> None:
         (tmp_path / "raw").mkdir()

--- a/tests/test_parse/test_narrator_extraction.py
+++ b/tests/test_parse/test_narrator_extraction.py
@@ -59,6 +59,51 @@ class TestArabicExtraction:
         assert len(spans) >= 1
 
 
+class TestDa146VoweledSegmentation:
+    """Regression tests for da#146: fully-voweled (diacritized) Arabic isnads.
+
+    Real lk-corpus chains are fully voweled (``حَدَّثَنَا ...``). Before da#146 the
+    diacritic-free transmission patterns never matched, so the whole chain
+    collapsed into a single un-segmented "narrator" mention. These tests pin the
+    fixed behaviour: a voweled chain splits into one mention per narrator.
+    """
+
+    # Sahih al-Bukhari hadith 1 isnad — five named narrators in the chain.
+    _BUKHARI_H1_ISNAD = (
+        "حَدَّثَنَا الْحُمَيْدِيُّ عَبْدُاللَّهِ بْنُ الزُّبَيْرِ، قَالَ حَدَّثَنَا "
+        "سُفْيَانُ، قَالَ حَدَّثَنَا يَحْيَى بْنُ سَعِيدٍ الأَنْصَارِيُّ، قَالَ "
+        "أَخْبَرَنِي مُحَمَّدُ بْنُ إِبْرَاهِيمَ التَّيْمِيُّ، أَنَّهُ سَمِعَ "
+        "عَلْقَمَةَ بْنَ وَقَّاصٍ اللَّيْثِيَّ"
+    )
+
+    def test_voweled_chain_does_not_collapse_to_blob(self) -> None:
+        """The whole voweled chain must not become one giant mention."""
+        spans = extract_narrator_mentions(self._BUKHARI_H1_ISNAD, "ar")
+        assert len(spans) >= 4
+        # No single span should swallow the entire chain.
+        assert all(len(s.name) < len(self._BUKHARI_H1_ISNAD) // 2 for s in spans)
+
+    def test_positions_sequential_and_unique(self) -> None:
+        spans = extract_narrator_mentions(self._BUKHARI_H1_ISNAD, "ar")
+        positions = [s.position for s in spans]
+        assert positions == list(range(len(spans)))
+
+    def test_first_narrator_segmented(self) -> None:
+        """The first narrator after ``حدثنا`` is isolated (al-Humaydi)."""
+        spans = extract_narrator_mentions(self._BUKHARI_H1_ISNAD, "ar")
+        # Normalized form of الحميدي عبدالله بن الزبير, comma stripped.
+        assert spans[0].name.startswith("الحميدي")
+        assert "،" not in spans[0].name
+        assert spans[0].transmission_method == "haddathana"
+
+    def test_singular_variant_segments(self) -> None:
+        """``أخبرني`` / ``سمع`` (singular/3rd-person) also split the chain."""
+        spans = extract_narrator_mentions(self._BUKHARI_H1_ISNAD, "ar")
+        methods = {s.transmission_method for s in spans}
+        assert "akhbarani" in methods
+        assert "samia" in methods
+
+
 class TestEdgeCases:
     def test_empty_string(self) -> None:
         assert extract_narrator_mentions("", "en") == []

--- a/tests/test_resolve/fixtures/cluster_precision_gold.json
+++ b/tests/test_resolve/fixtures/cluster_precision_gold.json
@@ -1,0 +1,25 @@
+{
+  "_README": "Labeled gold set for the da#138 fuzzy-cluster PRECISION harness. Each entry is one canonical narrator record (as the exact-name pass would emit it) with a hand-assigned `gold_person`: records sharing a `gold_person` are the SAME real narrator and SHOULD cluster; distinct `gold_person` values must stay apart. The set deliberately mixes legitimate cross-source variants (recall) with the precision traps that over-merging fuzzy clustering falls into (death-year-distinguished homonyms; the da#138 nasab-reversal pair whose token_set_ratio is a perfect 100). No two DISTINCT-person records share a normalized name — byte-identical names already collapse in the exact-name pass before fuzzy clustering runs, so they are not a fuzzy false-merge. `name_ar` is normalized by the harness via normalize_arabic, exactly as the real producers key make_canonical_id.",
+  "records": [
+    {"name_ar": "محمد بن اسماعيل البخاري", "gold_person": "bukhari", "death_year_ah": 256, "mention_count": 10, "source_corpora": ["itqan"]},
+    {"name_ar": "محمد بن اسماعيل", "gold_person": "bukhari", "death_year_ah": 256, "mention_count": 3, "source_corpora": ["sanadset"]},
+
+    {"name_ar": "احمد بن حنبل الشيباني", "gold_person": "ahmad", "death_year_ah": 241, "mention_count": 8, "source_corpora": ["itqan"]},
+    {"name_ar": "احمد بن حنبل", "gold_person": "ahmad", "death_year_ah": 241, "mention_count": 2, "source_corpora": ["sanadset"]},
+
+    {"name_ar": "مالك بن انس الاصبحي", "gold_person": "malik", "death_year_ah": 179, "mention_count": 6, "source_corpora": ["itqan"]},
+    {"name_ar": "مالك بن انس", "gold_person": "malik", "death_year_ah": 179, "mention_count": 4, "source_corpora": ["thaqalayn"]},
+
+    {"name_ar": "ابو حفص العدوي القرشي", "gold_person": "umar", "aliases": ["عمر بن الخطاب"], "mention_count": 5, "source_corpora": ["itqan"]},
+    {"name_ar": "عمر بن الخطاب", "gold_person": "umar", "mention_count": 7, "source_corpora": ["sanadset"]},
+
+    {"name_ar": "سفيان الثوري", "gold_person": "thawri", "death_year_ah": 161, "mention_count": 4, "source_corpora": ["itqan"]},
+    {"name_ar": "سفيان بن عيينة", "gold_person": "uyayna", "death_year_ah": 198, "mention_count": 3, "source_corpora": ["sanadset"]},
+
+    {"name_ar": "يحيى بن سعيد القطان", "gold_person": "yahya_qattan", "death_year_ah": 198, "mention_count": 3, "source_corpora": ["itqan"]},
+    {"name_ar": "يحيى بن سعيد الانصاري", "gold_person": "yahya_ansari", "death_year_ah": 143, "mention_count": 2, "source_corpora": ["sanadset"]},
+
+    {"name_ar": "محمد بن عبد الله", "gold_person": "muhammad_b_abdullah", "mention_count": 2, "source_corpora": ["itqan"]},
+    {"name_ar": "عبد الله بن محمد", "gold_person": "abdullah_b_muhammad", "mention_count": 2, "source_corpora": ["thaqalayn"]}
+  ]
+}

--- a/tests/test_resolve/test_cluster_precision.py
+++ b/tests/test_resolve/test_cluster_precision.py
@@ -1,0 +1,142 @@
+"""Precision-validation harness for fuzzy cross-source narrator clustering (da#138).
+
+The fuzzy pass (``src.resolve.fuzzy_cluster``) trades a little precision for recall:
+it merges high-confidence name variants of one narrator that the exact-name pass
+leaves split. The risk is *over-merging* — collapsing two genuinely different
+people into one canonical narrator. ``test_fuzzy_cluster`` already proves a handful
+of individual guards; this module is the aggregate **precision guard**: a labeled
+gold set of narrator records run end-to-end through ``cluster_assignment`` and
+scored with ``quality.pairwise_quality``, asserting precision stays at its
+documented baseline so a future change that loosens clustering is caught here.
+
+Findings that motivated the harness (measured on ``cluster_precision_gold.json``):
+
+* Before da#138 the clustering **falsely merged a nasab reversal** — ``محمد بن عبد
+  الله`` (Muḥammad b. ʿAbdullāh) and ``عبد الله بن محمد`` (ʿAbdullāh b. Muḥammad),
+  two different people — because ``rapidfuzz.token_set_ratio`` is order-insensitive
+  and scores that pair a perfect ``100``. With no death-year/gender metadata to
+  corroborate, the merge went through: precision ``0.667`` / **false-merge rate
+  ``0.333``** on this set. Raising the numeric threshold cannot fix a 100 score and
+  would only cost recall, so the fix is the token-order guard, not a higher bar.
+* With the da#138 token-order guard in place the same set scores precision
+  ``1.000`` (**false-merge rate ``0.000``**) at recall ``1.000`` — the legitimate
+  cross-source variants still merge. The sensitivity test below re-introduces the
+  regression to prove this harness would catch it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.parse.identity import make_canonical_id
+from src.resolve import fuzzy_cluster
+from src.resolve.fuzzy_cluster import cluster_assignment
+from src.resolve.quality import pairwise_quality
+from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+
+# The documented precision floor for the labeled gold set. The fuzzy pass must not
+# over-merge any distinct narrator in the set — every predicted same-narrator pair
+# must be a true one (false-merge rate 0.0). A drop here means a change loosened
+# clustering precision; investigate before lowering this number.
+PRECISION_BASELINE = 1.0
+
+# Recall floor on the same set: a precision guard is worthless if it is satisfied
+# by refusing every merge, so we also pin recall — the legitimate cross-source
+# variants in the fixture must still cluster.
+RECALL_FLOOR = 1.0
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "cluster_precision_gold.json"
+
+
+def _load_gold() -> tuple[list[dict[str, Any]], dict[str, str]]:
+    """Build canonical records + the gold ``canonical_id -> person`` map from JSON.
+
+    Each fixture entry becomes a full ``NARRATORS_CANONICAL_SCHEMA`` record keyed,
+    like the real producers, on ``make_canonical_id(normalize_arabic(name_ar))`` so
+    the harness exercises the genuine identity contract. Distinct people never share
+    a normalized name (asserted), so canonical ids are unique and the gold map is
+    lossless.
+    """
+    raw = json.loads(_FIXTURE.read_text(encoding="utf-8"))
+    records: list[dict[str, Any]] = []
+    gold: dict[str, str] = {}
+    for entry in raw["records"]:
+        norm = normalize_arabic(entry["name_ar"])
+        canonical_id = make_canonical_id(norm)
+        record: dict[str, Any] = {f.name: None for f in NARRATORS_CANONICAL_SCHEMA}
+        record.update(
+            {
+                "canonical_id": canonical_id,
+                "name_ar": entry["name_ar"],
+                "name_ar_normalized": norm,
+                "aliases": [normalize_arabic(a) for a in entry.get("aliases", [])],
+                "source_ids": [],
+                "source_corpora": entry.get("source_corpora", []),
+                "mention_count": entry.get("mention_count", 1),
+            }
+        )
+        for field in ("death_year_ah", "gender", "external_id"):
+            if field in entry:
+                record[field] = entry[field]
+        records.append(record)
+        gold[canonical_id] = entry["gold_person"]
+    return records, gold
+
+
+def test_gold_fixture_is_well_formed() -> None:
+    """The fixture has no distinct-person name collisions and ≥1 true merge pair."""
+    records, gold = _load_gold()
+    ids = [r["canonical_id"] for r in records]
+    assert len(ids) == len(set(ids)), "distinct records collide on canonical_id"
+    # At least one gold cluster has >1 member, else recall is vacuous.
+    person_counts: dict[str, int] = {}
+    for person in gold.values():
+        person_counts[person] = person_counts.get(person, 0) + 1
+    assert any(n > 1 for n in person_counts.values())
+
+
+def test_clustering_precision_meets_baseline() -> None:
+    """End-to-end: clustering the gold set over-merges nothing (precision floor)."""
+    records, gold = _load_gold()
+    predicted = cluster_assignment(records)
+    quality = pairwise_quality(predicted, gold)
+
+    assert quality.precision >= PRECISION_BASELINE, (
+        f"clustering precision regressed: {quality.summary()} "
+        f"(false-merge rate {quality.false_merge_rate:.3f})"
+    )
+    # Precision floor of 1.0 means zero false merges — keep the two phrasings in sync.
+    assert quality.false_merge_rate <= 1.0 - PRECISION_BASELINE
+    # And the guard is not met by under-merging: the real variants still cluster.
+    assert quality.recall >= RECALL_FLOOR, f"recall regressed: {quality.summary()}"
+
+
+def test_nasab_reversal_does_not_false_merge() -> None:
+    """The da#138 trap pair (reversed nasab, different people) stays in two clusters."""
+    records, _ = _load_gold()
+    forward = make_canonical_id(normalize_arabic("محمد بن عبد الله"))
+    reversed_ = make_canonical_id(normalize_arabic("عبد الله بن محمد"))
+    predicted = cluster_assignment(records)
+    assert predicted[forward] != predicted[reversed_]
+
+
+def test_harness_detects_a_precision_regression(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disabling the da#138 token-order guard must drop the harness's precision.
+
+    This is the harness's own meta-test: if a future refactor silently removed the
+    order guard, ``test_clustering_precision_meets_baseline`` must start failing.
+    We simulate that removal by neutralizing ``_token_order_consistent`` and confirm
+    precision falls below the baseline and the false-merge rate rises — i.e. the
+    reversed-nasab pair gets wrongly merged again.
+    """
+    records, gold = _load_gold()
+    monkeypatch.setattr(fuzzy_cluster, "_token_order_consistent", lambda a, b: True)
+
+    regressed = pairwise_quality(cluster_assignment(records), gold)
+    assert regressed.precision < PRECISION_BASELINE
+    assert regressed.false_merge_rate > 0.0

--- a/tests/test_resolve/test_lk_segmentation_e2e.py
+++ b/tests/test_resolve/test_lk_segmentation_e2e.py
@@ -1,0 +1,120 @@
+"""End-to-end regression for da#146: a voweled lk-corpus chain must resolve to
+*multiple* canonical narrators, not a single un-segmented blob.
+
+Flow exercised: lk CSV (fully voweled Arabic isnad)
+  → :func:`src.parse.lk_corpus.run`        (narrator_mentions_lk.parquet)
+  → :func:`src.resolve.ner.run`            (narrator_mentions_resolved.parquet)
+  → :func:`src.resolve.disambiguate.run`   (narrators_canonical.parquet)
+
+Before da#146 the diacritic-free transmission patterns never matched the voweled
+chain, so each whole chain became one mention → one "narrator". This test pins
+that a single chain now yields several distinct canonical narrators.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from src.parse.lk_corpus import LK_COLUMNS
+from src.parse.lk_corpus import run as lk_run
+from src.parse.schemas import NARRATOR_BIO_SCHEMA
+from src.resolve import disambiguate, ner
+
+# Sahih al-Bukhari hadith 1 — five+ named narrators in a fully-voweled isnad.
+_BUKHARI_H1_ISNAD_AR = (
+    "حَدَّثَنَا الْحُمَيْدِيُّ عَبْدُاللَّهِ بْنُ الزُّبَيْرِ، قَالَ حَدَّثَنَا "
+    "سُفْيَانُ، قَالَ حَدَّثَنَا يَحْيَى بْنُ سَعِيدٍ الأَنْصَارِيُّ، قَالَ "
+    "أَخْبَرَنِي مُحَمَّدُ بْنُ إِبْرَاهِيمَ التَّيْمِيُّ، أَنَّهُ سَمِعَ "
+    "عَلْقَمَةَ بْنَ وَقَّاصٍ اللَّيْثِيَّ"
+)
+
+
+def _write_lk_csv(path: Path) -> None:
+    """Write a one-row lk CSV (16-column layout) with a voweled Arabic isnad."""
+    row = {c: "" for c in LK_COLUMNS}
+    row.update(
+        {
+            "Chapter_Number": "1",
+            "Chapter_English": "Revelation",
+            "Chapter_Arabic": "بدء الوحي",
+            "Section_Number": "1",
+            "Hadith_number": "1",
+            "English_Hadith": "Narrated Umar: Actions are by intentions",
+            "English_Isnad": "Narrated 'Umar bin Al-Khattab:",
+            "English_Matn": "Actions are by intentions",
+            "Arabic_Isnad": _BUKHARI_H1_ISNAD_AR,
+            "Arabic_Matn": "إنما الأعمال بالنيات",
+            "Arabic_Hadith": _BUKHARI_H1_ISNAD_AR,
+            "English_Grade": "Sahih",
+            "Arabic_Grade": "صحيح",
+        }
+    )
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=LK_COLUMNS)
+        writer.writeheader()
+        writer.writerow(row)
+
+
+def _seed_bio_candidate(staging_dir: Path) -> None:
+    """Write a minimal narrators_bio parquet so disambiguate has candidates.
+
+    ``disambiguate.run`` early-returns when no biographical candidates exist;
+    one Sufyan bio both unblocks the run and provides an exact-match target for
+    the segmented ``سفيان`` mention.
+    """
+    fields = {f.name: None for f in NARRATOR_BIO_SCHEMA}
+    fields.update(
+        {
+            "bio_id": "bio:test:sufyan",
+            "source": "test",
+            "name_ar": "سفيان",
+            "name_ar_normalized": "سفيان",
+            "name_en": "Sufyan",
+            "death_year_ah": 198,
+        }
+    )
+    arrays = {f.name: pa.array([fields[f.name]], type=f.type) for f in NARRATOR_BIO_SCHEMA}
+    table = pa.table(arrays, schema=NARRATOR_BIO_SCHEMA)
+    pq.write_table(table, staging_dir / "narrators_bio_test.parquet")
+
+
+def test_voweled_lk_chain_yields_multiple_canonical_narrators(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    (raw_dir / "lk").mkdir(parents=True)
+    staging_dir = tmp_path / "staging"
+    output_dir = tmp_path / "output"
+    staging_dir.mkdir()
+    output_dir.mkdir()
+
+    _write_lk_csv(raw_dir / "lk" / "albukhari.csv")
+
+    # 1) Parse — the lk parser must emit several mention rows for the one chain.
+    lk_run(raw_dir, staging_dir)
+    mentions = pq.read_table(staging_dir / "narrator_mentions_lk.parquet")
+    ar_mentions = [
+        mentions.column("name_ar")[i].as_py()
+        for i in range(mentions.num_rows)
+        if mentions.column("name_ar")[i].as_py()
+    ]
+    assert len(ar_mentions) >= 4, f"chain not segmented: {ar_mentions}"
+    # No mention should be the whole chain (the pre-da#146 blob failure mode).
+    assert all(len(m) < len(_BUKHARI_H1_ISNAD_AR) // 2 for m in ar_mentions)
+
+    # 2) NER consolidation.
+    ner.run(staging_dir, output_dir)
+    resolved = pq.read_table(output_dir / "narrator_mentions_resolved.parquet")
+    assert resolved.num_rows >= 4
+
+    # 3) Disambiguate — must materialize multiple canonical narrators, not 0/1.
+    _seed_bio_candidate(staging_dir)
+    disambiguate.run(staging_dir, output_dir)
+    canonical = pq.read_table(output_dir / "narrators_canonical.parquet")
+    assert canonical.num_rows >= 4
+
+    # The seeded Sufyan bio should have matched the segmented سفيان mention.
+    names_en = {canonical.column("name_en")[i].as_py() for i in range(canonical.num_rows)}
+    assert "Sufyan" in names_en

--- a/tests/test_utils/test_arabic.py
+++ b/tests/test_utils/test_arabic.py
@@ -223,3 +223,26 @@ class TestExtractTransmissionPhrases:
         assert isinstance(start, int)
         assert isinstance(end, int)
         assert label == "haddathana"
+
+    def test_matches_diacritized_term(self) -> None:
+        """Fully-voweled terms must match (da#146) — bare patterns alone do not."""
+        # حَدَّثَنَا (voweled) vs the bare keyword حدثنا.
+        results = extract_transmission_phrases("حَدَّثَنَا سُفْيَانُ")
+        labels = [label for _, _, label in results]
+        assert "haddathana" in labels
+
+    def test_overlapping_variants_resolve_to_longer(self) -> None:
+        """``سمعت`` must win over the bare ``سمع`` at a shared position."""
+        results = extract_transmission_phrases("سمعت فلانا")
+        # Exactly one transmission phrase at the start, labelled samitu.
+        starts = [s for s, _, _ in results]
+        assert starts == sorted(starts)
+        assert results[0][2] == "samitu"
+        # No duplicate/overlapping samia span at the same start.
+        assert not any(label == "samia" and start == 0 for start, _, label in results)
+
+    def test_singular_variants_recognized(self) -> None:
+        results = extract_transmission_phrases("حدثني فلان أخبرني فلان")
+        labels = {label for _, _, label in results}
+        assert "haddathani" in labels
+        assert "akhbarani" in labels

--- a/tests/test_utils/test_grade.py
+++ b/tests/test_utils/test_grade.py
@@ -1,0 +1,48 @@
+"""Tests for src.utils.grade — raw grade -> HadithGrade normalization (da#148)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models.enums import HadithGrade
+from src.utils.grade import normalize_grade
+
+
+class TestNormalizeGrade:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # Arabic forms (with and without diacritics).
+            ("صحيح", HadithGrade.SAHIH.value),
+            ("صَحِيح", HadithGrade.SAHIH.value),
+            ("حسن", HadithGrade.HASAN.value),
+            ("ضعيف", HadithGrade.DAIF.value),
+            ("موضوع", HadithGrade.MAWDU.value),
+            ("صحيح لغيره", HadithGrade.SAHIH_LI_GHAYRIHI.value),
+            ("حسن لغيره", HadithGrade.HASAN_LI_GHAYRIHI.value),
+            # English / transliterated forms.
+            ("Sahih", HadithGrade.SAHIH.value),
+            ("HASAN", HadithGrade.HASAN.value),
+            ("Da'if", HadithGrade.DAIF.value),
+            ("Daif", HadithGrade.DAIF.value),
+            ("weak", HadithGrade.DAIF.value),
+            ("authentic", HadithGrade.SAHIH.value),
+            ("fabricated", HadithGrade.MAWDU.value),
+            ("Sahih li ghayrihi", HadithGrade.SAHIH_LI_GHAYRIHI.value),
+        ],
+    )
+    def test_known_grades(self, raw: str, expected: str) -> None:
+        assert normalize_grade(raw) == expected
+
+    @pytest.mark.parametrize("raw", [None, "", "   ", "no-clear-grade", 42])
+    def test_unknown_or_empty_maps_to_unknown(self, raw: object) -> None:
+        assert normalize_grade(raw) == HadithGrade.UNKNOWN.value  # type: ignore[arg-type]
+
+    def test_li_ghayrihi_wins_over_bare_grade(self) -> None:
+        # The qualified form must not be matched as the bare grade first.
+        assert normalize_grade("صحيح لغيره") == HadithGrade.SAHIH_LI_GHAYRIHI.value
+        assert normalize_grade("حسن لغيره") == HadithGrade.HASAN_LI_GHAYRIHI.value
+
+    def test_return_value_is_always_a_valid_enum_member(self) -> None:
+        for raw in ["صحيح", "weak", "garbage", "", None]:
+            assert normalize_grade(raw) in {g.value for g in HadithGrade}  # type: ignore[arg-type]


### PR DESCRIPTION
Wave merge for noorinalabs-data-acquisition — P5W1 'Data spine'. 4 PRs reviewed (2/2 Approved each) + merged to wave branch:
- #151 da#146: segment voweled lk isnad chains into per-narrator mentions (keystone; 31,525 blobs → real mentions)
- #150 da#148: integrity sweep — self-loop guard + grade normalization (remainder → da#153)
- #149 da#144: mis adapter parses restructured 3-file Mendeley dataset
- #152 da#138: fuzzy-cluster precision harness + nasab-reversal order guard (TD intake)

Follow-ups: da#153, da#154, da#155 (عن-anchor — gates W4 real-data load). da#147 closed premise-false.