### PR TITLE
fix(segmentation): production-robust isnad segmenter + fail loud (da#158/#154/#155)

### DIFF
--- a/src/parse/narrator_extraction.py
+++ b/src/parse/narrator_extraction.py
@@ -10,9 +10,13 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from src.utils.arabic import extract_transmission_phrases, normalize_arabic
+from src.utils.arabic import (
+    contains_transmission_marker,
+    extract_transmission_phrases,
+    normalize_arabic,
+)
 
-__all__ = ["NarratorSpan", "extract_narrator_mentions"]
+__all__ = ["IsnadSegmentationError", "NarratorSpan", "extract_narrator_mentions"]
 
 # English transmission keywords used as chain delimiters.
 _EN_DELIMITERS: re.Pattern[str] = re.compile(
@@ -20,10 +24,38 @@ _EN_DELIMITERS: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
+# Trailing matn clause to drop from an English name span (da#154 over-merge). A
+# narrator name is followed by a reporting verb / complementizer that introduces
+# the matn (``Anas b. Malik reported …``, ``Aishah that the Prophet said``); the
+# bare ``reported``/``said``/``that`` is NOT one of the ``_EN_DELIMITERS`` split
+# tokens, so without this trim the matn rides along on the name. None of these
+# words occurs inside a real narrator name, so the cut is safe.
+_EN_MATN_TRIM_RE: re.Pattern[str] = re.compile(
+    r"\s+(?:reported|narrat(?:ed|ing)|said|says?|mentioned|relate[ds]?|that)\b.*$",
+    re.IGNORECASE,
+)
+
 # Trailing punctuation to strip from extracted names. Includes the Arabic comma
 # (، U+060C) and semicolon (؛ U+061B), which routinely terminate a narrator span
 # in voweled isnads (da#146) and would otherwise pollute the exact-match key.
 _TRAILING_PUNCT_RE: re.Pattern[str] = re.compile(r"[.,;:!?()،؛\s]+$")
+
+# Connective particles that trail a narrator name into the next clause and should
+# not be part of the name span (da#154 name-boundary precision). Compared against
+# the *normalized* trailing token, so they cover diacritic/orthographic variants
+# (أَنَّهُ → انه). ``قال`` is already consumed as a transmission phrase upstream.
+_AR_TRAILING_CONNECTIVES: frozenset[str] = frozenset({"انه", "انها", "انهم", "انك", "اني", "يقول"})
+
+
+class IsnadSegmentationError(ValueError):
+    """Raised when an Arabic isnad chain cannot be segmented into narrators.
+
+    Failing loud is deliberate: a chain that carries a transmission marker but
+    cannot be split must NEVER be minted as a single whole-chain "narrator" blob
+    (da#158 — ~80% of loaded Narrator nodes were exactly such blobs). The error
+    surfaces the segmentation failure to the pipeline instead of silently
+    polluting the graph.
+    """
 
 
 @dataclass(frozen=True)
@@ -41,25 +73,60 @@ def _clean_name(raw: str) -> str | None:
     return cleaned if cleaned else None
 
 
+def _clean_ar_name(normalized: str) -> str | None:
+    """Clean a normalized Arabic name span: punctuation + trailing connectives.
+
+    Strips trailing punctuation, then drops trailing connective particles
+    (انه/يقول/…) that bleed the name into the following clause, re-stripping any
+    punctuation the connective removal re-exposes (da#154).
+    """
+    cleaned = _clean_name(normalized)
+    if cleaned is None:
+        return None
+    tokens = cleaned.split()
+    while tokens and tokens[-1] in _AR_TRAILING_CONNECTIVES:
+        tokens.pop()
+    if not tokens:
+        return None
+    return _clean_name(" ".join(tokens))
+
+
 def _extract_english(text: str) -> list[NarratorSpan]:
     """Extract narrator mentions from English isnad text."""
     parts = _EN_DELIMITERS.split(text)
     spans: list[NarratorSpan] = []
-    for i, part in enumerate(parts):
-        name = _clean_name(part)
+    position = 0
+    for part in parts:
+        # Drop any trailing matn clause before cleaning (da#154 over-merge).
+        name = _clean_name(_EN_MATN_TRIM_RE.sub("", part))
         if name:
-            spans.append(NarratorSpan(name=name, position=i))
+            spans.append(NarratorSpan(name=name, position=position))
+            position += 1
     return spans
 
 
 def _extract_arabic(text: str) -> list[NarratorSpan]:
-    """Extract narrator mentions from Arabic isnad text."""
+    """Extract narrator mentions from Arabic isnad text.
+
+    Raises:
+        IsnadSegmentationError: when the text carries a transmission marker but
+            cannot be split into per-narrator spans (a whole- or partial-chain
+            blob would otherwise be minted — da#158).
+    """
+    stripped = text.strip()
     phrases = extract_transmission_phrases(text)
     if not phrases:
-        name = normalize_arabic(text.strip())
-        if name:
-            return [NarratorSpan(name=name, position=0)]
-        return []
+        # No transmission phrase: either a single bare narrator name (legitimate)
+        # or a chain the segmenter failed on. Distinguish by an independent,
+        # normalization-anchored marker check and fail loud on the latter rather
+        # than mint the whole chain as one "narrator" (da#158).
+        if contains_transmission_marker(stripped):
+            raise IsnadSegmentationError(
+                "isnad carries a transmission marker but no segmentable phrase "
+                f"was found (would mint a chain blob): {stripped[:120]!r}"
+            )
+        name = normalize_arabic(stripped)
+        return [NarratorSpan(name=name, position=0)] if name else []
 
     spans: list[NarratorSpan] = []
     position = 0
@@ -67,7 +134,7 @@ def _extract_arabic(text: str) -> list[NarratorSpan]:
     # Text before the first transmission phrase may contain a name.
     if phrases[0][0] > 0:
         prefix = text[: phrases[0][0]]
-        prefix_name = _clean_name(normalize_arabic(prefix))
+        prefix_name = _clean_ar_name(normalize_arabic(prefix))
         if prefix_name:
             spans.append(NarratorSpan(name=prefix_name, position=position))
             position += 1
@@ -76,10 +143,20 @@ def _extract_arabic(text: str) -> list[NarratorSpan]:
         # The name follows the transmission phrase, up to the next phrase or end of text.
         next_start = phrases[idx + 1][0] if idx + 1 < len(phrases) else len(text)
         segment = text[end:next_start]
-        seg_name = _clean_name(normalize_arabic(segment))
+        seg_name = _clean_ar_name(normalize_arabic(segment))
         if seg_name:
             spans.append(NarratorSpan(name=seg_name, position=position, transmission_method=label))
             position += 1
+
+    # Post-split guard: no emitted span may still carry a transmission marker.
+    # If one does, the chain was only partially segmented (a residual blob) —
+    # fail loud rather than store it (da#158).
+    for span in spans:
+        if contains_transmission_marker(span.name):
+            raise IsnadSegmentationError(
+                "segmented narrator span still contains a transmission marker "
+                f"(partial chain blob): {span.name[:120]!r}"
+            )
 
     return spans
 

--- a/src/utils/arabic.py
+++ b/src/utils/arabic.py
@@ -17,6 +17,7 @@ __all__ = [
     "clean_whitespace",
     "is_arabic",
     "extract_transmission_phrases",
+    "contains_transmission_marker",
     "transliterate",
 ]
 
@@ -78,26 +79,75 @@ _TRANSMISSION_TERMS: dict[str, str] = {
     "كتب إلي": "kataba_ilayya",
 }
 
+# Short transmission particles that must be anchored on a word boundary. Unlike
+# the long forms (حدثنا/أخبرنا/…), these one-to-three-letter particles occur as
+# substrings *inside* real narrator names — عن in عَنْبَسَة / مَعْن / يَعْنِي,
+# قال in مَقَالَة — so an un-anchored match over-segments a genuine name into a
+# spurious mention (da#155 / da#154). The long forms are distinctive enough that
+# substring collisions don't occur in practice, so they stay un-anchored.
+_SHORT_PARTICLES: frozenset[str] = frozenset({"عن", "قال", "سمع"})
 
-def _compile_diacritic_tolerant(term: str) -> re.Pattern[str]:
+# Arabic letters + combining marks + tatweel, as a regex class body (no
+# brackets). Used to build the word-boundary lookarounds below: a particle is a
+# standalone transmission term only when it is NOT flanked by another Arabic
+# letter or diacritic. Punctuation (، ؛ …) and whitespace fall outside this
+# class, so they correctly count as boundaries. Excludes Arabic-Indic digits.
+_AR_LETTER_OR_MARK: str = "\u0621-\u063a\u0640-\u065f\u0670-\u06d3"
+
+# Fixed-width (single-char) lookbehind/lookahead asserting a non-letter boundary.
+_LB: str = rf"(?<![{_AR_LETTER_OR_MARK}])"
+_LA: str = rf"(?![{_AR_LETTER_OR_MARK}])"
+
+# Normalization equivalence classes mirroring :func:`normalize_arabic`. A term
+# written with one orthographic variant (e.g. أخبرنا with hamza-alif U+0623)
+# must also match the bare-alif form found throughout the real corpus (اخبرنا
+# U+0627) — the production isnads mix both, and matching only the hamza form
+# left whole sub-chains un-split into blobs (da#158).
+_ALIF_CLASS: str = "اأإآٱ"  # ا أ إ آ ٱ
+_HAMZA_CLASS: str = "ءؤئ"  # ء ؤ ئ
+_TAA_CLASS: str = "ةه"  # ة ه
+_NORM_EQUIV: dict[str, str] = {}
+for _cls in (_ALIF_CLASS, _HAMZA_CLASS, _TAA_CLASS):
+    for _ch in _cls:
+        _NORM_EQUIV[_ch] = _cls
+
+
+def _variant_class(ch: str) -> str:
+    """Return a regex fragment matching *ch* and its normalization-equivalents."""
+    equiv = _NORM_EQUIV.get(ch)
+    if equiv is not None:
+        return "[" + equiv + "]"
+    return re.escape(ch)
+
+
+def _compile_diacritic_tolerant(term: str, *, anchor: bool) -> re.Pattern[str]:
     """Compile *term* into a regex that tolerates interleaved diacritics.
 
-    Each base letter is followed by an optional diacritics/tatweel run, and
-    inter-word whitespace is matched flexibly. The compiled pattern matches the
-    fully-voweled form found in real isnads while preserving match positions in
-    the original (un-normalized) text.
+    Each base letter is expanded to a normalization-equivalence class (so alif
+    and hamza/taa variants all match) followed by an optional diacritics/tatweel
+    run, and inter-word whitespace is matched flexibly. The compiled pattern
+    matches the fully-voweled, orthographically-variant forms found in real
+    isnads while preserving match positions in the original (un-normalized) text.
+
+    When *anchor* is true the pattern is wrapped in non-letter-boundary
+    lookarounds so a short particle (عن/قال/سمع) only matches as a standalone
+    transmission term, never as a substring of a longer name (da#155).
     """
     parts: list[str] = []
     for ch in term:
         if ch.isspace():
             parts.append(r"\s+")
         else:
-            parts.append(re.escape(ch) + _OPT_DIAC)
-    return re.compile("".join(parts))
+            parts.append(_variant_class(ch) + _OPT_DIAC)
+    body = "".join(parts)
+    if anchor:
+        body = _LB + body + _LA
+    return re.compile(body)
 
 
 TRANSMISSION_PATTERNS: dict[re.Pattern[str], str] = {
-    _compile_diacritic_tolerant(term): label for term, label in _TRANSMISSION_TERMS.items()
+    _compile_diacritic_tolerant(term, anchor=term in _SHORT_PARTICLES): label
+    for term, label in _TRANSMISSION_TERMS.items()
 }
 
 # ---------------------------------------------------------------------------
@@ -420,3 +470,28 @@ def transliterate(text: str) -> str:
         else:
             out.append(latin)
     return " ".join(out).strip()
+
+
+# Independent, normalization-anchored detector for whether a string carries a
+# transmission marker at all. It runs on :func:`normalize_arabic` output and
+# anchors *every* term on a non-letter boundary, so it neither misses an
+# orthographic variant nor false-matches a marker buried inside a longer name.
+# Built off the canonical normalizer (not the hand-built char-classes used by
+# TRANSMISSION_PATTERNS) so it stays a valid fail-loud signal even if those
+# pattern classes ever drift — see src.parse.narrator_extraction._extract_arabic.
+_NORM_MARKER_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(_LB + re.escape(normalize_arabic(term)) + _LA) for term in _TRANSMISSION_TERMS
+)
+
+
+def contains_transmission_marker(text: str) -> bool:
+    """Return True if *text* contains a transmission term as a bounded word.
+
+    Used by the Arabic narrator extractor to *fail loud* — a chain that carries a
+    transmission marker but yields no segmentable phrases means the segmenter
+    failed, and the whole chain must never be minted as a single "narrator" blob
+    (da#158). Matching is diacritic/variant-insensitive (via normalization) and
+    word-boundary anchored (so ``عن`` in ``عنبسة`` does not count).
+    """
+    normalized = normalize_arabic(text)
+    return any(pattern.search(normalized) for pattern in _NORM_MARKER_PATTERNS)

--- a/tests/test_parse/test_narrator_extraction.py
+++ b/tests/test_parse/test_narrator_extraction.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from src.parse.narrator_extraction import NarratorSpan, extract_narrator_mentions
+import pytest
+
+from src.parse.narrator_extraction import (
+    IsnadSegmentationError,
+    NarratorSpan,
+    extract_narrator_mentions,
+)
+from src.utils.arabic import contains_transmission_marker
 
 
 class TestNarratorSpanDataclass:
@@ -119,3 +126,121 @@ class TestEdgeCases:
         # Even without keywords, the full text may be returned as a single span
         # depending on splitting behavior — just verify no crash
         assert isinstance(spans, list)
+
+
+class TestDa158ProductionBlobSegmentation:
+    """Regression tests for da#158: ~80% of loaded Narrator nodes were raw isnad
+    blobs because the segmenter failed on production-realistic voweled Arabic.
+
+    The keystone failure was orthographic: real chains mix hamza-alif (أخبرنا)
+    and bare-alif (اخبرنا) transmission verbs, and the bare-alif forms were not
+    matched — so a sub-chain starting with one stayed merged into the previous
+    span as a blob. These fixtures are real-shaped (mixed orthography, voweled),
+    not toy h-1 data (production-fixture standards, main#671).
+    """
+
+    # The exact staging blob cited in da#158 (note bare-alif اخبرنا, U+0627).
+    _STAGING_BLOB = (
+        "حدثنا علي بن عبد الله، اخبرنا سفيان، حدثنا شبيب بن غرقده، قال سمعت الحى، يحدثون عن عروه،"
+    )
+
+    # Fully-voweled Bukhari-style chain mixing hamza-alif and bare-alif verbs.
+    _VOWELED_MIXED = "حَدَّثَنَا عَلِيُّ بْنُ عَبْدِ اللَّهِ، اخْبَرَنَا سُفْيَانُ، عَنْ عُرْوَةَ بْنِ الزُّبَيْرِ"
+
+    def test_bare_alif_chain_fully_segmented(self) -> None:
+        """The bare-alif اخبرنا must split the chain, not merge into a blob."""
+        spans = extract_narrator_mentions(self._STAGING_BLOB, "ar")
+        # علي / سفيان / شبيب / ... — at least four distinct narrators.
+        assert len(spans) >= 4
+        assert spans[1].name == "سفيان"
+        assert spans[1].transmission_method == "akhbarana"
+
+    def test_no_span_is_a_blob(self) -> None:
+        """Corpus-level sanity invariant: NO produced mention may contain a
+        transmission verb (da#158 asked for ~0%)."""
+        for fixture in (self._STAGING_BLOB, self._VOWELED_MIXED):
+            for span in extract_narrator_mentions(fixture, "ar"):
+                assert not contains_transmission_marker(span.name), span.name
+
+    def test_voweled_mixed_orthography_segments(self) -> None:
+        spans = extract_narrator_mentions(self._VOWELED_MIXED, "ar")
+        methods = {s.transmission_method for s in spans}
+        assert {"haddathana", "akhbarana", "an"} <= methods
+
+    def test_positions_sequential_zero_based(self) -> None:
+        spans = extract_narrator_mentions(self._STAGING_BLOB, "ar")
+        assert [s.position for s in spans] == list(range(len(spans)))
+
+
+class TestDa158FailLoud:
+    """The segmenter must FAIL LOUD rather than mint a whole-chain blob (da#158)."""
+
+    _CHAIN = "حدثنا علي بن عبد الله، اخبرنا سفيان، عن عروه"
+
+    def test_marker_without_phrases_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If phrase detection regresses to empty but a marker is present, the
+        extractor raises instead of returning the whole chain as one span."""
+        monkeypatch.setattr(
+            "src.parse.narrator_extraction.extract_transmission_phrases",
+            lambda _text: [],
+        )
+        with pytest.raises(IsnadSegmentationError):
+            extract_narrator_mentions(self._CHAIN, "ar")
+
+    def test_bare_name_without_marker_does_not_raise(self) -> None:
+        """A genuine single narrator name (no transmission marker) is fine."""
+        spans = extract_narrator_mentions("عبد الله بن مسلمة القعنبي", "ar")
+        assert len(spans) == 1
+        assert spans[0].transmission_method is None
+
+
+class TestDa155ShortParticleBoundary:
+    """da#155: عن/قال/سمع must not over-segment real names that contain them."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["عنبسة", "معن", "يعني", "مقالة", "عبد الله بن عنبسة"],
+    )
+    def test_name_with_particle_substring_not_split(self, name: str) -> None:
+        spans = extract_narrator_mentions(name, "ar")
+        # Stays a single narrator — the particle substring does not split it.
+        assert len(spans) == 1
+        # No spurious fragment (e.g. "بسة" from عنبسة).
+        assert "بسة" not in [s.name for s in spans]
+
+    def test_real_particle_in_chain_still_splits(self) -> None:
+        """A standalone عن between two names splits; the عن inside عنبسة does not."""
+        spans = extract_narrator_mentions("حدثنا عنبسة عن عبد الله بن عنبسة", "ar")
+        assert len(spans) == 2
+        assert spans[1].transmission_method == "an"
+        assert "عنبس" in spans[1].name  # the trailing عنبسة survived intact
+
+
+class TestDa154NameBoundary:
+    """da#154: deterministic name-boundary refinement — drop trailing matn /
+    connectives; keep multi-token (kunya/laqab) names joined."""
+
+    def test_english_trailing_report_verb_trimmed(self) -> None:
+        spans = extract_narrator_mentions("Anas b. Malik reported", "en")
+        assert [s.name for s in spans] == ["Anas b. Malik"]
+
+    def test_english_trailing_matn_clause_trimmed(self) -> None:
+        spans = extract_narrator_mentions("Aishah that the Prophet said", "en")
+        assert [s.name for s in spans] == ["Aishah"]
+
+    def test_english_kunya_stays_joined(self) -> None:
+        spans = extract_narrator_mentions("Narrated Abu Hurayra", "en")
+        assert [s.name for s in spans] == ["Abu Hurayra"]
+
+    def test_arabic_trailing_connective_trimmed(self) -> None:
+        # ...التيمي أنه سمع... — أنه must not ride along on the name span.
+        chain = "أخبرني محمد بن إبراهيم التيمي، أنه سمع علقمة"
+        spans = extract_narrator_mentions(chain, "ar")
+        names = [s.name for s in spans]
+        assert "محمد بن ابراهيم التيمي" in names
+        assert all("انه" not in n.split() for n in names)
+
+    def test_arabic_laqab_stays_joined(self) -> None:
+        # Multi-token name with a laqab (al-Ansari) stays a single span.
+        spans = extract_narrator_mentions("حدثنا يحيى بن سعيد الأنصاري", "ar")
+        assert spans[0].name == "يحيى بن سعيد الانصاري"

