### PR TITLE
da#174: load multi-source Sunni corpora → staging Neo4j (containerized loader)

### DIFF
--- a/Dockerfile.load
+++ b/Dockerfile.load
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+# One-off graph-load image for staging / prod ingest (da#174).
+#
+# Why a dedicated image: the target Neo4j (``bolt://neo4j:7687``) is reachable
+# only on the internet-isolated ``noorinalabs_backend`` docker network, so a
+# loader container attached to that network CANNOT ``pip install`` at run time.
+# This image therefore bakes every dependency + the loader code at BUILD time
+# (on a network with egress, e.g. the default bridge), and is then RUN attached
+# to ``noorinalabs_backend`` (no egress needed). Staging Parquet is bind-mounted
+# at run time under ``/app/data`` — nothing data-bearing is baked into the image.
+#
+# Driven by ``scripts/load_staging.sh`` (the runbook). The deployed isnad-graph
+# API image cannot be reused for this: it ships the neo4j driver but not pyarrow,
+# which the Parquet node/edge loaders require.
+FROM python:3.14-slim AS base
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM base AS builder
+WORKDIR /app
+COPY pyproject.toml uv.lock ./
+RUN pip install --no-cache-dir uv && uv sync --frozen --no-dev --no-install-project
+
+FROM base AS runtime
+WORKDIR /app
+COPY --from=builder /app/.venv /app/.venv
+COPY pyproject.toml uv.lock ./
+COPY src ./src
+COPY queries ./queries
+ENV PATH="/app/.venv/bin:$PATH"
+# Data dirs (data/staging, data/curated) are bind-mounted at run time.
+# Invoked via the module path (not the console script) so no project install is
+# required in the image. Default command is a nodes-only load; override the
+# command (e.g. `load` for full nodes+edges) at `docker run` time.
+ENTRYPOINT ["python", "-m", "src.cli"]
+CMD ["load", "--nodes-only"]

--- a/scripts/load_staging.sh
+++ b/scripts/load_staging.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Build + run the one-off graph-load image against a remote cluster's Neo4j.
+#
+# da#174 — multi-source staging graph load. The cluster Neo4j (bolt://neo4j:7687)
+# is reachable only on the internet-isolated `noorinalabs_backend` docker network,
+# so we cannot tunnel a host port to it and cannot pip-install inside a container
+# attached to that network. Instead we build a self-contained loader image
+# (Dockerfile.load) where deps + code are baked at build time, ship the staging
+# Parquet, and run the loader attached to `noorinalabs_backend`.
+#
+# Idempotent: the loaders MERGE on stable, corpus-namespaced ids, so re-running is
+# safe. Reversible: every node carries `source_corpus`, so a source is cleanly
+# removable with `MATCH (n {source_corpus:'<corpus>'}) DETACH DELETE n`.
+#
+# The Neo4j password is read from the running neo4j container's NEO4J_AUTH on the
+# remote host, so no secret is committed or passed through this machine's shell
+# history.
+#
+# Usage:
+#   scripts/load_staging.sh                 # nodes-only load to staging
+#   LOAD_ARGS="load" scripts/load_staging.sh   # full nodes+edges load
+#   SSH_HOST=noorinalabs-prod scripts/load_staging.sh   # target prod (after owner go)
+set -euo pipefail
+
+SSH_HOST="${SSH_HOST:-noorinalabs-stg}"
+NEO4J_CONTAINER="${NEO4J_CONTAINER:-noorinalabs-neo4j-1}"
+BACKEND_NET="${BACKEND_NET:-noorinalabs_backend}"
+REMOTE_DIR="${REMOTE_DIR:-/tmp/da174-load}"
+IMAGE="${IMAGE:-noorinalabs-graph-load:da174}"
+# Default: nodes only (Hadith/Collection/Grading/Chain) — no edges, no dependency
+# on the shared narrator-resolve output. Set LOAD_ARGS="load" for a full load.
+LOAD_ARGS="${LOAD_ARGS:-load --nodes-only}"
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+echo "[1/5] sync code + node-bearing staging parquet -> ${SSH_HOST}:${REMOTE_DIR}"
+ssh "$SSH_HOST" "mkdir -p ${REMOTE_DIR}/data/staging ${REMOTE_DIR}/data/curated"
+rsync -az pyproject.toml uv.lock Dockerfile.load "${SSH_HOST}:${REMOTE_DIR}/"
+rsync -az --delete src queries "${SSH_HOST}:${REMOTE_DIR}/"
+# Ship only the node-bearing parquet (hadiths_/collections_) for a nodes-only load.
+rsync -az --delete \
+    --include='hadiths_*.parquet' --include='collections_*.parquet' --exclude='*' \
+    data/staging/ "${SSH_HOST}:${REMOTE_DIR}/data/staging/"
+
+echo "[2/5] build loader image on ${SSH_HOST}"
+ssh "$SSH_HOST" "cd ${REMOTE_DIR} && docker build -f Dockerfile.load -t ${IMAGE} ."
+
+echo "[3/5] run loader on the ${BACKEND_NET} network (${LOAD_ARGS})"
+# shellcheck disable=SC2087  # heredoc is intentionally expanded on the remote.
+ssh "$SSH_HOST" bash -s <<REMOTE
+  set -euo pipefail
+  PW=\$(docker exec ${NEO4J_CONTAINER} printenv NEO4J_AUTH | cut -d/ -f2)
+  docker run --rm --network ${BACKEND_NET} \
+    -e NEO4J_URI=bolt://neo4j:7687 -e NEO4J_USER=neo4j -e NEO4J_PASSWORD="\$PW" \
+    -v ${REMOTE_DIR}/data:/app/data \
+    ${IMAGE} ${LOAD_ARGS}
+REMOTE
+
+echo "[4/5] read back source_corpus distribution"
+ssh "$SSH_HOST" bash -s <<REMOTE
+  set -euo pipefail
+  PW=\$(docker exec ${NEO4J_CONTAINER} printenv NEO4J_AUTH | cut -d/ -f2)
+  docker exec ${NEO4J_CONTAINER} cypher-shell -u neo4j -p "\$PW" \
+    'MATCH (h:Hadith) RETURN h.source_corpus AS source_corpus, count(*) AS hadiths ORDER BY hadiths DESC'
+REMOTE
+
+echo "[5/5] done."


