### PR TITLE
fix(thaqalayn): real-schema parse + V2 scope; load Shia Four Books to staging (da#175)

### DIFF
--- a/src/acquire/thaqalayn.py
+++ b/src/acquire/thaqalayn.py
@@ -4,6 +4,14 @@ Fetches Shia hadith collections by cloning the MohammedArab1/ThaqalaynAPI
 GitHub repository. The Thaqalayn REST API v2 was removed circa early 2026
 when the website was rebuilt with Next.js — the GitHub repo is now the
 primary acquisition method.
+
+The repo ships the dataset multiple times (V1 + V2 trees, each with a giant
+``allBooks.json`` aggregate) plus build/index files. Acquisition has version/
+scope discipline: it counts and emits only the **canonical per-book files**
+(``V2/ThaqalaynData/<n>.json``) via :func:`src.parse.thaqalayn.book_json_files`,
+the single selector shared with the parser, so the manifest + ``raw_new`` event
+never reference the aggregates or repo config that the old ``rglob`` swept in
+(da#175).
 """
 
 from __future__ import annotations
@@ -12,6 +20,7 @@ from pathlib import Path
 
 from src.acquire.base import clone_repo, ensure_dir, write_manifest
 from src.messaging import emit_raw_new_for_manifest
+from src.parse.thaqalayn import book_json_files
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -20,45 +29,30 @@ THAQALAYN_GITHUB_URL = "https://github.com/MohammedArab1/ThaqalaynAPI.git"
 MIN_EXPECTED_BOOKS = 15
 
 
-def _download_via_github(dest: Path) -> list[Path]:
-    """Clone the ThaqalaynAPI repo. Returns JSON files found."""
-    github_dest = dest / "github_clone"
-    clone_repo(THAQALAYN_GITHUB_URL, github_dest)
-    json_files = list(github_dest.rglob("*.json"))
-    logger.info("thaqalayn_github_clone", file_count=len(json_files))
-    return json_files
-
-
 def run(raw_dir: Path) -> Path:
-    """Download Thaqalayn data via GitHub clone."""
+    """Download Thaqalayn data via GitHub clone (idempotent)."""
     dest = ensure_dir(raw_dir / "thaqalayn")
 
-    # Check for idempotent skip: already have enough book JSONs
-    existing_books = list(dest.glob("book_*.json"))
-    github_clone = dest / "github_clone"
-    github_jsons = list(github_clone.rglob("*.json")) if github_clone.exists() else []
-    if len(existing_books) >= MIN_EXPECTED_BOOKS or len(github_jsons) >= MIN_EXPECTED_BOOKS:
-        all_files = existing_books or github_jsons
-        logger.info(
-            "thaqalayn_skipped",
-            reason="already_acquired",
-            file_count=len(all_files),
-        )
-        write_manifest(dest, all_files)
-        emit_raw_new_for_manifest(source="thaqalayn", local_dir=dest, files=all_files)
+    # Idempotent skip: a prior clone already has the canonical per-book files.
+    existing = book_json_files(dest)
+    if len(existing) >= MIN_EXPECTED_BOOKS:
+        logger.info("thaqalayn_skipped", reason="already_acquired", file_count=len(existing))
+        write_manifest(dest, existing)
+        emit_raw_new_for_manifest(source="thaqalayn", local_dir=dest, files=existing)
         return dest
 
-    saved = _download_via_github(dest)
+    clone_repo(THAQALAYN_GITHUB_URL, dest / "github_clone")
+    book_files = book_json_files(dest)
+    logger.info("thaqalayn_github_clone", book_count=len(book_files))
 
-    json_files = [f for f in saved if f.suffix == ".json"]
-    if len(json_files) < MIN_EXPECTED_BOOKS:
+    if len(book_files) < MIN_EXPECTED_BOOKS:
         msg = (
-            f"Expected >= {MIN_EXPECTED_BOOKS} JSON files from GitHub clone, "
-            f"found {len(json_files)}"
+            f"Expected >= {MIN_EXPECTED_BOOKS} canonical per-book JSON files under "
+            f"V2/ThaqalaynData, found {len(book_files)}"
         )
         raise AssertionError(msg)
 
-    write_manifest(dest, json_files)
-    emit_raw_new_for_manifest(source="thaqalayn", local_dir=dest, files=json_files)
-    logger.info("thaqalayn_acquired", total_files=len(json_files))
+    write_manifest(dest, book_files)
+    emit_raw_new_for_manifest(source="thaqalayn", local_dir=dest, files=book_files)
+    logger.info("thaqalayn_acquired", total_files=len(book_files))
     return dest

--- a/src/parse/thaqalayn.py
+++ b/src/parse/thaqalayn.py
@@ -1,13 +1,29 @@
 """Parse Thaqalayn raw JSON into staging Parquet.
 
-Handles two formats:
-- **API format**: JSON from ``/api/v2/hadith/{bookId}`` — typically has a
-  ``data`` wrapper key with hadith objects.
-- **GitHub format**: scraped JSON files from the ThaqalaynAPI repository —
-  typically stored as bare arrays or nested differently.
+The Thaqalayn REST API v2 was removed circa early 2026 when the site was rebuilt
+with Next.js, so the **GitHub repo** (``MohammedArab1/ThaqalaynAPI``) is the sole
+acquisition source. That repo ships the dataset SEVERAL times over — a ``V1`` and
+a ``V2`` tree, each holding per-book files AND a giant ``allBooks.json`` aggregate
+— plus build/index files (``package-lock.json``, ``tsconfig.json``,
+``BookNames.json``, ``Ingredients/``). An earlier ``rglob("*.json")`` swept all of
+them, producing ~4x-duplicated rows and config files parsed as "collections"
+(da#175). We therefore read exactly ONE canonical tree: the per-book numeric files
+under ``V2/ThaqalaynData/<n>.json`` (V2 is richer — it carries the
+``thaqalaynSanad``/``thaqalaynMatn`` *English* isnad/matn split). :func:`book_json_files`
+is the single source of truth for that selection, shared with the acquire adapter.
 
-Detection heuristic: if top-level dict contains a ``"data"`` key whose value
-is a list, treat as API format. Otherwise treat as GitHub format.
+Each numeric file is a JSON array of hadith records with the real upstream schema::
+
+    id, bookId, book, volume, category, categoryId, chapter, chapterInCategoryId,
+    author, translator, englishText, arabicText, frenchText, URL,
+    majlisiGrading, behbudiGrading, mohseniGrading, gradingsFull,
+    thaqalaynSanad, thaqalaynMatn
+
+Identity (da#175): ``source_id = thaqalayn:<bookId>:<id>`` — ``id`` is the in-book
+ordinal and is REQUIRED for collision-safe ids (without it every row in a book
+collapsed onto one node). ``collection_name`` is the ``bookId`` slug so the graph
+APPEARS_IN loader (which keys collections as ``{corpus}:{collection_name}``) links
+each hadith to its volume's Collection.
 """
 
 from __future__ import annotations
@@ -27,265 +43,152 @@ logger = get_logger(__name__)
 SOURCE_CORPUS = "thaqalayn"
 SECT = "shia"
 
-
-def _detect_format(data: Any) -> str:
-    """Return 'api' or 'github' based on JSON structure."""
-    if isinstance(data, dict) and isinstance(data.get("data"), list):
-        return "api"
-    return "github"
+# The one canonical tree we read — see module docstring. Per-book files here are
+# named ``<n>.json``; the non-book ``allBooks.json``/``BookNames.json`` siblings
+# (and the ``Ingredients/`` subdir) are excluded by requiring a numeric stem.
+_DATA_SUBDIR = ("github_clone", "V2", "ThaqalaynData")
 
 
-def _extract_hadiths_api(data: dict[str, Any]) -> list[dict[str, Any]]:
-    """Extract hadith list from API-format JSON."""
-    result: list[dict[str, Any]] = data.get("data", [])
-    return result
+def book_json_files(thaq_dir: Path) -> list[Path]:
+    """Return the canonical per-book Thaqalayn JSON files under ``thaq_dir``.
+
+    Scoped to ``V2/ThaqalaynData/<numeric>.json`` — the per-book data files —
+    excluding the ``allBooks.json``/``BookNames.json`` aggregates, the
+    ``Ingredients/`` subdir, and repo build/config files. Shared with
+    :mod:`src.acquire.thaqalayn` so acquisition and parsing never drift (da#175).
+    """
+    data_dir = thaq_dir.joinpath(*_DATA_SUBDIR)
+    if not data_dir.is_dir():
+        return []
+    return sorted(p for p in data_dir.glob("*.json") if p.stem.isdigit())
 
 
-# Fields that indicate a dict is a hadith record rather than arbitrary metadata
-_HADITH_FIELD_INDICATORS = frozenset(
-    {
-        "hadithNumber",
-        "hadith_number",
-        "number",
-        "textAr",
-        "text_ar",
-        "arabicText",
-        "arabic",
-        "textEn",
-        "text_en",
-        "englishText",
-        "english",
-        "translation",
-        "isnad",
-        "matn",
-        "grade",
-        "grading",
-    }
-)
+def _primary_grade(rec: dict[str, Any]) -> str | None:
+    """Pick a single representative grade from the per-grader fields.
+
+    Thaqalayn carries up to three independent gradings; the staging schema (and
+    the Grading node it feeds) holds one ``grade`` per hadith. We prefer
+    al-Majlisi's grade (the most-cited classical grading), then Behbudi, then
+    Mohseni. ``behdudiGrading`` is accepted as a V1 spelling fallback. Empty
+    strings (the upstream "ungraded" sentinel) are treated as absent.
+    """
+    for key in ("majlisiGrading", "behbudiGrading", "behdudiGrading", "mohseniGrading"):
+        val = safe_str(rec.get(key))
+        if val:
+            return val
+    return None
 
 
-def _looks_like_hadith(obj: object) -> bool:
-    """Return True if a dict has at least one hadith-indicative field."""
-    return isinstance(obj, dict) and bool(obj.keys() & _HADITH_FIELD_INDICATORS)
-
-
-def _extract_hadiths_github(data: Any) -> list[dict[str, Any]]:
-    """Extract hadith list from GitHub-format JSON."""
-    if isinstance(data, list):
-        return [item for item in data if _looks_like_hadith(item)]
-    if isinstance(data, dict):
-        # Try common wrapper keys
-        for key in ("hadiths", "data", "chapters"):
-            val = data.get(key)
-            if isinstance(val, list):
-                return [item for item in val if _looks_like_hadith(item)]
-        # Might be nested chapters with hadiths — require hadith-indicative fields
-        result: list[dict[str, Any]] = []
-        for val in data.values():
-            if isinstance(val, list):
-                result.extend(v for v in val if _looks_like_hadith(v))
-        return result
-    return []
-
-
-def _normalize_grade(raw: Any) -> str | None:
-    """Serialize grades to a single string. Arrays or semicolons preserved as JSON."""
-    if raw is None:
+def _hadith_to_row(rec: dict[str, Any]) -> dict[str, Any] | None:
+    """Convert one upstream record to a staging row, or None if unusable."""
+    book_id = safe_str(rec.get("bookId"))
+    hadith_num = safe_int(rec.get("id"))
+    if not book_id or hadith_num is None:
         return None
-    if isinstance(raw, list):
-        if len(raw) == 1:
-            return safe_str(raw[0])
-        return json.dumps(raw, ensure_ascii=False)
-    s = safe_str(raw)
-    if s and ";" in s:
-        parts = [p.strip() for p in s.split(";") if p.strip()]
-        if len(parts) > 1:
-            return json.dumps(parts, ensure_ascii=False)
-    return s
 
+    source_id = generate_source_id(SOURCE_CORPUS, book_id, hadith_num)
 
-def _hadith_to_row(
-    h: dict[str, Any],
-    collection_name: str,
-    book_number: int | None,
-) -> dict[str, Any]:
-    """Convert a single hadith dict to a staging row."""
-    hadith_num = safe_int(h.get("hadithNumber") or h.get("hadith_number") or h.get("number"))
-    source_id = generate_source_id(
-        SOURCE_CORPUS,
-        collection_name,
-        book_number or 0,
-        hadith_num or 0,
-    )
-
-    # Isnad/matn: Thaqalayn generally does not separate isnad from matn.
-    # If explicit fields exist, use them; otherwise put everything in full_text.
-    isnad_ar = safe_str(h.get("isnad") or h.get("isnad_ar"))
-    matn_ar = safe_str(h.get("matn") or h.get("matn_ar") or h.get("textAr") or h.get("text_ar"))
-    full_ar = safe_str(
-        h.get("fullText")
-        or h.get("full_text")
-        or h.get("textAr")
-        or h.get("text_ar")
-        or h.get("arabicText")
-        or h.get("arabic")
-    )
-    matn_en = safe_str(
-        h.get("matn_en")
-        or h.get("textEn")
-        or h.get("text_en")
-        or h.get("english")
-        or h.get("englishText")
-        or h.get("translation")
-    )
-    full_en = safe_str(h.get("fullTextEn") or h.get("full_text_en"))
-    chapter_ar = safe_str(h.get("chapterAr") or h.get("chapter_ar") or h.get("babAr"))
-    chapter_en = safe_str(
-        h.get("chapter") or h.get("chapterEn") or h.get("chapter_en") or h.get("babEn")
-    )
-    chapter_num = safe_int(h.get("chapterNumber") or h.get("chapter_number"))
-
-    grade = _normalize_grade(h.get("grade") or h.get("grading") or h.get("grades"))
+    # Thaqalayn separates isnad from matn only on the ENGLISH translation
+    # (``thaqalaynSanad``/``thaqalaynMatn`` are English); the Arabic (``arabicText``)
+    # is stored whole, isnad + matn together. So the split feeds the ``*_en`` fields
+    # and the Arabic text stays intact in both ``matn_ar`` and ``full_text_ar``
+    # rather than mis-routing English prose into an Arabic column (da#175).
+    arabic = safe_str(rec.get("arabicText"))
+    english = safe_str(rec.get("englishText"))
+    sanad_en = safe_str(rec.get("thaqalaynSanad"))
+    matn_en = safe_str(rec.get("thaqalaynMatn")) or english
 
     return {
         "source_id": source_id,
         "source_corpus": SOURCE_CORPUS,
-        "collection_name": collection_name,
-        "book_number": book_number,
-        "chapter_number": chapter_num,
+        "collection_name": book_id,
+        "book_number": safe_int(rec.get("categoryId")),
+        "chapter_number": safe_int(rec.get("chapterInCategoryId")),
         "hadith_number": hadith_num,
-        "matn_ar": matn_ar,
+        "matn_ar": arabic,
         "matn_en": matn_en,
-        "isnad_raw_ar": isnad_ar,
-        "isnad_raw_en": None,
-        "full_text_ar": full_ar,
-        "full_text_en": full_en,
-        "grade": grade,
-        "chapter_name_ar": chapter_ar,
-        "chapter_name_en": chapter_en,
+        "isnad_raw_ar": None,
+        "isnad_raw_en": sanad_en,
+        "full_text_ar": arabic,
+        "full_text_en": english,
+        "grade": _primary_grade(rec),
+        "chapter_name_ar": None,
+        "chapter_name_en": safe_str(rec.get("chapter")),
         "sect": SECT,
     }
 
 
-def _infer_collection_name(file_path: Path, data: Any) -> str:
-    """Best-effort collection name from file or data."""
-    if isinstance(data, dict):
-        for key in ("bookName", "book_name", "collection", "title"):
-            val = data.get(key)
-            if isinstance(val, str) and val.strip():
-                return val.strip()
-    # Fall back to file stem (e.g., "book_123" -> "book_123")
-    return file_path.stem
+def _collection_name_en(rec: dict[str, Any], book_id: str) -> str:
+    """Human display name for a book's Collection node.
 
-
-def _infer_book_number(file_path: Path) -> int | None:
-    """Extract book number from filename like book_42.json."""
-    stem = file_path.stem
-    if stem.startswith("book_"):
-        return safe_int(stem.removeprefix("book_"))
-    return None
-
-
-def _discover(raw_dir: Path) -> None:
-    """Load first JSON and log keys/structure for field mapping discovery.
-
-    Development utility — only callable via ``python -m src.parse.thaqalayn``.
+    Volumes of a multi-volume work share the same ``book`` title, so the volume
+    is appended to keep each Collection distinct (and matching the per-volume
+    ``bookId``). Falls back to the ``bookId`` slug if no title is present.
     """
-    thaq_dir = raw_dir / "thaqalayn"
-    json_files = sorted(thaq_dir.glob("book_*.json"))
-    if not json_files:
-        # Try github clone
-        json_files = sorted((thaq_dir / "github_clone").rglob("*.json"))
-
-    if not json_files:
-        logger.warning("thaqalayn_discover_no_files")
-        return
-
-    sample = json_files[0]
-    with open(sample, encoding="utf-8") as f:
-        data = json.load(f)
-
-    fmt = _detect_format(data)
-    logger.info("thaqalayn_discover", file=sample.name, format=fmt)
-
-    if isinstance(data, dict):
-        logger.info("thaqalayn_discover_top_keys", keys=list(data.keys()))
-        for key, val in data.items():
-            if isinstance(val, list) and val:
-                first = val[0]
-                if isinstance(first, dict):
-                    logger.info("thaqalayn_discover_item_keys", parent=key, keys=list(first.keys()))
-    elif isinstance(data, list) and data and isinstance(data[0], dict):
-        logger.info("thaqalayn_discover_item_keys", parent="root", keys=list(data[0].keys()))
+    book = safe_str(rec.get("book"))
+    if not book:
+        return book_id
+    volume = safe_int(rec.get("volume"))
+    if volume and "volume" not in book.lower():
+        return f"{book} (Volume {volume})"
+    return book
 
 
 def run(raw_dir: Path, staging_dir: Path) -> tuple[Path, Path]:
-    """Parse Thaqalayn JSONs into hadiths + collections Parquet files."""
+    """Parse Thaqalayn per-book JSONs into hadiths + collections Parquet files."""
     thaq_dir = raw_dir / "thaqalayn"
-
-    # Gather JSON files from API download or GitHub clone
-    json_files = sorted(thaq_dir.glob("book_*.json"))
-    github_jsons: list[Path] = []
+    json_files = book_json_files(thaq_dir)
     if not json_files:
-        github_jsons = sorted((thaq_dir / "github_clone").rglob("*.json"))
-        json_files = github_jsons
-
-    if not json_files:
-        msg = "No Thaqalayn JSON files found"
+        msg = f"No Thaqalayn per-book JSON files under {thaq_dir}/{'/'.join(_DATA_SUBDIR)}"
         raise FileNotFoundError(msg)
 
     logger.info("thaqalayn_parse_start", file_count=len(json_files))
 
     hadith_rows: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
     collections: dict[str, dict[str, Any]] = {}
     total_with_isnad = 0
-    total_hadiths = 0
 
     for fp in json_files:
         with open(fp, encoding="utf-8") as f:
             data = json.load(f)
+        if not isinstance(data, list):
+            logger.warning("thaqalayn_unexpected_shape", file=fp.name, type=type(data).__name__)
+            continue
 
-        fmt = _detect_format(data)
-        if fmt == "api":
-            hadiths = _extract_hadiths_api(data)
-        else:
-            hadiths = _extract_hadiths_github(data)
-
-        collection_name = _infer_collection_name(fp, data)
-        book_number = _infer_book_number(fp)
-
-        for h in hadiths:
-            if not isinstance(h, dict):
+        for rec in data:
+            if not isinstance(rec, dict):
                 continue
-            row = _hadith_to_row(h, collection_name, book_number)
+            row = _hadith_to_row(rec)
+            if row is None:
+                continue
+            # (bookId, id) is unique upstream, but guard against any dup so the
+            # MERGE-by-id load never silently collapses rows (da#175).
+            if row["source_id"] in seen_ids:
+                continue
+            seen_ids.add(row["source_id"])
             hadith_rows.append(row)
-            total_hadiths += 1
-            if row["isnad_raw_ar"] is not None:
+            # Thaqalayn's isnad/matn split is English-only (see _hadith_to_row).
+            if row["isnad_raw_en"] is not None:
                 total_with_isnad += 1
 
-        # Track collection metadata
-        if collection_name not in collections:
-            collections[collection_name] = {
-                "collection_id": generate_source_id(SOURCE_CORPUS, collection_name),
-                "name_ar": safe_str(
-                    (data if isinstance(data, dict) else {}).get("bookNameAr")
-                    or (data if isinstance(data, dict) else {}).get("book_name_ar")
-                ),
-                "name_en": collection_name,
-                "compiler_name": safe_str(
-                    (data if isinstance(data, dict) else {}).get("author")
-                    or (data if isinstance(data, dict) else {}).get("compiler")
-                ),
-                "compilation_year_ah": None,
-                "sect": SECT,
-                "total_hadiths": 0,
-                "source_corpus": SOURCE_CORPUS,
-            }
-        collections[collection_name]["total_hadiths"] += len(
-            [h for h in hadiths if isinstance(h, dict)]
-        )
+            book_id = row["collection_name"]
+            coll = collections.get(book_id)
+            if coll is None:
+                collections[book_id] = {
+                    "collection_id": generate_source_id(SOURCE_CORPUS, book_id),
+                    "name_ar": None,
+                    "name_en": _collection_name_en(rec, book_id),
+                    "compiler_name": safe_str(rec.get("author")),
+                    "compilation_year_ah": None,
+                    "sect": SECT,
+                    "total_hadiths": 1,
+                    "source_corpus": SOURCE_CORPUS,
+                }
+            else:
+                coll["total_hadiths"] += 1
 
-    # Log isnad separation rate
+    total_hadiths = len(hadith_rows)
     isnad_rate = (total_with_isnad / total_hadiths * 100) if total_hadiths else 0.0
     logger.info(
         "thaqalayn_isnad_rate",
@@ -294,7 +197,6 @@ def run(raw_dir: Path, staging_dir: Path) -> tuple[Path, Path]:
         rate_pct=round(isnad_rate, 1),
     )
 
-    # Build and write hadiths parquet
     hadith_table = pa.table(
         {field.name: [r[field.name] for r in hadith_rows] for field in HADITH_SCHEMA},
         schema=HADITH_SCHEMA,
@@ -303,7 +205,6 @@ def run(raw_dir: Path, staging_dir: Path) -> tuple[Path, Path]:
         hadith_table, Path(staging_dir) / "hadiths_thaqalayn.parquet", schema=HADITH_SCHEMA
     )
 
-    # Build and write collections parquet
     coll_rows = list(collections.values())
     coll_table = pa.table(
         {field.name: [r[field.name] for r in coll_rows] for field in COLLECTION_SCHEMA},
@@ -319,13 +220,3 @@ def run(raw_dir: Path, staging_dir: Path) -> tuple[Path, Path]:
         collections=len(coll_rows),
     )
     return hadiths_path, collections_path
-
-
-if __name__ == "__main__":
-    import sys
-
-    from src.config import get_settings
-
-    settings = get_settings()
-    if "--discover" in sys.argv:
-        _discover(settings.data_raw_dir)

--- a/src/parse/validate.py
+++ b/src/parse/validate.py
@@ -133,7 +133,10 @@ DEFAULT_BASELINES: dict[str, dict[str, float | int]] = {
     # Baselines calibrated from Wave 3 full pipeline run (2026-03-30)
     "hadiths_sunnah_api": {"row_count": 30000, "arabic_coverage_pct": 90.0},
     "hadiths_open_hadith": {"row_count": 62160, "arabic_coverage_pct": 0.0},
-    "hadiths_thaqalayn": {"row_count": 113401, "arabic_coverage_pct": 0.0},
+    # Recalibrated da#175: the old 113401/0.0 baseline was captured from the
+    # broken parse (V1+V2+allBooks duplication, English text mis-routed into the
+    # Arabic column). Corrected = V2 per-book scope, Arabic in matn_ar.
+    "hadiths_thaqalayn": {"row_count": 33190, "arabic_coverage_pct": 99.0},
     "hadiths_lk": {"row_count": 34088, "arabic_coverage_pct": 99.0},
     "hadiths_fawaz": {"row_count": 0, "arabic_coverage_pct": 0.0},
     "hadiths_sanadset": {"row_count": 650986, "arabic_coverage_pct": 90.0},
@@ -148,7 +151,7 @@ DEFAULT_BASELINES: dict[str, dict[str, float | int]] = {
     "narrators_bio_itqan": {"row_count": 115735},
     "collections_sunnah_api": {"row_count": 15},
     "collections_sunnah_scraped": {"row_count": 5},
-    "collections_thaqalayn": {"row_count": 64},
+    "collections_thaqalayn": {"row_count": 33},  # da#175: V2 per-book collections
     "collections_lk": {"row_count": 6},
     "collections_fawaz": {"row_count": 0},
     "network_edges_muhaddithat": {"row_count": 330},

--- a/tests/integration/test_thaqalayn_lightup.py
+++ b/tests/integration/test_thaqalayn_lightup.py
@@ -33,80 +33,109 @@ pytestmark = pytest.mark.integration
 
 
 # ---------------------------------------------------------------------------
-# Sample Thaqalayn data — API-format JSON, two of the Four Books (Shia).
-# Mirrors the real ThaqalaynAPI shape: a top-level ``data`` list of hadith
-# objects under a ``bookName``. Arabic + English matn, grades, chapters.
+# Sample Thaqalayn data — the REAL upstream record shape (da#175): a JSON array
+# of records per book under ``github_clone/V2/ThaqalaynData/<n>.json``, with
+# ``id``/``bookId``/``arabicText``/``thaqalaynSanad``/``majlisiGrading`` fields.
+# Two of the Four Books (al-Kafi, Man Lā Yaḥḍuruhu al-Faqīh).
 # ---------------------------------------------------------------------------
 
-_AL_KAFI = {
-    "bookName": "Al-Kafi",
-    "bookNameAr": "الكافي",
-    "author": "al-Kulayni",
-    "data": [
-        {
-            "hadithNumber": 1,
-            "textAr": "إنما الأعمال بالنيات ولكل امرئ ما نوى",
-            "textEn": "Actions are but by intentions; everyone shall have what they intended.",
-            "grade": "Sahih",
-            "chapterEn": "The Book of Intellect and Ignorance",
-            "chapterNumber": 1,
-        },
-        {
-            "hadithNumber": 2,
-            "textAr": "العلم نور يقذفه الله في قلب من يشاء",
-            "textEn": "Knowledge is a light that Allah casts into the heart of whom He wills.",
-            "grade": "Hasan",
-            "chapterEn": "The Book of the Excellence of Knowledge",
-            "chapterNumber": 2,
-        },
-        {
-            "hadithNumber": 3,
-            "textAr": "من سلك طريقا يطلب فيه علما سلك الله به طريقا إلى الجنة",
-            "textEn": "Whoever travels a path seeking knowledge, Allah sets them toward Paradise.",
-            "grade": "Sahih",
-            "chapterEn": "The Book of the Excellence of Knowledge",
-            "chapterNumber": 2,
-        },
-    ],
-}
+_AL_KAFI = [
+    {
+        "id": 1,
+        "bookId": "Al-Kafi-Volume-1-Kulayni",
+        "book": "Al-Kāfi",
+        "volume": 1,
+        "category": "The Book of Intellect and Ignorance",
+        "categoryId": 1,
+        "chapter": "Chapter 1",
+        "chapterInCategoryId": 1,
+        "author": "al-Kulayni",
+        "arabicText": "إنما الأعمال بالنيات ولكل امرئ ما نوى",
+        "englishText": "Actions are but by intentions; everyone shall have what they intended.",
+        "majlisiGrading": "Sahih",
+        "thaqalaynSanad": "A number of our companions narrated",
+        "thaqalaynMatn": "Actions are but by intentions.",
+    },
+    {
+        "id": 2,
+        "bookId": "Al-Kafi-Volume-1-Kulayni",
+        "book": "Al-Kāfi",
+        "volume": 1,
+        "category": "The Book of the Excellence of Knowledge",
+        "categoryId": 2,
+        "chapter": "Chapter 2",
+        "chapterInCategoryId": 1,
+        "author": "al-Kulayni",
+        "arabicText": "العلم نور يقذفه الله في قلب من يشاء",
+        "englishText": "Knowledge is a light that Allah casts into the heart of whom He wills.",
+        "majlisiGrading": "Hasan",
+        "thaqalaynSanad": "",
+        "thaqalaynMatn": "",
+    },
+    {
+        "id": 3,
+        "bookId": "Al-Kafi-Volume-1-Kulayni",
+        "book": "Al-Kāfi",
+        "volume": 1,
+        "category": "The Book of the Excellence of Knowledge",
+        "categoryId": 2,
+        "chapter": "Chapter 2",
+        "chapterInCategoryId": 2,
+        "author": "al-Kulayni",
+        "arabicText": "من سلك طريقا يطلب فيه علما سلك الله به طريقا إلى الجنة",
+        "englishText": "Whoever travels a path seeking knowledge, Allah sets them toward Paradise.",
+        "majlisiGrading": "Sahih",
+        "thaqalaynSanad": "",
+        "thaqalaynMatn": "",
+    },
+]
 
-_MAN_LA_YAHDURUHU = {
-    "bookName": "Man La Yahduruhu al-Faqih",
-    "bookNameAr": "من لا يحضره الفقيه",
-    "author": "al-Shaykh al-Saduq",
-    "data": [
-        {
-            "hadithNumber": 1,
-            "textAr": "الطهور نصف الإيمان",
-            "textEn": "Purification is half of faith.",
-            "grade": "Sahih",
-            "chapterEn": "The Book of Purification",
-            "chapterNumber": 1,
-        },
-        {
-            "hadithNumber": 2,
-            "textAr": "الصلاة عمود الدين",
-            "textEn": "Prayer is the pillar of the religion.",
-            "grade": "Sahih",
-            "chapterEn": "The Book of Prayer",
-            "chapterNumber": 2,
-        },
-    ],
-}
+_MAN_LA_YAHDURUHU = [
+    {
+        "id": 1,
+        "bookId": "Man-La-Yahduruh-al-Faqih-Volume-1-Saduq",
+        "book": "Man Lā Yaḥḍuruhu al-Faqīh",
+        "volume": 1,
+        "category": "The Book of Purification",
+        "categoryId": 1,
+        "chapter": "Chapter 1",
+        "chapterInCategoryId": 1,
+        "author": "al-Shaykh al-Saduq",
+        "arabicText": "الطهور نصف الإيمان",
+        "englishText": "Purification is half of faith.",
+        "majlisiGrading": "Sahih",
+        "thaqalaynSanad": "",
+        "thaqalaynMatn": "",
+    },
+    {
+        "id": 2,
+        "bookId": "Man-La-Yahduruh-al-Faqih-Volume-1-Saduq",
+        "book": "Man Lā Yaḥḍuruhu al-Faqīh",
+        "volume": 1,
+        "category": "The Book of Prayer",
+        "categoryId": 2,
+        "chapter": "Chapter 2",
+        "chapterInCategoryId": 1,
+        "author": "al-Shaykh al-Saduq",
+        "arabicText": "الصلاة عمود الدين",
+        "englishText": "Prayer is the pillar of the religion.",
+        "majlisiGrading": "Sahih",
+        "thaqalaynSanad": "",
+        "thaqalaynMatn": "",
+    },
+]
 
 # Total hadith / collection counts the fixture is expected to produce.
-_EXPECTED_HADITHS = len(_AL_KAFI["data"]) + len(_MAN_LA_YAHDURUHU["data"])  # 5
+_EXPECTED_HADITHS = len(_AL_KAFI) + len(_MAN_LA_YAHDURUHU)  # 5
 _EXPECTED_COLLECTIONS = 2
 
 
 def _write_thaqalayn_raw(raw_dir: Path) -> None:
-    """Write the two-book Thaqalayn API-format fixture under raw/thaqalayn/."""
-    thaq_dir = raw_dir / "thaqalayn"
-    thaq_dir.mkdir(parents=True)
-    (thaq_dir / "book_1.json").write_text(
-        json.dumps(_AL_KAFI, ensure_ascii=False), encoding="utf-8"
-    )
-    (thaq_dir / "book_2.json").write_text(
+    """Write the two-book Thaqalayn fixture under the real V2 clone layout."""
+    data_dir = raw_dir / "thaqalayn" / "github_clone" / "V2" / "ThaqalaynData"
+    data_dir.mkdir(parents=True)
+    (data_dir / "1.json").write_text(json.dumps(_AL_KAFI, ensure_ascii=False), encoding="utf-8")
+    (data_dir / "2.json").write_text(
         json.dumps(_MAN_LA_YAHDURUHU, ensure_ascii=False), encoding="utf-8"
     )
 

--- a/tests/test_acquire/test_thaqalayn.py
+++ b/tests/test_acquire/test_thaqalayn.py
@@ -1,9 +1,10 @@
 """Tests for the Thaqalayn (Shia) acquire adapter.
 
-da#85 — closing the acquire-side test gap (only ``base`` and ``sunnah_scraper``
-had one before). The network/clone is mocked: ``clone_repo`` is patched to
-materialise fake book JSONs so the GitHub-clone, idempotent-skip, and
-under-minimum branches of ``run`` are exercised without touching the network.
+The network clone is mocked: ``clone_repo`` is patched to materialise fake
+per-book JSONs under the real ``V2/ThaqalaynData/<n>.json`` layout, so the
+clone, idempotent-skip, and under-minimum branches of ``run`` are exercised
+without touching the network. Scope discipline (da#175): the adapter counts and
+emits only the canonical per-book files, never the aggregates/config.
 """
 
 from __future__ import annotations
@@ -17,14 +18,27 @@ import pytest
 from src.acquire.thaqalayn import MIN_EXPECTED_BOOKS, run
 
 
-def _fake_clone(_url: str, dest: Path, **_kwargs: object) -> Path:
-    """Stand-in for ``clone_repo``: materialise MIN_EXPECTED_BOOKS JSON files."""
-    dest.mkdir(parents=True, exist_ok=True)
-    for i in range(MIN_EXPECTED_BOOKS):
-        (dest / f"book_{i}.json").write_text(
-            json.dumps({"bookName": f"Book {i}", "data": []}), encoding="utf-8"
+def _data_dir(clone_dest: Path) -> Path:
+    """The canonical per-book dir inside a clone destination."""
+    return clone_dest / "V2" / "ThaqalaynData"
+
+
+def _write_book_files(data_dir: Path, count: int) -> None:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        (data_dir / f"{i}.json").write_text(
+            json.dumps([{"id": 1, "bookId": f"Book-{i}", "arabicText": "نص"}], ensure_ascii=False),
+            encoding="utf-8",
         )
-    return dest
+    # Aggregate/config siblings that must NOT be counted as book files.
+    (data_dir / "allBooks.json").write_text("[]", encoding="utf-8")
+    (data_dir / "BookNames.json").write_text("[]", encoding="utf-8")
+
+
+def _fake_clone(_url: str, clone_dest: Path, **_kwargs: object) -> Path:
+    """Stand-in for ``clone_repo``: materialise MIN_EXPECTED_BOOKS book files."""
+    _write_book_files(_data_dir(clone_dest), MIN_EXPECTED_BOOKS)
+    return clone_dest
 
 
 class TestThaqalaynAcquire:
@@ -43,20 +57,18 @@ class TestThaqalaynAcquire:
         mock_clone.assert_called_once()  # type: ignore[attr-defined]
         mock_emit.assert_called_once()  # type: ignore[attr-defined]
 
-        # Manifest lists the cloned JSONs.
+        # Manifest lists exactly the canonical per-book files (not aggregates).
         manifest = json.loads((dest / "manifest.json").read_text())
-        assert len(manifest) >= MIN_EXPECTED_BOOKS
+        assert len(manifest) == MIN_EXPECTED_BOOKS
 
     @patch("src.acquire.thaqalayn.emit_raw_new_for_manifest")
     @patch("src.acquire.thaqalayn.clone_repo", side_effect=_fake_clone)
     def test_idempotent_skips_when_already_acquired(
         self, mock_clone: object, mock_emit: object, tmp_path: Path
     ) -> None:
-        """Pre-existing ``book_*.json`` short-circuits the clone (no network)."""
+        """A pre-existing clone short-circuits the network clone."""
         dest = tmp_path / "raw" / "thaqalayn"
-        dest.mkdir(parents=True)
-        for i in range(MIN_EXPECTED_BOOKS):
-            (dest / f"book_{i}.json").write_text("{}", encoding="utf-8")
+        _write_book_files(_data_dir(dest / "github_clone"), MIN_EXPECTED_BOOKS)
 
         result = run(tmp_path / "raw")
 
@@ -71,16 +83,15 @@ class TestThaqalaynAcquire:
     def test_raises_when_too_few_books(
         self, mock_clone: object, mock_emit: object, tmp_path: Path
     ) -> None:
-        """A clone yielding fewer than MIN_EXPECTED_BOOKS JSONs fails loudly."""
+        """A clone yielding fewer than MIN_EXPECTED_BOOKS book files fails loudly."""
 
         def _sparse_clone(_url: str, clone_dest: Path, **_kwargs: object) -> Path:
-            clone_dest.mkdir(parents=True, exist_ok=True)
-            (clone_dest / "book_0.json").write_text("{}", encoding="utf-8")
+            _write_book_files(_data_dir(clone_dest), 1)
             return clone_dest
 
         mock_clone.side_effect = _sparse_clone  # type: ignore[attr-defined]
 
-        with pytest.raises(AssertionError, match="JSON files"):
+        with pytest.raises(AssertionError, match="per-book JSON files"):
             run(tmp_path / "raw")
 
         mock_emit.assert_not_called()  # type: ignore[attr-defined]

--- a/tests/test_messaging/test_acquire_wireins.py
+++ b/tests/test_messaging/test_acquire_wireins.py
@@ -101,9 +101,9 @@ class TestMuhaddithatWireIn:
 class TestThaqalaynWireIn:
     def test_run_emits_with_source_thaqalayn_on_skip_path(self, tmp_path: Path) -> None:
         raw = tmp_path / "raw"
-        dest = raw / "thaqalayn"
-        # Pre-seed enough book_*.json files to hit the idempotent skip branch.
-        _seed_jsons(dest, [f"book_{i:03d}.json" for i in range(16)])
+        # Pre-seed enough canonical V2 per-book files to hit the idempotent skip.
+        data_dir = raw / "thaqalayn" / "github_clone" / "V2" / "ThaqalaynData"
+        _seed_jsons(data_dir, [f"{i}.json" for i in range(16)])
 
         with patch("src.acquire.thaqalayn.emit_raw_new_for_manifest") as emit:
             from src.acquire import thaqalayn
@@ -116,16 +116,12 @@ class TestThaqalaynWireIn:
     def test_run_emits_with_source_thaqalayn_on_fresh_clone(self, tmp_path: Path) -> None:
         raw = tmp_path / "raw"
 
-        def fake_download(dest: Path) -> list[Path]:
-            clone_dest = dest / "github_clone"
-            _seed_jsons(clone_dest, [f"book_{i:03d}.json" for i in range(16)])
-            return list(clone_dest.glob("*.json"))
+        def fake_clone_repo(_url: str, dest: Path, **_kw: Any) -> Path:
+            _seed_jsons(dest / "V2" / "ThaqalaynData", [f"{i}.json" for i in range(16)])
+            return dest
 
         with (
-            patch(
-                "src.acquire.thaqalayn._download_via_github",
-                side_effect=fake_download,
-            ),
+            patch("src.acquire.thaqalayn.clone_repo", side_effect=fake_clone_repo),
             patch("src.acquire.thaqalayn.emit_raw_new_for_manifest") as emit,
         ):
             from src.acquire import thaqalayn

--- a/tests/test_parse/test_thaqalayn_parser.py
+++ b/tests/test_parse/test_thaqalayn_parser.py
@@ -1,4 +1,16 @@
-"""End-to-end tests for the Thaqalayn parser."""
+"""Tests for the Thaqalayn parser against the REAL upstream repo schema.
+
+The previous fixtures here used invented field names (``hadithNumber``,
+``textAr``, ``arabicText`` with a ``data`` wrapper) that do not exist in the
+``MohammedArab1/ThaqalaynAPI`` repo. They passed while the parser produced
+unloadable garbage on real data — 0% Arabic text and one ``source_id`` per book
+(da#175). This suite seeds the **actual** record shape (``id``, ``bookId``,
+``arabicText``, ``thaqalaynSanad``/``thaqalaynMatn``, ``majlisiGrading`` …) under
+the real ``github_clone/V2/ThaqalaynData/<n>.json`` layout, plus the aggregate
+and repo-config decoys the parser must ignore. This is main#671's fixture-masks-
+bug rule applied in miniature: the fixture mirrors production, not the parser's
+assumptions.
+"""
 
 from __future__ import annotations
 
@@ -9,239 +21,212 @@ import pyarrow.parquet as pq
 
 from src.parse.identity import is_double_prefixed, validate_source_id
 from src.parse.schemas import COLLECTION_SCHEMA, HADITH_SCHEMA
-from src.parse.thaqalayn import run
+from src.parse.thaqalayn import book_json_files, run
+
+# Two real-shaped records from al-Kafi Volume 1: an introduction entry (no
+# sanad/matn split, ungraded) and a graded narration with the isnad/matn split.
+_BOOK_1 = [
+    {
+        "id": 1,
+        "bookId": "Al-Kafi-Volume-1-Kulayni",
+        "book": "Al-Kāfi",
+        "volume": 1,
+        "category": "Introduction",
+        "categoryId": 1,
+        "chapter": "Introduction",
+        "chapterInCategoryId": 1,
+        "author": "Shaykh Muḥammad b. Yaʿqūb al-Kulaynī",
+        "translator": "Muhammad Sarwar",
+        "englishText": "In the praise of Allah...",
+        "arabicText": "الحمد لله الذي حمده",
+        "majlisiGrading": "",
+        "behbudiGrading": "",
+        "mohseniGrading": "",
+        "thaqalaynSanad": "",
+        "thaqalaynMatn": "",
+    },
+    {
+        "id": 2,
+        "bookId": "Al-Kafi-Volume-1-Kulayni",
+        "book": "Al-Kāfi",
+        "volume": 1,
+        "category": "The Book of Reason and Ignorance",
+        "categoryId": 2,
+        "chapter": "Chapter 1",
+        "chapterInCategoryId": 1,
+        "author": "Shaykh Muḥammad b. Yaʿqūb al-Kulaynī",
+        "translator": "Muhammad Sarwar",
+        "englishText": "Reason is that by which the Merciful is worshipped.",
+        "arabicText": "عدة من أصحابنا عن أحمد العقل ما عبد به الرحمن",
+        "majlisiGrading": "Ṣaḥīḥ",
+        "behbudiGrading": "",
+        "mohseniGrading": "Muʿtabar",
+        # Thaqalayn's sanad/matn split is on the ENGLISH translation, not Arabic.
+        "thaqalaynSanad": "A number of our companions narrated from Ahmad",
+        "thaqalaynMatn": "Reason is that by which the Merciful is worshipped.",
+    },
+]
+
+# A second book (different bookId, same multi-volume title) — exercises the
+# per-volume Collection split and the volume-suffixed display name.
+_BOOK_2 = [
+    {
+        "id": 1,
+        "bookId": "Al-Kafi-Volume-2-Kulayni",
+        "book": "Al-Kāfi",
+        "volume": 2,
+        "category": "The Book of Faith and Disbelief",
+        "categoryId": 1,
+        "chapter": "Chapter 1",
+        "chapterInCategoryId": 1,
+        "author": "Shaykh Muḥammad b. Yaʿqūb al-Kulaynī",
+        "translator": "Muhammad Sarwar",
+        "englishText": "When Allah created reason...",
+        "arabicText": "نص عربي للحديث",
+        "majlisiGrading": "Ḥasan",
+        "behbudiGrading": "Ḥasan",
+        "mohseniGrading": "",
+        "thaqalaynSanad": "Muhammad b. Yahya narrated",
+        "thaqalaynMatn": "When Allah created reason.",
+    },
+]
 
 
-def _make_thaqalayn_json(raw_dir: Path) -> None:
-    """Create minimal Thaqalayn API-format JSON test data."""
-    thaq_dir = raw_dir / "thaqalayn"
-    thaq_dir.mkdir(parents=True)
+def _seed_real_clone(raw_dir: Path) -> None:
+    """Materialise the real ``V2/ThaqalaynData`` layout plus must-ignore decoys."""
+    clone = raw_dir / "thaqalayn" / "github_clone"
+    data_dir = clone / "V2" / "ThaqalaynData"
+    data_dir.mkdir(parents=True)
 
-    data = {
-        "bookName": "Al-Kafi",
-        "bookNameAr": "الكافي",
-        "data": [
-            {
-                "hadithNumber": 1,
-                "textAr": "نص الحديث الأول",
-                "textEn": "First hadith text",
-                "grade": "Sahih",
-                "chapterEn": "Chapter One",
-                "chapterNumber": 1,
-            },
-            {
-                "hadithNumber": 2,
-                "textAr": "نص الحديث الثاني",
-                "textEn": "Second hadith text",
-                "grade": "Hasan",
-                "chapterEn": "Chapter One",
-                "chapterNumber": 1,
-            },
-        ],
-    }
-    (thaq_dir / "book_1.json").write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    (data_dir / "1.json").write_text(json.dumps(_BOOK_1, ensure_ascii=False), encoding="utf-8")
+    (data_dir / "2.json").write_text(json.dumps(_BOOK_2, ensure_ascii=False), encoding="utf-8")
+
+    # Decoys the selector MUST exclude (da#175): the giant aggregate that
+    # re-lists every hadith, the index file, the Ingredients subdir, and repo
+    # config. If any leaked in, row counts would inflate / collections corrupt.
+    (data_dir / "allBooks.json").write_text(
+        json.dumps(_BOOK_1 + _BOOK_2, ensure_ascii=False), encoding="utf-8"
+    )
+    (data_dir / "BookNames.json").write_text(
+        json.dumps([{"bookId": "Al-Kafi-Volume-1-Kulayni", "name": "Al-Kāfi"}]), encoding="utf-8"
+    )
+    (data_dir / "Ingredients").mkdir()
+    (data_dir / "Ingredients" / "ingredients.json").write_text("[]", encoding="utf-8")
+    (clone / "package-lock.json").write_text('{"name": "thaqalayn"}', encoding="utf-8")
+    (clone / "API").mkdir()
+    (clone / "API" / "tsconfig.json").write_text("{}", encoding="utf-8")
+
+
+_TOTAL_HADITHS = len(_BOOK_1) + len(_BOOK_2)
+
+
+class TestBookFileSelection:
+    def test_selects_only_numeric_book_files(self, tmp_path: Path) -> None:
+        _seed_real_clone(tmp_path)
+        files = book_json_files(tmp_path / "thaqalayn")
+        names = sorted(f.name for f in files)
+        assert names == ["1.json", "2.json"]  # aggregates / index / config excluded
+
+    def test_empty_when_no_clone(self, tmp_path: Path) -> None:
+        assert book_json_files(tmp_path / "thaqalayn") == []
 
 
 class TestThaqalaynParser:
     def test_produces_parquet_files(self, tmp_path: Path) -> None:
-        raw_dir = tmp_path / "raw"
-        staging_dir = tmp_path / "staging"
-        _make_thaqalayn_json(raw_dir)
+        _seed_real_clone(tmp_path)
+        h, c = run(tmp_path, tmp_path / "staging")
+        assert h.exists() and c.exists()
 
-        hadiths_path, collections_path = run(raw_dir, staging_dir)
-
-        assert hadiths_path.exists()
-        assert collections_path.exists()
-
-    def test_hadith_schema_conforms(self, tmp_path: Path) -> None:
-        raw_dir = tmp_path / "raw"
-        staging_dir = tmp_path / "staging"
-        _make_thaqalayn_json(raw_dir)
-
-        hadiths_path, _ = run(raw_dir, staging_dir)
-
-        table = pq.read_table(hadiths_path)
+    def test_hadith_schema_and_row_count(self, tmp_path: Path) -> None:
+        _seed_real_clone(tmp_path)
+        h, _ = run(tmp_path, tmp_path / "staging")
+        table = pq.read_table(h)
         assert table.schema == HADITH_SCHEMA
-        assert table.num_rows == 2
+        # Only the two numeric book files — the allBooks aggregate is NOT counted.
+        assert table.num_rows == _TOTAL_HADITHS
 
-    def test_collection_schema_conforms(self, tmp_path: Path) -> None:
-        raw_dir = tmp_path / "raw"
-        staging_dir = tmp_path / "staging"
-        _make_thaqalayn_json(raw_dir)
-
-        _, collections_path = run(raw_dir, staging_dir)
-
-        table = pq.read_table(collections_path)
-        assert table.schema == COLLECTION_SCHEMA
-        assert table.num_rows >= 1
-
-    def test_sect_is_shia(self, tmp_path: Path) -> None:
-        raw_dir = tmp_path / "raw"
-        staging_dir = tmp_path / "staging"
-        _make_thaqalayn_json(raw_dir)
-
-        hadiths_path, _ = run(raw_dir, staging_dir)
-
-        table = pq.read_table(hadiths_path)
-        sects = table.column("sect").to_pylist()
-        assert all(s == "shia" for s in sects)
-
-
-def _make_thaqalayn_github_json(raw_dir: Path) -> None:
-    """Create GitHub-format Thaqalayn test data under ``github_clone/``.
-
-    Mirrors the production acquisition path: ``src/acquire/thaqalayn.py`` clones
-    the ThaqalaynAPI repo into ``thaqalayn/github_clone/`` and the parser walks it
-    with ``rglob("*.json")`` (no top-level ``book_*.json``), so detection takes the
-    ``_extract_hadiths_github`` branch instead of the API ``data``-wrapper branch.
-
-    Two shapes are seeded to cover both GitHub-format variants the extractor
-    handles:
-
-    * a **bare array** of hadith objects (with one non-hadith metadata dict that
-      ``_looks_like_hadith`` must filter out), and
-    * a **wrapper dict** whose hadiths live under a ``"hadiths"`` key.
-    """
-    gh_dir = raw_dir / "thaqalayn" / "github_clone" / "dataset"
-    gh_dir.mkdir(parents=True)
-
-    # Bare-array form — the most common ThaqalaynAPI dataset shape. The trailing
-    # metadata dict has no hadith-indicative field and must be dropped.
-    al_kafi = [
-        {
-            "hadithNumber": 1,
-            "arabicText": "نص الحديث الأول",
-            "englishText": "First hadith text",
-            "grade": "Sahih",
-            "chapter": "Book of Reason",
-            "chapterNumber": 1,
-        },
-        {
-            "hadithNumber": 2,
-            "arabicText": "نص الحديث الثاني",
-            "englishText": "Second hadith text",
-            "grade": ["Sahih", "Hasan"],
-            "chapter": "Book of Reason",
-            "chapterNumber": 1,
-        },
-        {"_meta": "license", "version": "2.0"},
-    ]
-    (gh_dir / "al_kafi.json").write_text(json.dumps(al_kafi, ensure_ascii=False), encoding="utf-8")
-
-    # Wrapper-dict form — hadiths nested under a "hadiths" key, no top-level
-    # "data" list (so detection stays on the GitHub branch).
-    faqih = {
-        "bookName": "Man La Yahduruhu al-Faqih",
-        "bookNameAr": "من لا يحضره الفقيه",
-        "author": "al-Shaykh al-Saduq",
-        "hadiths": [
-            {
-                "hadith_number": 1,
-                "textAr": "نص الحديث الثالث",
-                "textEn": "Third hadith text",
-                "grading": "Muwaththaq",
-                "chapterEn": "Book of Purity",
-            },
-        ],
-    }
-    (gh_dir / "faqih.json").write_text(json.dumps(faqih, ensure_ascii=False), encoding="utf-8")
-
-
-class TestThaqalaynGithubFormat:
-    """Cover the production GitHub-format parse path (``_extract_hadiths_github``).
-
-    Production acquisition is a ``git clone`` of the ThaqalaynAPI repo, so the
-    GitHub branch — not the API ``data``-wrapper branch the other tests exercise —
-    is what runs against real data (da#108, follow-up from da#105 / PR #105).
-    """
-
-    def test_produces_parquet_files(self, tmp_path: Path) -> None:
-        raw_dir = tmp_path / "raw"
-        staging_dir = tmp_path / "staging"
-        _make_thaqalayn_github_json(raw_dir)
-
-        hadiths_path, collections_path = run(raw_dir, staging_dir)
-
-        assert hadiths_path.exists()
-        assert collections_path.exists()
-
-    def test_hadith_schema_conforms_and_filters_non_hadith(self, tmp_path: Path) -> None:
-        raw_dir = tmp_path / "raw"
-        staging_dir = tmp_path / "staging"
-        _make_thaqalayn_github_json(raw_dir)
-
-        hadiths_path, _ = run(raw_dir, staging_dir)
-
-        table = pq.read_table(hadiths_path)
-        assert table.schema == HADITH_SCHEMA
-        # 2 from the bare array (the non-hadith metadata dict is filtered) +
-        # 1 from the wrapper dict's "hadiths" key == 3.
-        assert table.num_rows == 3
-
-    def test_both_github_shapes_extracted(self, tmp_path: Path) -> None:
-        """Both the bare-array and wrapper-dict hadiths reach staging."""
-        raw_dir = tmp_path / "raw"
-        staging_dir = tmp_path / "staging"
-        _make_thaqalayn_github_json(raw_dir)
-
-        hadiths_path, _ = run(raw_dir, staging_dir)
-
-        rows = pq.read_table(hadiths_path).to_pylist()
-        english = {r["matn_en"] for r in rows}
-        # bare-array hadiths + the wrapper-dict ("hadiths" key) hadith.
-        assert english == {"First hadith text", "Second hadith text", "Third hadith text"}
-
-    def test_provenance_matches_api_path(self, tmp_path: Path) -> None:
-        """sect=shia + source_corpus=thaqalayn on every GitHub-format row."""
-        raw_dir = tmp_path / "raw"
-        staging_dir = tmp_path / "staging"
-        _make_thaqalayn_github_json(raw_dir)
-
-        hadiths_path, _ = run(raw_dir, staging_dir)
-
-        table = pq.read_table(hadiths_path)
-        assert all(s == "shia" for s in table.column("sect").to_pylist())
-        assert all(c == "thaqalayn" for c in table.column("source_corpus").to_pylist())
-
-    def test_source_ids_satisfy_identity_contract(self, tmp_path: Path) -> None:
-        """Every GitHub-path source_id is canonical and not double-prefixed.
-
-        Same contract the API path and the live light-up assert (da#82 / main#139):
-        a known leading corpus, no empty segments, no doubled corpus prefix.
-        """
-        raw_dir = tmp_path / "raw"
-        staging_dir = tmp_path / "staging"
-        _make_thaqalayn_github_json(raw_dir)
-
-        hadiths_path, _ = run(raw_dir, staging_dir)
-
-        source_ids = pq.read_table(hadiths_path).column("source_id").to_pylist()
-        assert source_ids  # non-empty
-        for sid in source_ids:
+    def test_source_ids_unique_and_canonical(self, tmp_path: Path) -> None:
+        """One node per hadith — the da#175 collision regression guard."""
+        _seed_real_clone(tmp_path)
+        h, _ = run(tmp_path, tmp_path / "staging")
+        sids = pq.read_table(h).column("source_id").to_pylist()
+        assert len(set(sids)) == _TOTAL_HADITHS  # no collapse onto one id per book
+        assert "thaqalayn:Al-Kafi-Volume-1-Kulayni:1" in sids
+        for sid in sids:
             assert validate_source_id(sid) == [], f"non-canonical source_id: {sid!r}"
             assert not is_double_prefixed(sid), f"double-prefixed source_id: {sid!r}"
 
-    def test_grade_array_serialized_to_json(self, tmp_path: Path) -> None:
-        """A multi-value grade array is preserved as a JSON string, not dropped."""
-        raw_dir = tmp_path / "raw"
-        staging_dir = tmp_path / "staging"
-        _make_thaqalayn_github_json(raw_dir)
+    def test_matn_always_populated(self, tmp_path: Path) -> None:
+        """Every row carries Arabic text (the 100%-empty-matn regression guard)."""
+        _seed_real_clone(tmp_path)
+        h, _ = run(tmp_path, tmp_path / "staging")
+        matn = pq.read_table(h).column("matn_ar").to_pylist()
+        assert all(m for m in matn)
 
-        hadiths_path, _ = run(raw_dir, staging_dir)
+    def test_isnad_matn_split_is_english_arabic_intact(self, tmp_path: Path) -> None:
+        """The (English) sanad/matn split feeds *_en; matn_ar stays full Arabic."""
+        _seed_real_clone(tmp_path)
+        h, _ = run(tmp_path, tmp_path / "staging")
+        rows = {r["source_id"]: r for r in pq.read_table(h).to_pylist()}
+        graded = rows["thaqalayn:Al-Kafi-Volume-1-Kulayni:2"]
+        # thaqalaynSanad/thaqalaynMatn are English -> isnad_raw_en / matn_en.
+        assert graded["isnad_raw_en"] == "A number of our companions narrated from Ahmad"
+        assert graded["matn_en"] == "Reason is that by which the Merciful is worshipped."
+        # Arabic is never split upstream: matn_ar == full_text_ar == arabicText,
+        # and no Arabic isnad is fabricated.
+        assert graded["isnad_raw_ar"] is None
+        assert graded["matn_ar"] == "عدة من أصحابنا عن أحمد العقل ما عبد به الرحمن"
+        assert graded["full_text_ar"] == graded["matn_ar"]
+        # Introduction entry has no English split — matn_en falls back to englishText.
+        intro = rows["thaqalayn:Al-Kafi-Volume-1-Kulayni:1"]
+        assert intro["isnad_raw_en"] is None
+        assert intro["matn_ar"] == "الحمد لله الذي حمده"
+        assert intro["matn_en"] == "In the praise of Allah..."
 
-        rows = pq.read_table(hadiths_path).to_pylist()
-        grades = {r["matn_en"]: r["grade"] for r in rows}
-        assert grades["First hadith text"] == "Sahih"
-        assert json.loads(grades["Second hadith text"]) == ["Sahih", "Hasan"]
+    def test_primary_grade_prefers_majlisi(self, tmp_path: Path) -> None:
+        _seed_real_clone(tmp_path)
+        h, _ = run(tmp_path, tmp_path / "staging")
+        rows = {r["source_id"]: r for r in pq.read_table(h).to_pylist()}
+        # Majlisi present -> chosen over Mohseni; ungraded intro -> None.
+        assert rows["thaqalayn:Al-Kafi-Volume-1-Kulayni:2"]["grade"] == "Ṣaḥīḥ"
+        assert rows["thaqalayn:Al-Kafi-Volume-1-Kulayni:1"]["grade"] is None
 
-    def test_collections_carry_shia_provenance(self, tmp_path: Path) -> None:
-        raw_dir = tmp_path / "raw"
-        staging_dir = tmp_path / "staging"
-        _make_thaqalayn_github_json(raw_dir)
-
-        _, collections_path = run(raw_dir, staging_dir)
-
-        table = pq.read_table(collections_path)
-        assert table.schema == COLLECTION_SCHEMA
+    def test_provenance_is_shia_thaqalayn(self, tmp_path: Path) -> None:
+        _seed_real_clone(tmp_path)
+        h, _ = run(tmp_path, tmp_path / "staging")
+        table = pq.read_table(h)
         assert all(s == "shia" for s in table.column("sect").to_pylist())
         assert all(c == "thaqalayn" for c in table.column("source_corpus").to_pylist())
+
+    def test_collection_identity_and_appears_in_key(self, tmp_path: Path) -> None:
+        """collection_name == bookId so APPEARS_IN ({corpus}:{name}) links cleanly."""
+        _seed_real_clone(tmp_path)
+        h, c = run(tmp_path, tmp_path / "staging")
+        hrows = pq.read_table(h).to_pylist()
+        assert {r["collection_name"] for r in hrows} == {
+            "Al-Kafi-Volume-1-Kulayni",
+            "Al-Kafi-Volume-2-Kulayni",
+        }
+        crows = {r["collection_id"]: r for r in pq.read_table(c).to_pylist()}
+        # collection_id = thaqalayn:<bookId> == f"{corpus}:{hadith.collection_name}"
+        assert "thaqalayn:Al-Kafi-Volume-1-Kulayni" in crows
+        assert "thaqalayn:Al-Kafi-Volume-2-Kulayni" in crows
+
+    def test_collection_schema_and_volume_display(self, tmp_path: Path) -> None:
+        _seed_real_clone(tmp_path)
+        _, c = run(tmp_path, tmp_path / "staging")
+        table = pq.read_table(c)
+        assert table.schema == COLLECTION_SCHEMA
+        assert table.num_rows == 2  # one Collection per volume
+        names = {r["collection_id"]: r for r in table.to_pylist()}
+        v1 = names["thaqalayn:Al-Kafi-Volume-1-Kulayni"]
+        assert v1["name_en"] == "Al-Kāfi (Volume 1)"  # volume disambiguates the title
+        assert v1["sect"] == "shia"
+        assert v1["source_corpus"] == "thaqalayn"
+        assert v1["total_hadiths"] == len(_BOOK_1)
+
+    def test_no_duplication_from_aggregate(self, tmp_path: Path) -> None:
+        """The allBooks.json aggregate must NOT double the row count (da#175)."""
+        _seed_real_clone(tmp_path)
+        h, _ = run(tmp_path, tmp_path / "staging")
+        assert pq.read_table(h).num_rows == _TOTAL_HADITHS


### PR DESCRIPTION
## Summary
Fixes the `thaqalayn` (Shia) adapter so it actually loads against the **real** `MohammedArab1/ThaqalaynAPI` upstream, then loads the corpus to staging Neo4j. The issue's "code-complete / no new code" premise was false — see da#175 thread.

This is **main#671's fixture-masks-bug rule in miniature**: the old parse-path test passed while the parser produced unloadable garbage on real data.

## The bug (on the real clone)
- Parser mapped an **assumed** schema (`hadithNumber`/`textAr`/`matn`/`grade`) absent from the repo; real keys are `id`/`bookId`/`arabicText`/`englishText`/`majlisiGrading`/`thaqalaynSanad`/`thaqalaynMatn`.
- `id` never read → `source_id` collided → **59 unique ids for 113,401 rows** (MERGE-by-id would collapse each book to one node).
- `matn_ar` **0% Arabic** (field never mapped).
- `rglob("*.json")` swept V1 + V2 + two `allBooks.json` aggregates + repo config → ~4x duplication and config files parsed as "collections".

## The fix
- **Real schema mapping**: identity `source_id = thaqalayn:<bookId>:<id>`; `arabicText` → `matn_ar`/`full_text_ar`; gradings majlisi>behbudi>mohseni. `collection_name = bookId` so the APPEARS_IN loader (`{corpus}:{collection_name}`) links each hadith to its volume Collection.
- **English-only isnad/matn split**: `thaqalaynSanad`/`thaqalaynMatn` are English → routed to `isnad_raw_en`/`matn_en`; the whole Arabic stays in `matn_ar` (caught mid-fix: an earlier pass mis-routed English into `matn_ar`, dropping Arabic coverage to 17%).
- **Scope discipline**: acquire + parse read only `V2/ThaqalaynData/<n>.json` via one shared selector `book_json_files()` (excludes aggregates, `BookNames`, `Ingredients/`, repo config). No more drift between acquire and parse.
- **Recalibrated** the thaqalayn drift baselines (the old ones were captured from the broken run).
- **Real-upstream fixtures** across the parser, acquire, wire-in, and integration light-up tests (replacing the synthetic ones that masked the bug).

## Verification
- Real clone: **33,190 unique hadiths / 33 books** (al-Kafi=14,245); 100% non-empty `matn_ar` (99.96% Arabic); 27,863 with English isnad; sect=shia, source_corpus=thaqalayn.
- `isnad-ingest validate-staging --strict` → **PASSED** (drift OK, gating the staging load per the W5 plan).
- Full unit suite: **898 passed**, ruff + mypy clean.
- Integration light-up (parse→load_nodes→load_edges→read-back) **green against a live neo4j:5 container**: APPEARS_IN edges link, single-prefix ids, sect=shia.
- Staging load counts: see the comment below (loaded via SSH tunnel + the real loader, additive MERGE).

## Owner note (separate decision)
Thaqalayn upstream carries **al-Kafi + Man-La-Yahduruh-al-Faqih** but **NOT Tahdhib al-Ahkam or al-Istibsar** — so the "Four Books" are only partially available from this source. Tahdhib al-Ahkam + al-Istibsar are tracked separately in **da#182** (parallel, this wave).

## Reviewers
@Kwesi-Boateng @Nikolaos-Papadopoulos (per charter pairing for data-acquisition)

Closes #175