--- a/tests/test_utils/test_arabic.py
+++ b/tests/test_utils/test_arabic.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.utils.arabic import (
     clean_whitespace,
+    contains_transmission_marker,
     extract_transmission_phrases,
     is_arabic,
     normalize_alif,
@@ -332,3 +333,86 @@ class TestTransliterate:
 
     def test_already_latin_passthrough(self) -> None:
         assert transliterate("Anas") == "Anas"
+
+
+# ---------------------------------------------------------------------------
+# Orthographic-variant tolerance (da#158) — patterns must match bare-alif forms
+# ---------------------------------------------------------------------------
+
+
+class TestTransmissionVariantTolerance:
+    """The real corpus mixes hamza-alif (أخبرنا) and bare-alif (اخبرنا) forms.
+
+    The transmission patterns are written with the classical hamza forms but
+    must also match the bare-alif spellings, otherwise sub-chains starting with
+    a bare-alif verb stay merged into the previous span as a blob (da#158).
+    """
+
+    def test_bare_alif_akhbarana_matches(self) -> None:
+        # اخبرنا (bare alif U+0627), not أخبرنا (hamza-alif U+0623).
+        labels = [label for _, _, label in extract_transmission_phrases("اخبرنا سفيان")]
+        assert "akhbarana" in labels
+
+    def test_bare_alif_anbaana_matches(self) -> None:
+        labels = [label for _, _, label in extract_transmission_phrases("انبانا فلان")]
+        assert "anba_ana" in labels
+
+    def test_voweled_bare_alif_matches(self) -> None:
+        # Voweled bare-alif form: اِخْبَرَنَا-style with diacritics on bare alif.
+        text = "اخْبَرَنَا سُفْيَانُ"
+        labels = [label for _, _, label in extract_transmission_phrases(text)]
+        assert "akhbarana" in labels
+
+
+# ---------------------------------------------------------------------------
+# Short-particle word-boundary anchoring (da#155)
+# ---------------------------------------------------------------------------
+
+
+class TestShortParticleBoundary:
+    """عن / قال / سمع must only match as standalone particles, never mid-word."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "عنبسة",  # عن at offset 0, followed by a letter
+            "معن",  # عن after a letter
+            "يعني",  # عن inside the word
+            "مقالة",  # قال inside the word
+        ],
+    )
+    def test_no_mid_word_particle_match(self, name: str) -> None:
+        assert extract_transmission_phrases(name) == []
+
+    def test_standalone_particle_still_matches(self) -> None:
+        labels = [label for _, _, label in extract_transmission_phrases("فلان عن فلان")]
+        assert "an" in labels
+
+    def test_only_real_particle_matches_in_mixed(self) -> None:
+        # The real عن (between the two names) matches; the عن inside عنبسة does not.
+        results = extract_transmission_phrases("عنبسة عن عبد الله")
+        assert [label for _, _, label in results] == ["an"]
+
+
+# ---------------------------------------------------------------------------
+# contains_transmission_marker — fail-loud signal (da#158)
+# ---------------------------------------------------------------------------
+
+
+class TestContainsTransmissionMarker:
+    def test_detects_voweled_long_form(self) -> None:
+        assert contains_transmission_marker("حَدَّثَنَا سُفْيَانُ") is True
+
+    def test_detects_bare_alif_variant(self) -> None:
+        assert contains_transmission_marker("اخبرنا سفيان") is True
+
+    def test_ignores_particle_inside_name(self) -> None:
+        # عنبسة / مقالة contain عن / قال as substrings but carry no real marker.
+        assert contains_transmission_marker("عنبسة") is False
+        assert contains_transmission_marker("مقالة") is False
+
+    def test_plain_name_has_no_marker(self) -> None:
+        assert contains_transmission_marker("عبد الله بن مسلمة") is False
+
+    def test_empty(self) -> None:
+        assert contains_transmission_marker("") is False


### PR DESCRIPTION
## Summary
Keystone P5W3 fix for the segmenter cluster (da#158 / da#154 / da#155). The
deterministic isnad splitter (da#146) passed CI on a toy fixture but
under-segmented the real Kutub al-Sittah corpus, leaving ~80% of loaded
`Narrator` nodes as raw isnad blobs.

**Root cause (da#158):** the transmission patterns matched only the classical
hamza-alif verb forms (`أخبرنا`) while the production corpus mixes those with
the **bare-alif** spellings (`اخبرنا`). A sub-chain beginning with a bare-alif
verb was never matched, so it stayed merged into the previous span as a blob.
Reproduced directly against the exact staging blob cited in da#158.

## What changed
**da#158 — robustness + fail loud** (`src/utils/arabic.py`,
`src/parse/narrator_extraction.py`)
- Transmission patterns are now **normalization-variant tolerant** (alif / hamza
  / taa equivalence classes) on top of the existing diacritic tolerance, so
  bare-alif and hamza-alif forms both match.
- `_extract_arabic` now **fails loud** (`IsnadSegmentationError`) instead of
  minting a whole-chain blob — both when zero phrases are found but an
  independent, normalization-anchored marker check (`contains_transmission_marker`)
  detects a transmission verb, and via a **post-split guard** if any emitted span
  still carries a marker. A genuine single bare name (no marker) is still
  returned normally. This per-mention guard structurally enforces the
  "% of narrator nodes containing transmission verbs ≈ 0" corpus invariant da#158
  asked for.

**da#155 — short-particle boundaries**
- `عن` / `قال` / `سمع` are word-boundary anchored (non-letter lookarounds), so
  they no longer match mid-word inside real names (`عنبسة` / `معن` / `يعني` /
  `مقالة`). The long forms stay un-anchored (no substring collisions in practice).

**da#154 — deterministic name-boundary refinement**
- Trailing matn clause trimmed from English spans (`Anas b. Malik reported` →
  `Anas b. Malik`; `Aishah that the Prophet said` → `Aishah`).
- Trailing Arabic connectives (`أنه` / `يقول` / …) trimmed off name spans.
- `عن`-substring false positives eliminated (shares the da#155 anchoring).
- Multi-token kunya/laqab names stay joined (segment-based splitting already
  preserves them). **Full statistical NER remains the deferred portion of da#154.**

## Tests
Production-shaped fixtures only (mixed orthography, fully voweled — per main#671;
no toy `h-1` data):
- The exact da#158 staging blob → segments into ≥4 narrators, none a blob.
- Corpus-level invariant: **no produced mention contains a transmission verb.**
- Fail-loud coverage (marker present + phrases regress → raises; bare name → no raise).
- da#155 boundary cases + da#154 EN/AR boundary cases.

Gates green locally: `ruff@0.15.11 format --check` + `check`, `mypy` (strict),
full `pytest` (901 passed, 5 skipped).

Closes #158
Closes #154
Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)
