### PR TITLE
fix(graph): fail-fast on undeclared edge relation — no STUDIED_UNDER default (da#157)

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -22,7 +22,7 @@ from src.parse.identity import (
     make_canonical_id,
     narrator_node_id,
 )
-from src.parse.schemas import EDGE_RELATION_STUDIED_UNDER
+from src.parse.schemas import EDGE_RELATION_STUDIED_UNDER, VALID_EDGE_RELATIONS
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
 from src.utils.neo4j_client import Neo4jClient
@@ -530,40 +530,40 @@ def _load_parallel_of(
 # different relation type AND the opposite direction) — must NOT load as
 # STUDIED_UNDER, or their edges would land as wrong-type, wrong-direction edges.
 #
-# The durable routing (da#133) is the per-row ``relation`` field on
-# NETWORK_EDGE_SCHEMA: a row is loaded here iff it DECLARES STUDIED_UNDER. The
-# filename allowlist below is no longer the primary gate — it survives only as the
-# back-compat inference for a pre-da#133 file whose rows carry no ``relation`` at
-# all (a legacy studentship file → STUDIED_UNDER; anything else → skipped). Once a
-# file carries an explicit ``relation`` the allowlist is never consulted, so a new
-# studentship source needs no allowlist edit and a transmission file named like a
-# studentship one (or vice-versa) is still routed correctly by its data.
-_STUDIED_UNDER_SOURCES: frozenset[str] = frozenset({"muhaddithat", "itqan"})
+# Routing is by the per-row ``relation`` field on NETWORK_EDGE_SCHEMA (da#133): a
+# row is loaded here iff it DECLARES STUDIED_UNDER. da#157 removes the old filename
+# allowlist that silently defaulted a relation-LESS row to STUDIED_UNDER — that
+# default was a footgun: the next isnad-transmission producer that forgot to set
+# ``relation`` would have its edges mis-routed onto the studentship relation. The
+# loader now REFUSES (raises on) any row that declares no — or an unrecognized —
+# relation (:func:`_row_relation`). Every producer must set ``relation`` explicitly.
 
 
-def _is_studied_under_file(path: Path) -> bool:
-    """True if a ``network_edges_<slug>.parquet`` belongs to a studentship source.
+def _row_relation(row: dict[str, Any], *, source: str) -> str:
+    """Relation a NETWORK_EDGE row declares — REQUIRED (da#133 / da#157).
 
-    Matches the exact slug or a chunked ``<slug>_NNN`` variant, so a future
-    sharded write still resolves but a different corpus (``mis``) never does. Used
-    only as the back-compat default for relation-less (pre-da#133) rows.
-    """
-    slug = path.stem.removeprefix("network_edges_")
-    return any(slug == src or slug.startswith(f"{src}_") for src in _STUDIED_UNDER_SOURCES)
-
-
-def _row_relation(row: dict[str, Any], *, legacy_default: str | None) -> str | None:
-    """Relation a NETWORK_EDGE row declares.
-
-    Honors an explicit ``relation`` value (da#133). A row carrying none — a
-    pre-da#133 parquet — falls back to *legacy_default*: the relation the file's
-    name implied under the old filename allowlist (``None`` when the name matched
-    no studentship source, so such legacy rows are skipped rather than mislabeled).
+    Returns the row's explicit ``relation``. Refuses a row that declares none, or
+    one whose value is not a recognized relation, by raising ``ValueError`` —
+    there is no default. This is the da#157 fail-safe: a relation-less edge is a
+    producer defect that must never be silently routed onto the STUDIED_UNDER
+    (studentship) allowlist. *source* names the offending file for the error.
     """
     rel = row.get("relation")
-    if isinstance(rel, str) and rel.strip():
-        return rel
-    return legacy_default
+    if not isinstance(rel, str) or not rel.strip():
+        msg = (
+            f"network edge in {source!r} declares no `relation` — refused "
+            f"(da#157: an undeclared relation is never defaulted to STUDIED_UNDER). "
+            f"The producer must set `relation` to one of {sorted(VALID_EDGE_RELATIONS)}."
+        )
+        raise ValueError(msg)
+    rel = rel.strip()
+    if rel not in VALID_EDGE_RELATIONS:
+        msg = (
+            f"network edge in {source!r} declares unknown relation {rel!r}; "
+            f"expected one of {sorted(VALID_EDGE_RELATIONS)}."
+        )
+        raise ValueError(msg)
+    return rel
 
 
 _STUDIED_UNDER_QUERY = """\
@@ -615,9 +615,10 @@ def _load_studied_under(
     Globs every ``network_edges_*`` file and keeps only the rows that DECLARE the
     STUDIED_UNDER relation (:func:`_row_relation`, da#133). A NETWORK_EDGE producer
     whose edges are a different relation (e.g. ``mis`` isnad transmission, declared
-    TRANSMITTED_TO) is skipped row-by-row regardless of filename. Rows in a
-    pre-da#133 file that carry no relation fall back to the filename allowlist.
-    Gracefully skips when no ``network_edges_*`` file exists.
+    TRANSMITTED_TO) is skipped row-by-row regardless of filename. A row that
+    declares NO relation (or an unrecognized one) raises ``ValueError`` — it is
+    never silently defaulted to STUDIED_UNDER (da#157). Gracefully skips when no
+    ``network_edges_*`` file exists.
     """
     edge_files = _parquet_files(staging_dir, "network_edges_")
     if not edge_files:
@@ -629,13 +630,13 @@ def _load_studied_under(
     skipped = 0
 
     for path in edge_files:
-        # Relation a relation-less (pre-da#133) row in this file defaults to.
-        legacy_default = EDGE_RELATION_STUDIED_UNDER if _is_studied_under_file(path) else None
         for row in _read_parquet_rows(path):
-            if _row_relation(row, legacy_default=legacy_default) != EDGE_RELATION_STUDIED_UNDER:
-                # Not a studentship edge (e.g. an isnad-transmission row) — leave it
-                # off STUDIED_UNDER. Not counted as skipped: skipped tracks edges we
-                # meant to load but could not resolve, not other relations.
+            if _row_relation(row, source=path.name) != EDGE_RELATION_STUDIED_UNDER:
+                # A validly-declared non-studentship edge (e.g. an isnad-transmission
+                # row → TRANSMITTED_TO) — leave it off STUDIED_UNDER. _row_relation has
+                # already REFUSED any row that declares no relation (da#157), so nothing
+                # is silently routed here. Not counted as skipped: skipped tracks edges
+                # we meant to load but could not resolve, not other relations.
                 continue
             from_id = _studied_under_endpoint(
                 row.get("from_narrator_name"), row.get("from_external_id")

--- a/src/parse/schemas.py
+++ b/src/parse/schemas.py
@@ -18,19 +18,19 @@ __all__ = [
     "NETWORK_EDGE_SCHEMA",
     "EDGE_RELATION_STUDIED_UNDER",
     "EDGE_RELATION_TRANSMITTED_TO",
-    "DEFAULT_EDGE_RELATION",
+    "VALID_EDGE_RELATIONS",
 ]
 
 # ``NETWORK_EDGE_SCHEMA.relation`` values (da#133). The graph loader routes a
 # network edge to a Neo4j relationship type by this DECLARED relation rather than
 # guessing it from the producing file's name: a studentship producer (muhaddithat,
 # itqan) emits ``STUDIED_UNDER``; an isnad-transmission producer (mis) emits
-# ``TRANSMITTED_TO``. ``DEFAULT_EDGE_RELATION`` is the back-compat value the loader
-# assumes for a row that carries no relation — a pre-da#133 parquet — which is
-# exactly what those legacy (studentship-only) files meant.
+# ``TRANSMITTED_TO``. There is deliberately NO default relation (da#157): a row
+# that declares none is REFUSED by the loader, never silently routed onto the
+# studentship allowlist. Every producer MUST set ``relation`` explicitly.
 EDGE_RELATION_STUDIED_UNDER = "STUDIED_UNDER"
 EDGE_RELATION_TRANSMITTED_TO = "TRANSMITTED_TO"
-DEFAULT_EDGE_RELATION = EDGE_RELATION_STUDIED_UNDER
+VALID_EDGE_RELATIONS = frozenset({EDGE_RELATION_STUDIED_UNDER, EDGE_RELATION_TRANSMITTED_TO})
 
 # ``source_id`` grammar and the graph node-id rules derived from it are the
 # canonical identity contract — see :mod:`src.parse.identity` (``<corpus>:
@@ -111,9 +111,11 @@ COLLECTION_SCHEMA = pa.schema(
 
 # ``relation`` declares which graph relationship the row's narrator pair forms
 # (:data:`EDGE_RELATION_STUDIED_UNDER` vs :data:`EDGE_RELATION_TRANSMITTED_TO`) so
-# the loader keys on the data, not on the filename (da#133). It is nullable for
-# back-compat: a pre-da#133 file carries no relation and the loader falls back to
-# :data:`DEFAULT_EDGE_RELATION`. Current producers always populate it.
+# the loader keys on the data, not on the filename (da#133). Every producer MUST
+# set it: the loader REFUSES a row that declares no relation rather than defaulting
+# it to STUDIED_UNDER (da#157). The field stays physically nullable so a malformed
+# (relation-less) parquet can still be read — and then loudly rejected — rather
+# than failing opaquely at read time.
 NETWORK_EDGE_SCHEMA = pa.schema(
     [
         pa.field("from_narrator_name", pa.string(), nullable=False),

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -454,6 +454,7 @@ class TestLoadStudiedUnderGlob:
                     "source": "muhaddithat",
                     "from_external_id": "1",
                     "to_external_id": "2",
+                    "relation": "STUDIED_UNDER",
                 }
             ],
         )
@@ -467,6 +468,7 @@ class TestLoadStudiedUnderGlob:
                     "source": "itqan",
                     "from_external_id": "2",
                     "to_external_id": "3",
+                    "relation": "STUDIED_UNDER",
                 }
             ],
         )
@@ -493,6 +495,7 @@ class TestLoadStudiedUnderGlob:
             "source": "x",
             "from_external_id": "1",
             "to_external_id": "2",
+            "relation": "STUDIED_UNDER",
         }
         _write_network_edges(staging_dir, "muhaddithat", [edge])
         _write_network_edges(staging_dir, "itqan", [dict(edge, source="itqan")])
@@ -507,8 +510,9 @@ class TestLoadStudiedUnderGlob:
         assert result.created == 0
 
     def test_excludes_non_studentship_source(self, staging_dir: Path) -> None:
-        """A non-studentship NETWORK_EDGE producer (mis = isnad transmission) is
-        NOT globbed into STUDIED_UNDER — only the muhaddithat edge loads (da#133)."""
+        """A non-studentship NETWORK_EDGE producer (mis = isnad transmission, declaring
+        TRANSMITTED_TO) is NOT globbed into STUDIED_UNDER — only the muhaddithat edge
+        loads (da#133)."""
         _write_network_edges(
             staging_dir,
             "muhaddithat",
@@ -519,6 +523,7 @@ class TestLoadStudiedUnderGlob:
                     "source": "muhaddithat",
                     "from_external_id": "1",
                     "to_external_id": "2",
+                    "relation": "STUDIED_UNDER",
                 }
             ],
         )
@@ -531,6 +536,7 @@ class TestLoadStudiedUnderGlob:
                     "to_narrator_name": "Y",
                     "source": "mis",
                     "hadith_id": "mis:sahih_muslim:1:1",
+                    "relation": "TRANSMITTED_TO",
                 }
             ],
         )
@@ -553,8 +559,8 @@ class TestLoadStudiedUnderGlob:
 
 class TestStudiedUnderRelationRouting:
     """da#133: the loader routes by the declared ``relation`` field, not the
-    filename. The filename allowlist only survives as the default for legacy
-    relation-less rows (covered by :class:`TestLoadStudiedUnderGlob`)."""
+    filename. da#157 removed the relation-less default — every row MUST declare a
+    relation (fail-fast covered by :class:`TestStudiedUnderRelationRequired`)."""
 
     def test_relation_field_includes_non_allowlisted_source(self, staging_dir: Path) -> None:
         """A NETWORK_EDGE file whose slug is NOT in the studentship allowlist still
@@ -643,3 +649,119 @@ class TestStudiedUnderRelationRouting:
             "from_id": make_canonical_id(normalize_arabic("X")),
             "to_id": make_canonical_id(normalize_arabic("Y")),
         } not in batch
+
+
+class TestStudiedUnderRelationRequired:
+    """da#157: a NETWORK_EDGE that declares NO relation is REFUSED (raises), never
+    silently defaulted to STUDIED_UNDER. Removes the footgun where the next
+    isnad-transmission producer that forgot to set ``relation`` would have its edges
+    mis-routed onto the studentship relation."""
+
+    def test_relationless_row_raises_for_allowlisted_filename(self, staging_dir: Path) -> None:
+        """A relation-less row in a ``muhaddithat`` (formerly allowlisted) file no
+        longer silently becomes STUDIED_UNDER — it raises. This is the exact trap
+        da#157 closes."""
+        _write_network_edges(
+            staging_dir,
+            "muhaddithat",
+            [
+                {
+                    "from_narrator_name": "أ",
+                    "to_narrator_name": "ب",
+                    "source": "muhaddithat",
+                    "from_external_id": "1",
+                    "to_external_id": "2",
+                    "relation": None,  # producer forgot to declare the relation
+                }
+            ],
+        )
+        with pytest.raises(ValueError, match=r"declares no `relation`"):
+            _load_studied_under(MockNeo4jClient(), staging_dir)
+
+    def test_relationless_row_raises_for_unknown_source(self, staging_dir: Path) -> None:
+        """A relation-less row in a non-allowlisted file used to be silently dropped;
+        now it raises loudly so the producer defect cannot pass unnoticed."""
+        _write_network_edges(
+            staging_dir,
+            "newsource",
+            [
+                {
+                    "from_narrator_name": "أ",
+                    "to_narrator_name": "ب",
+                    "source": "newsource",
+                    "from_external_id": "1",
+                    "to_external_id": "2",
+                    "relation": None,
+                }
+            ],
+        )
+        with pytest.raises(ValueError, match=r"declares no `relation`"):
+            _load_studied_under(MockNeo4jClient(), staging_dir)
+
+    def test_blank_relation_raises(self, staging_dir: Path) -> None:
+        """A whitespace-only relation is treated as undeclared and refused."""
+        _write_network_edges(
+            staging_dir,
+            "muhaddithat",
+            [
+                {
+                    "from_narrator_name": "أ",
+                    "to_narrator_name": "ب",
+                    "source": "muhaddithat",
+                    "from_external_id": "1",
+                    "to_external_id": "2",
+                    "relation": "   ",
+                }
+            ],
+        )
+        with pytest.raises(ValueError, match=r"declares no `relation`"):
+            _load_studied_under(MockNeo4jClient(), staging_dir)
+
+    def test_unknown_relation_value_raises(self, staging_dir: Path) -> None:
+        """A relation value outside the recognized set is refused rather than
+        silently skipped — guards against typos like ``STUDENT_OF``."""
+        _write_network_edges(
+            staging_dir,
+            "muhaddithat",
+            [
+                {
+                    "from_narrator_name": "أ",
+                    "to_narrator_name": "ب",
+                    "source": "muhaddithat",
+                    "from_external_id": "1",
+                    "to_external_id": "2",
+                    "relation": "STUDENT_OF",
+                }
+            ],
+        )
+        with pytest.raises(ValueError, match=r"unknown relation 'STUDENT_OF'"):
+            _load_studied_under(MockNeo4jClient(), staging_dir)
+
+    def test_transmission_producer_never_mislabeled_studied_under(self, staging_dir: Path) -> None:
+        """A transmission producer (mis) whose every row declares TRANSMITTED_TO
+        contributes ZERO STUDIED_UNDER edges — its isnad edges are never mislabeled
+        as studentship."""
+        _write_network_edges(
+            staging_dir,
+            "mis",
+            [
+                {
+                    "from_narrator_name": "X",
+                    "to_narrator_name": "Y",
+                    "source": "mis",
+                    "from_external_id": "1",
+                    "to_external_id": "2",
+                    "relation": "TRANSMITTED_TO",
+                },
+                {
+                    "from_narrator_name": "Y",
+                    "to_narrator_name": "Z",
+                    "source": "mis",
+                    "from_external_id": "2",
+                    "to_external_id": "3",
+                    "relation": "TRANSMITTED_TO",
+                },
+            ],
+        )
+        result = _load_studied_under(MockNeo4jClient(), staging_dir)
+        assert result.created == 0


### PR DESCRIPTION
## Summary

Closes #157 (P5W1-retro Proposed Change #2, owner-adopted 2026-06-14; builds on da#133).

The da#133 edge-relation migration was incomplete **at the default**: a `NETWORK_EDGE` row that declared no `relation` silently inferred `STUDIED_UNDER` from a filename allowlist (muhaddithat/itqan) — or was silently dropped for any other source. That made the next isnad-transmission producer one forgotten line away from a silent corpus-level mis-classification (transmission edges landing on the studentship relation, wrong type AND wrong direction).

This makes the loader **fail-fast** instead of defaulting.

## Changes

- **`src/parse/schemas.py`** — remove `DEFAULT_EDGE_RELATION` (the `STUDIED_UNDER` fallback footgun); add `VALID_EDGE_RELATIONS`. There is deliberately **no default relation** — every producer must set `relation` explicitly.
- **`src/graph/load_edges.py`** — `_row_relation` now REQUIRES an explicit, recognized relation: it raises `ValueError` (naming the offending file) on a missing, blank, or unknown value, never defaulting to `STUDIED_UNDER`. Removed the filename allowlist (`_STUDIED_UNDER_SOURCES`, `_is_studied_under_file`) which existed only to infer relation-less rows.
- **Producer sweep** (fix direction #2) — muhaddithat/itqan (`STUDIED_UNDER`) and mis (`TRANSMITTED_TO`) already declare `relation` for every row; the schema-field comprehension keeps it mandatory at write time. No producer change needed; confirmed by audit.

## Tests (fix direction #3)

New `TestStudiedUnderRelationRequired`:
- relation-less row raises — in an allowlisted (`muhaddithat`) filename (the exact trap) AND in an unlisted one (previously a silent drop)
- blank / whitespace relation raises
- unknown relation value (e.g. `STUDENT_OF`) raises
- a transmission producer (mis, all rows `TRANSMITTED_TO`) contributes **zero** `STUDIED_UNDER` edges

Existing relation-routing tests updated to declare `relation` explicitly.

## Verification

- `ruff check .` + `ruff format --check .` clean
- `mypy src` (strict) — no issues, 78 files
- `pytest` — 875 passed, 5 skipped (37/37 in `test_load_edges.py`)

## Cross-ref

da#133 (edge-relation field, CLOSED). Serves Phase 5 criterion #1 (data correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
