### PR TITLE
test(infra): pin testcontainers neo4j tag via shared NEO4J_TEST_IMAGE (#179)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,6 +18,11 @@ from testcontainers.postgres import PostgresContainer
 from src.utils.neo4j_client import Neo4jClient
 
 NEO4J_TEST_PASSWORD = "testpassword123"
+# Single source of truth for the testcontainers Neo4j base image tag.
+# Org-standardized on neo4j:5-community (noorinalabs-main#642) to share the image
+# cache and avoid redundant CI pulls. This is the upstream community base image,
+# NOT the app's custom isnad-graph-neo4j:5-community (which bundles APOC/plugins).
+NEO4J_TEST_IMAGE = "neo4j:5-community"
 
 
 @pytest.fixture(scope="session")
@@ -27,7 +32,7 @@ def neo4j_container():
     Requires Docker. Skips (does not error) when Docker is unavailable so the
     suite degrades gracefully off-CI / on a runner that cannot reach Docker Hub.
     """
-    container = Neo4jContainer("neo4j:5-community", password=NEO4J_TEST_PASSWORD)
+    container = Neo4jContainer(NEO4J_TEST_IMAGE, password=NEO4J_TEST_PASSWORD)
     try:
         # ``start`` is where Docker is actually contacted (daemon connect, image
         # pull, container create); guard only this so a real test-body failure


### PR DESCRIPTION
## What

Pin the testcontainers Neo4j base image tag behind a single module-level
constant `NEO4J_TEST_IMAGE = "neo4j:5-community"` in
`tests/integration/conftest.py`, and reference it from the `neo4j_container`
fixture.

## Why

Split per-repo from **noorinalabs-main#642** (neo4j test-image tag
standardization). The tag was **already** on the org-standardized
`neo4j:5-community` — the gap this closes is the *single source of truth*: the
literal was inline in the fixture, so this extracts it to one named constant,
mirroring the sibling isnad-graph fixture (ig#1096).

The app's custom `isnad-graph-neo4j:5-community` image (APOC/plugins) is
intentionally separate and untouched.

## Changes

- `tests/integration/conftest.py`: add `NEO4J_TEST_IMAGE` constant (with a
  comment explaining the org standardization + the community-vs-app distinction);
  `Neo4jContainer(...)` now takes the constant.

## Verification

- `uvx ruff@0.15.11 format --check` + `ruff check` — clean
- gated `uv run mypy src/` — Success, no issues (CI mypy scope is `src/`; the
  pre-existing untyped-fixture/docker-stub notes in `tests/` are out of that scope
  and unchanged by this PR)
- `pytest tests/integration/` collects 45 tests
- ran `tests/integration/test_source_id_collision.py` against a **live**
  `neo4j:5-community` container booted via the new constant — **3 passed**

Closes #179