### PR DESCRIPTION
## Summary
da#174 — load the multi-source Sunni corpora to staging Neo4j so the UI surfaces more than the two existing sources (`lk` + `sunnah`).

The 5 Sunni adapters were already merged; the gap was a repeatable way to run the graph loader against the cluster Neo4j, which is reachable only on the internet-isolated `noorinalabs_backend` docker network (no host-published bolt port, no egress for a runtime pip install). This PR adds that transport and uses it to load staging.

### What's in this PR
- `Dockerfile.load` — self-contained loader image (deps + loader code baked at build time) so it runs attached to `noorinalabs_backend` without needing egress. The deployed API image can't be reused: it ships the neo4j driver but not pyarrow, which the Parquet loaders require.
- `scripts/load_staging.sh` — ships the node-bearing staging Parquet, builds the image, runs the loader on the backend network, and reads the Neo4j password from the running neo4j container's `NEO4J_AUTH` (no secret committed or shell-logged). Default is a **nodes-only** load: idempotent (MERGE on corpus-namespaced ids), per-source, and with no dependency on the shared narrator-resolve output — so it is conflict-free with the parallel da#175 / da#176 staging loads.

### Staging load result (read back from staging Neo4j)
`/admin/data/sources` (`MATCH (h:Hadith) ... group by source_corpus`) now returns **7** distinct sources (was 2):

| source_corpus | hadiths |
|---|---|
| sanadset | 650,986 |
| halimbahae | 62,169 |
| open_hadith | 62,169 |
| fawaz | 36,435 |
| lk (pre-existing) | 33,981 |
| mis | 7,748 |
| sunnah (pre-existing) | 47 |

Hadith created=819,507 (merged=77 — fawaz ara/eng same-hadith dedup), Collection=28, Grading=21,182, total_errors=0, validation_passed.

### Acceptance
- [x] `GET /admin/data/sources` lists >2 source_corpus values (7).
- [x] Each source's Hadith/Collection nodes present with correct `source_corpus` provenance (cleanly removable via `MATCH (n {source_corpus:'<corpus>'}) DETACH DELETE n`).
- [x] Spot-check counts logged (above).

### Notes
- **Nodes-only by design.** Narrator nodes + chain/transmission edges come from the shared *global* resolve (`narrators_canonical.parquet`), which is a single combined step feeding the prod cutover (deploy#470) — deliberately kept out of the 3 parallel staging loads to avoid clobbering the shared canonical set.
- `sanadset` / `mis` emit no `collections_*` Parquet (narrator-record / multi-isnad centric); their Hadith nodes still carry `source_corpus`, so they surface as sources.
- The known sanadset hadith-id double-prefix is handled by the identity layer's collapse guard (node ids stay single-prefixed); the high warning volume is log-bloat only, not a correctness issue.

### Tests / checks
ruff format + check clean, mypy clean (78 files), pytest 897 passed / 5 skipped / 45 deselected. No secrets committed.

Refs #174
Reviewers requested: Kavitha Sundaramurthy, Kwesi Boateng

🤖 Generated with [Claude Code](https://claude.com/claude-code)
