### PR TITLE
feat(da#159): transliteration fallback for narrator English names

### DIFF
--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -40,6 +40,7 @@ from src.parse.identity import (
     grading_node_id,
     hadith_node_id,
 )
+from src.utils.arabic import transliterate
 from src.utils.grade import normalize_grade
 from src.utils.logging import get_logger
 from src.utils.neo4j_client import Neo4jClient
@@ -81,6 +82,31 @@ def _val(row: dict[str, Any], key: str, default: Any = None) -> Any:
     """Get a value from *row*, returning *default* for ``None``."""
     v = row.get(key)
     return default if v is None else v
+
+
+def _narrator_name_en(row: dict[str, Any]) -> str:
+    """Resolve a narrator's English display name, with a transliteration fallback.
+
+    Almost no narrator records carry a sourced ``name_en`` (113 / 47,199 at
+    P5W3 — da#159), leaving English search and display hollow. When a sourced
+    English name is present we use it verbatim; otherwise we synthesize a
+    deterministic Latin transliteration of ``name_ar`` (falling back to
+    ``name_ar_normalized``) so every Narrator node has a non-empty, searchable
+    English form.
+
+    The fallback is applied at *load* time rather than persisted into
+    ``narrators_canonical.parquet`` on purpose: the parquet ``name_en`` stays a
+    pure provenance field (sourced-or-empty), which keeps ``bio_promote``'s
+    only-when-missing back-fill idempotent and clobber-free, while the Neo4j
+    node — what ``/graph``, search and narrator pages actually read — always has
+    a display name. Legacy canonical files written before any English-name work
+    are covered too, with no resolve re-run required.
+    """
+    sourced = _val(row, "name_en", "")
+    if isinstance(sourced, str) and sourced.strip():
+        return sourced
+    name_ar = _val(row, "name_ar", "") or _val(row, "name_ar_normalized", "")
+    return transliterate(name_ar) if name_ar else ""
 
 
 # ---------------------------------------------------------------------------
@@ -149,7 +175,7 @@ def _load_narrators(
             {
                 "id": cid,
                 "name_ar": _val(row, "name_ar", ""),
-                "name_en": _val(row, "name_en", ""),
+                "name_en": _narrator_name_en(row),
                 "name_ar_normalized": _val(row, "name_ar_normalized"),
                 "birth_year_ah": _val(row, "birth_year_ah"),
                 "death_year_ah": _val(row, "death_year_ah"),

--- a/src/utils/arabic.py
+++ b/src/utils/arabic.py
@@ -17,6 +17,7 @@ __all__ = [
     "clean_whitespace",
     "is_arabic",
     "extract_transmission_phrases",
+    "transliterate",
 ]
 
 # ---------------------------------------------------------------------------
@@ -182,3 +183,240 @@ def extract_transmission_phrases(text: str) -> list[tuple[int, int, str]]:
             results.append((start, end, label))
             last_end = end
     return results
+
+
+# ---------------------------------------------------------------------------
+# Transliteration (Arabic name -> Latin display form)
+# ---------------------------------------------------------------------------
+#
+# Narrator records carry a required ``name_ar`` but almost never a sourced
+# ``name_en`` (113 / 47,199 at P5W3 — da#159), so English search and display are
+# hollow. This is a deterministic, dependency-free Arabic->Latin transliterator
+# used to synthesize a readable display name whenever a sourced English name is
+# absent.
+#
+# Two layers, in priority order:
+#   1. A token lexicon of the formulaic building blocks of classical narrator
+#      names — kunya/nasab particles (Abu, ibn, bint, Umm), theophorics
+#      (Abd Allah, al-Rahman), the most common given names (Muhammad, Ali,
+#      Husayn, ...) and high-frequency nisbas (al-Bukhari, al-Kufi, ...).
+#      Arabic names are highly repetitive, so a modest lexicon renders the
+#      overwhelming majority of *tokens* correctly.
+#   2. A consonant-skeleton letter map for any token outside the lexicon. The
+#      result is imperfect for rare, un-voweled tokens (Arabic script omits short
+#      vowels) but is always non-empty, ASCII, and deterministic — turning 0%
+#      coverage into ~100% with sane, stable output.
+#
+# Output is intentionally plain ASCII (no ʿayn/macrons) so it is friendly to
+# fulltext search and case-insensitive matching.
+
+# Per-letter consonant/long-vowel map. Carriers that contribute no Latin glyph
+# in plain ASCII (hamza, ayn) map to the empty string. The input is expected to
+# be normalized (diacritics already stripped by :func:`normalize_arabic`).
+_TRANSLIT_LETTERS: dict[str, str] = {
+    "ا": "a",
+    "ب": "b",
+    "ت": "t",
+    "ث": "th",
+    "ج": "j",
+    "ح": "h",
+    "خ": "kh",
+    "د": "d",
+    "ذ": "dh",
+    "ر": "r",
+    "ز": "z",
+    "س": "s",
+    "ش": "sh",
+    "ص": "s",
+    "ض": "d",
+    "ط": "t",
+    "ظ": "z",
+    "ع": "",
+    "غ": "gh",
+    "ف": "f",
+    "ق": "q",
+    "ك": "k",
+    "ل": "l",
+    "م": "m",
+    "ن": "n",
+    "ه": "h",
+    "ة": "a",
+    "و": "w",
+    "ي": "y",
+    "ى": "a",
+    "ء": "",
+}
+
+# Token lexicon, written with natural spellings; keys are normalized at import so
+# a normalized lookup token matches regardless of diacritics / alif-hamza form.
+# Values are pre-cased for their typical role (particles ``ibn``/``bint`` stay
+# lowercase for mid-name use; the article prefix stays ``al-``).
+_RAW_NAME_LEXICON: dict[str, str] = {
+    # Kunya / nasab particles
+    "أبو": "Abu",
+    "أبا": "Aba",
+    "أبي": "Abi",
+    "ابن": "ibn",
+    "بن": "ibn",
+    "بنت": "bint",
+    "أم": "Umm",
+    # Theophorics & honorifics
+    "عبد": "Abd",
+    "الله": "Allah",
+    "عبدالله": "Abd Allah",
+    "عبدالرحمن": "Abd al-Rahman",
+    "الرحمن": "al-Rahman",
+    "الرحيم": "al-Rahim",
+    "الصديق": "al-Siddiq",
+    "الفاروق": "al-Faruq",
+    # Common given names
+    "محمد": "Muhammad",
+    "أحمد": "Ahmad",
+    "علي": "Ali",
+    "حسن": "Hasan",
+    "الحسن": "al-Hasan",
+    "حسين": "Husayn",
+    "الحسين": "al-Husayn",
+    "عمر": "Umar",
+    "عثمان": "Uthman",
+    "إبراهيم": "Ibrahim",
+    "إسماعيل": "Ismail",
+    "إسحاق": "Ishaq",
+    "يعقوب": "Yaqub",
+    "يوسف": "Yusuf",
+    "موسى": "Musa",
+    "عيسى": "Isa",
+    "داود": "Dawud",
+    "سليمان": "Sulayman",
+    "يحيى": "Yahya",
+    "خالد": "Khalid",
+    "جعفر": "Jafar",
+    "صالح": "Salih",
+    "حماد": "Hammad",
+    "حمزة": "Hamza",
+    "زيد": "Zayd",
+    "سعيد": "Said",
+    "سعد": "Sad",
+    "سفيان": "Sufyan",
+    "سلمان": "Salman",
+    "طلحة": "Talha",
+    "عمرو": "Amr",
+    "عباس": "Abbas",
+    "العباس": "al-Abbas",
+    "معاوية": "Muawiya",
+    "مالك": "Malik",
+    "أنس": "Anas",
+    "بكر": "Bakr",
+    "هريرة": "Hurayra",
+    "الزبير": "al-Zubayr",
+    "عوف": "Awf",
+    "الخطاب": "al-Khattab",
+    "شعبة": "Shuba",
+    "قتادة": "Qatada",
+    "نافع": "Nafi",
+    "مجاهد": "Mujahid",
+    "عطاء": "Ata",
+    "هشام": "Hisham",
+    "عروة": "Urwa",
+    "معمر": "Mamar",
+    "وكيع": "Waki",
+    "الوليد": "al-Walid",
+    "يزيد": "Yazid",
+    "جابر": "Jabir",
+    "ثابت": "Thabit",
+    "حذيفة": "Hudhayfa",
+    "عمار": "Ammar",
+    "بلال": "Bilal",
+    # Women narrators
+    "عائشة": "Aisha",
+    "فاطمة": "Fatima",
+    "خديجة": "Khadija",
+    "سلمى": "Salma",
+    # High-frequency nisbas
+    "البخاري": "al-Bukhari",
+    "المدني": "al-Madani",
+    "الكوفي": "al-Kufi",
+    "البصري": "al-Basri",
+    "الدمشقي": "al-Dimashqi",
+    "الأنصاري": "al-Ansari",
+    "القرشي": "al-Qurashi",
+    "التميمي": "al-Tamimi",
+    "الثقفي": "al-Thaqafi",
+    "الهمداني": "al-Hamdani",
+    "الزهري": "al-Zuhri",
+    "الثوري": "al-Thawri",
+    "الأعمش": "al-Amash",
+    "الشعبي": "al-Shabi",
+    "الأوزاعي": "al-Awzai",
+    "الليث": "al-Layth",
+    "الأشعري": "al-Ashari",
+    "السلمي": "al-Sulami",
+}
+
+_NAME_LEXICON: dict[str, str] = {normalize_arabic(k): v for k, v in _RAW_NAME_LEXICON.items()}
+
+# Particles that read lowercase in the middle of a name but are capitalized when
+# they lead it (e.g. "Muhammad ibn Ali" vs "Ibn Sirin").
+_LOWERCASE_PARTICLES: frozenset[str] = frozenset({"ibn", "bint"})
+
+
+def _capitalize(token: str) -> str:
+    """Uppercase the first alphabetic character of *token*, leaving the rest."""
+    for i, ch in enumerate(token):
+        if ch.isalpha():
+            return token[:i] + ch.upper() + token[i + 1 :]
+    return token
+
+
+def _map_letters(token_norm: str) -> str:
+    """Map a normalized Arabic token to its consonant/vowel skeleton."""
+    return "".join(_TRANSLIT_LETTERS.get(ch, "") for ch in token_norm)
+
+
+def _transliterate_token(token: str) -> str:
+    """Transliterate a single whitespace-delimited token to a Latin form.
+
+    Lexicon hit wins; otherwise the definite article ``al-`` is split off and the
+    remainder is rendered with the consonant-skeleton map. Tokens with no Arabic
+    content are returned trimmed (already-Latin input passes through).
+    """
+    norm = normalize_arabic(token)
+    if not norm:
+        return ""
+    if norm in _NAME_LEXICON:
+        return _NAME_LEXICON[norm]
+    if not is_arabic(norm):
+        return token.strip()
+    # Definite article prefix (alif-lam) -> "al-" + capitalized remainder.
+    if norm.startswith("ال") and len(norm) > 2:
+        body = _map_letters(norm[2:])
+        return "al-" + _capitalize(body) if body else "al-"
+    return _capitalize(_map_letters(norm))
+
+
+def transliterate(text: str) -> str:
+    """Transliterate an Arabic name to a readable, ASCII Latin display form.
+
+    Deterministic and dependency-free. Returns ``""`` for empty/blank input.
+    Intended as a *fallback* display name when a record has no sourced
+    ``name_en`` — see :mod:`src.graph.load_nodes` (da#159). The output is not a
+    scholarly romanization; it favours readable, stable, search-friendly forms.
+    """
+    if not text or not text.strip():
+        return ""
+    text = _TATWEEL_RE.sub("", text)
+    out: list[str] = []
+    for token in _MULTI_WS_RE.sub(" ", text).strip().split(" "):
+        stripped = token.strip("،.,;:()[]{}\"'`-")
+        if not stripped:
+            continue
+        latin = _transliterate_token(stripped)
+        if not latin:
+            continue
+        if latin in _LOWERCASE_PARTICLES and out:
+            out.append(latin)
+        elif latin in _LOWERCASE_PARTICLES:
+            out.append(_capitalize(latin))
+        else:
+            out.append(latin)
+    return " ".join(out).strip()

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -167,6 +167,142 @@ class TestLoadNarrators:
         assert loaded_ids == {"nar:from-curated"}
 
 
+class TestNarratorNameEnFallback:
+    """da#159: every loaded Narrator gets a non-empty English display name.
+
+    Almost no canonical records carry a sourced ``name_en`` (113 / 47,199), so
+    the loader synthesizes a deterministic transliteration of ``name_ar`` when
+    one is absent — fixing hollow English search/display on ``/graph`` and
+    narrator pages.
+    """
+
+    @staticmethod
+    def _narrator_batch(client: MockNeo4jClient) -> list[dict[str, object]]:
+        _query, batch = next(
+            (q, b) for q, b in client.calls if isinstance(b, list) and "MERGE (n:Narrator" in q
+        )
+        assert isinstance(batch, list)
+        return batch
+
+    def test_missing_name_en_filled_from_transliteration(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        write_narrators_canonical(
+            curated_dir,
+            [{"canonical_id": "nar:m", "name_ar": "محمد", "name_en": None}],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        row = self._narrator_batch(mock_client)[0]
+        assert row["name_en"] == "Muhammad"
+
+    def test_empty_string_name_en_filled(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        write_narrators_canonical(
+            curated_dir,
+            [{"canonical_id": "nar:ah", "name_ar": "أبو هريرة", "name_en": ""}],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        row = self._narrator_batch(mock_client)[0]
+        assert row["name_en"] == "Abu Hurayra"
+
+    def test_sourced_name_en_preserved(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """A real sourced English name is used verbatim, never overwritten."""
+        write_narrators_canonical(
+            curated_dir,
+            [
+                {
+                    "canonical_id": "nar:prophet",
+                    "name_ar": "محمد",
+                    "name_en": "Prophet Muhammad",
+                }
+            ],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        row = self._narrator_batch(mock_client)[0]
+        assert row["name_en"] == "Prophet Muhammad"
+
+    def test_falls_back_to_normalized_when_name_ar_missing(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        write_narrators_canonical(
+            curated_dir,
+            [
+                {
+                    "canonical_id": "nar:nn",
+                    "name_ar": None,
+                    "name_ar_normalized": "علي",
+                    "name_en": None,
+                }
+            ],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        row = self._narrator_batch(mock_client)[0]
+        assert row["name_en"] == "Ali"
+
+    def test_no_arabic_anywhere_stays_empty(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        write_narrators_canonical(
+            curated_dir,
+            [{"canonical_id": "nar:bare", "name_ar": None, "name_en": None}],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        row = self._narrator_batch(mock_client)[0]
+        assert row["name_en"] == ""
+
+    def test_coverage_rises_to_full_on_production_shaped_batch(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """Production-shaped: many name_ar-only records, one sourced English name.
+
+        Mirrors the staging reality (coverage 113/47,199) at small scale: only a
+        single record arrives with a sourced ``name_en``; the rest are Arabic-only
+        and must come out of the loader with a non-empty, ASCII English name.
+        """
+        arabic_only = [
+            "محمد",
+            "علي",
+            "عبد الله",
+            "أبو هريرة",
+            "عائشة",
+            "محمد بن إسماعيل",
+            "عمر بن الخطاب",
+            "الزهري",
+            "سفيان الثوري",
+            "أنس بن مالك",
+        ]
+        rows = [
+            {"canonical_id": f"nar:{i}", "name_ar": ar, "name_en": None}
+            for i, ar in enumerate(arabic_only)
+        ]
+        rows.append(
+            {"canonical_id": "nar:sourced", "name_ar": "محمد", "name_en": "Prophet Muhammad"}
+        )
+        write_narrators_canonical(curated_dir, rows)
+
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        batch = self._narrator_batch(mock_client)
+        assert len(batch) == len(rows)
+
+        non_empty = [r for r in batch if str(r["name_en"]).strip()]
+        # Coverage is total (was ~0% pre-fix for the Arabic-only majority).
+        assert len(non_empty) == len(rows)
+        # Names are sane: ASCII and capitalized (the definite article ``al-``
+        # legitimately leads lowercase, e.g. "al-Zuhri").
+        for r in batch:
+            name_en = str(r["name_en"])
+            assert name_en.isascii()
+            assert name_en[0].isupper() or name_en.startswith("al-")
+        # Sourced name preserved; transliterations applied to the rest.
+        by_id = {r["id"]: r["name_en"] for r in batch}
+        assert by_id["nar:sourced"] == "Prophet Muhammad"
+        assert by_id["nar:2"] == "Abd Allah"
+        assert by_id["nar:3"] == "Abu Hurayra"
+
+
 class TestLoadHadiths:
     def test_valid_hadiths(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path

--- a/tests/test_utils/test_arabic.py
+++ b/tests/test_utils/test_arabic.py
@@ -13,6 +13,7 @@ from src.utils.arabic import (
     normalize_hamza,
     normalize_taa_marbuta,
     strip_diacritics,
+    transliterate,
 )
 
 # ---------------------------------------------------------------------------
@@ -246,3 +247,88 @@ class TestExtractTransmissionPhrases:
         labels = {label for _, _, label in results}
         assert "haddathani" in labels
         assert "akhbarani" in labels
+
+
+# ---------------------------------------------------------------------------
+# transliterate
+# ---------------------------------------------------------------------------
+
+
+class TestTransliterate:
+    @pytest.mark.parametrize(
+        ("name_ar", "expected"),
+        [
+            ("محمد", "Muhammad"),
+            ("أحمد", "Ahmad"),
+            ("علي", "Ali"),
+            ("عائشة", "Aisha"),
+            ("فاطمة", "Fatima"),
+            ("البخاري", "al-Bukhari"),
+            ("الزهري", "al-Zuhri"),
+        ],
+        ids=[
+            "muhammad",
+            "ahmad",
+            "ali",
+            "aisha",
+            "fatima",
+            "al-bukhari",
+            "al-zuhri",
+        ],
+    )
+    def test_lexicon_single_token(self, name_ar: str, expected: str) -> None:
+        assert transliterate(name_ar) == expected
+
+    def test_theophoric_two_tokens(self) -> None:
+        assert transliterate("عبد الله") == "Abd Allah"
+
+    def test_theophoric_single_token(self) -> None:
+        """A run-together ``عبدالله`` renders the same as the spaced form."""
+        assert transliterate("عبدالله") == "Abd Allah"
+
+    def test_kunya(self) -> None:
+        assert transliterate("أبو هريرة") == "Abu Hurayra"
+
+    def test_nasab_particle_lowercase_mid_name(self) -> None:
+        """``بن``/``ابن`` read lowercase between names."""
+        assert transliterate("محمد بن إسماعيل") == "Muhammad ibn Ismail"
+
+    def test_nasab_particle_capitalized_when_leading(self) -> None:
+        assert transliterate("ابن عباس") == "Ibn Abbas"
+
+    def test_compound_full_name(self) -> None:
+        assert transliterate("عبد الله بن عباس") == "Abd Allah ibn Abbas"
+
+    def test_diacritics_are_ignored(self) -> None:
+        """A voweled spelling normalizes to the same output as the bare form."""
+        assert transliterate("مُحَمَّد") == transliterate("محمد") == "Muhammad"
+
+    def test_diacritic_only_token_dropped(self) -> None:
+        assert transliterate("ًٌٍ") == ""
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+    def test_blank_input(self, blank: str) -> None:
+        assert transliterate(blank) == ""
+
+    def test_unknown_token_is_nonempty_ascii(self) -> None:
+        """A token outside the lexicon still yields a non-empty ASCII skeleton."""
+        out = transliterate("الخطاب")  # in lexicon -> al-Khattab
+        assert out == "al-Khattab"
+        # A genuinely rare token falls through to the consonant skeleton.
+        rare = transliterate("بستيطير")
+        assert rare
+        assert rare[0].isupper()
+        assert rare.isascii()
+
+    def test_output_is_ascii_for_full_chain(self) -> None:
+        out = transliterate("عبد الرحمن بن عوف الزهري")
+        assert out
+        assert out.isascii()
+        assert out.startswith("Abd al-Rahman ibn Awf")
+
+    def test_deterministic(self) -> None:
+        name = "محمد بن إسماعيل البخاري"
+        assert transliterate(name) == transliterate(name)
+
+    def test_already_latin_passthrough(self) -> None:
+        assert transliterate("Anas") == "Anas"


### PR DESCRIPTION
## Summary

Narrator **English-name coverage was 113 / 47,199 (0.24%)** — every narrator has `name_ar` but almost none a sourced `name_en`, so English search and display are hollow across `/graph`, `/search`, and narrator pages (da#159).

This raises coverage to ~100% with a deterministic transliteration fallback.

## What changed

- **`src/utils/arabic.py` — new `transliterate()`**: a deterministic, dependency-free Arabic→Latin name transliterator.
  - A **token lexicon** renders the formulaic building blocks of classical narrator names correctly: kunya/nasab particles (Abu, ibn, bint, Umm), theophorics (Abd Allah, al-Rahman), the most common given names (Muhammad, Ali, Husayn, …) and high-frequency nisbas (al-Bukhari, al-Kufi, …). Arabic names are highly repetitive, so a modest lexicon covers the vast majority of *tokens*.
  - A **consonant-skeleton letter map** covers any token outside the lexicon — imperfect for rare, un-voweled tokens (Arabic omits short vowels) but always non-empty, ASCII, and deterministic.
  - Output is plain ASCII (no ʿayn/macrons) for fulltext-search and case-insensitive friendliness.
- **`src/graph/load_nodes._load_narrators` — name_en fallback**: when a record has no sourced `name_en`, synthesize `transliterate(name_ar)` (then `name_ar_normalized`). Sourced names are used **verbatim and never overwritten**.

## Design note — why load-time, not the parquet

The fallback is applied at **load** time rather than persisted into `narrators_canonical.parquet`:

- The parquet `name_en` stays a **pure provenance field** (sourced-or-empty), which keeps `bio_promote`'s only-when-missing back-fill idempotent and clobber-free (respects the `disambiguate` OVERWRITES → `bio_promote` MERGES ordering).
- The **Neo4j node** — what `/graph`, search and narrator pages actually read, and what a downstream fulltext index is built over — always gets a display name.
- **Legacy** canonical files (written before any English-name work) are covered with no resolve re-run.

## Tests (production-shaped)

- `tests/test_utils/test_arabic.py::TestTransliterate` — lexicon correctness (Muhammad, Abu Hurayra, Abd Allah, al-Bukhari, …), nasab particle casing (mid-name `ibn` vs leading `Ibn`), diacritic-invariance, blank/diacritic-only/already-Latin handling, unknown-token ASCII skeleton, determinism.
- `tests/test_graph/test_load_nodes.py::TestNarratorNameEnFallback` — missing/empty `name_en` filled from transliteration, sourced name preserved, `name_ar_normalized` fallback, no-Arabic stays empty, and a production-shaped batch (mostly Arabic-only + one sourced) where coverage rises to total and names are sane.

Local gates green: `ruff format --check`, `ruff check`, `mypy`, full `pytest` (898 passed, 5 skipped).

## Scope

Downstream of **da#158** (~80% of current Narrator nodes are raw chain blobs); transliteration is faithful, so blob inputs produce long display names until #158 lands real narrator entities. This PR is the English-name layer; the lexicon is easily extended.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
