### PR TITLE
fix(sunnah_scraper): complete Riyad as-Salihin to 1,896 — enumerate named book segments (da#177)

### DIFF
--- a/scripts/first_light/run_slice.py
+++ b/scripts/first_light/run_slice.py
@@ -32,6 +32,10 @@ Examples
 
     # Live re-scrape riyadussalihin book 1, then load
     uv run python scripts/first_light/run_slice.py --live --collection riyadussalihin --book 1
+
+    # Complete a whole collection live (every book incl. the introduction) and
+    # load it — da#177 used this to take riyadussalihin to its full 1,896.
+    uv run python scripts/first_light/run_slice.py --live --all-books --collection riyadussalihin
 """
 
 from __future__ import annotations
@@ -80,6 +84,35 @@ def _acquire_live(raw_dir: Path, collection: str, book: int) -> Path:
     out.write_text(json.dumps(hadiths, ensure_ascii=False, indent=2), encoding="utf-8")
     write_manifest(dest, [out])
     print(f"[acquire:live] scraped {len(hadiths)} hadiths from {collection} book {book} -> {out}")
+    return dest
+
+
+def _acquire_live_full(raw_dir: Path, collection: str) -> Path:
+    """Live-scrape the ENTIRE collection (all books, incl. the introduction).
+
+    Unlike ``_acquire_live`` (one ``--book``), this walks every book the index
+    lists — the path used to *complete* a collection on staging (da#177:
+    riyadussalihin -> 1,896). Rate-limited by ``sunnah_scraper``; needs network.
+    """
+    import httpx
+
+    from src.acquire.base import ensure_dir
+    from src.acquire.sunnah_scraper import (
+        REQUEST_TIMEOUT,
+        USER_AGENT,
+        _scrape_collection,
+    )
+
+    dest = ensure_dir(raw_dir / "sunnah_scraped")
+    client = httpx.Client(
+        headers={"User-Agent": USER_AGENT}, timeout=REQUEST_TIMEOUT, follow_redirects=True
+    )
+    try:
+        out = _scrape_collection(client, collection, dest)
+    finally:
+        client.close()
+    count = len(json.loads(out.read_text(encoding="utf-8"))) if out is not None else 0
+    print(f"[acquire:live-full] scraped {count} hadiths from {collection} (all books) -> {dest}")
     return dest
 
 
@@ -183,6 +216,11 @@ def main() -> None:
     parser.add_argument("--collection", default="riyadussalihin", help="Collection (live mode)")
     parser.add_argument("--book", type=int, default=1, help="Book number (live mode)")
     parser.add_argument(
+        "--all-books",
+        action="store_true",
+        help="With --live: scrape the whole collection (every book incl. the introduction)",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Acquire + parse only; skip the Neo4j load (no DB connection)",
@@ -204,7 +242,9 @@ def main() -> None:
 
     print(f"=== first-light slice (da#73) — work_dir={work_dir} ===")
 
-    if args.live:
+    if args.live and args.all_books:
+        _acquire_live_full(raw_dir, args.collection)
+    elif args.live:
         _acquire_live(raw_dir, args.collection, args.book)
     else:
         _acquire_sample(raw_dir)

--- a/src/acquire/sunnah_scraper.py
+++ b/src/acquire/sunnah_scraper.py
@@ -200,13 +200,29 @@ def _extract_hadith_from_row(row: Tag) -> dict[str, Any] | None:
 def _scrape_book_page(
     client: httpx.Client,
     collection: str,
-    book_number: int,
+    book_number: int | str,
 ) -> list[dict[str, Any]]:
-    """Scrape all hadiths from a single book page."""
+    """Scrape all hadiths from a single book page.
+
+    ``book_number`` is the URL path segment: an ``int`` for numbered books or a
+    name such as ``"introduction"``.  A numeric *key* is derived for chapter
+    numbering and the per-row ``book_number`` fallback; named segments carry no
+    inherent number, so they key to ``0`` and their hadiths fall back to the
+    collection-wide reference for source_id keying (see
+    ``_extract_collection_ref_number``).
+    """
     url = f"{BASE_URL}/{collection}/{book_number}"
     soup = _fetch_page(client, url)
     if soup is None:
         return []
+
+    book_key = (
+        book_number
+        if isinstance(book_number, int)
+        else int(book_number)
+        if book_number.isdigit()
+        else 0
+    )
 
     # Chapter info
     chapter_name_en: str | None = None
@@ -238,7 +254,7 @@ def _scrape_book_page(
 
     # Track chapter numbers within a book page. Sunnah.com sometimes has
     # multiple chapters per book, marked by chapter header elements.
-    current_chapter_number = book_number
+    current_chapter_number = book_key
     chapter_counter = 0
     for row in rows:
         chapter_heading = row.find_previous_sibling(
@@ -246,14 +262,14 @@ def _scrape_book_page(
         )
         if chapter_heading:
             chapter_counter += 1
-            current_chapter_number = book_number * 100 + chapter_counter
+            current_chapter_number = book_key * 100 + chapter_counter
 
         record = _extract_hadith_from_row(row)
         if record is not None:
             # Prefer the book number parsed from the in-book reference; fall
-            # back to the page URL's book number when the row was absent.
+            # back to the page URL's book key when the row was absent.
             if record.get("book_number") is None:
-                record["book_number"] = book_number
+                record["book_number"] = book_key
             record["chapter_number"] = current_chapter_number
             record["chapter_name_ar"] = chapter_name_ar
             record["chapter_name_en"] = chapter_name_en
@@ -262,29 +278,50 @@ def _scrape_book_page(
     return hadiths
 
 
-def _get_book_numbers(client: httpx.Client, collection: str) -> list[int]:
-    """Get list of book numbers for a collection from its index page."""
+def _get_book_numbers(client: httpx.Client, collection: str) -> list[int | str]:
+    """Get the book "segments" for a collection from its index page.
+
+    Books are linked as ``/{collection}/{segment}``.  Most segments are numeric
+    (``/riyadussalihin/1``), but some are named — sunnah.com routes a
+    collection's first "Book of Miscellany"-style book at
+    ``/{collection}/introduction``.  Those named books are real hadith pages
+    (riyadussalihin's ``introduction`` alone holds 679 of its 1,896 hadiths), so
+    the earlier ``segment.isdigit()`` filter silently truncated such collections
+    by their entire first book.
+
+    Numeric segments are returned as ``int`` (sorted ascending); named segments
+    are returned as ``str`` and ordered first, since the named book (the
+    introduction) precedes the numbered ones.
+    """
     soup = _fetch_page(client, f"{BASE_URL}/{collection}")
     if soup is None:
         return []
 
-    book_numbers: list[int] = []
-    # Books are linked as /{collection}/{number}
+    numeric: list[int] = []
+    named: list[str] = []
     links = soup.select("a[href]")
     prefix = f"/{collection}/"
-    seen: set[int] = set()
+    seen: set[str] = set()
     for link in links:
         href = link.get("href", "")
-        if isinstance(href, str) and href.startswith(prefix):
-            segment = href[len(prefix) :].rstrip("/")
-            if segment.isdigit():
-                num = int(segment)
-                if num not in seen:
-                    seen.add(num)
-                    book_numbers.append(num)
+        if not isinstance(href, str) or not href.startswith(prefix):
+            continue
+        # Drop any #anchor / ?query, then trailing slashes, so a variant like
+        # "introduction#C0.00" folds onto the bare "introduction" book page.
+        segment = href[len(prefix) :].split("#", 1)[0].split("?", 1)[0].rstrip("/")
+        # Only single path components are book pages (skip "" and ".../x/y").
+        if not segment or "/" in segment or segment in seen:
+            continue
+        seen.add(segment)
+        if segment.isdigit():
+            numeric.append(int(segment))
+        else:
+            named.append(segment)
 
-    book_numbers.sort()
-    return book_numbers
+    numeric.sort()
+    named.sort()
+    # Named books (the introduction / first book) come before the numbered ones.
+    return [*named, *numeric]
 
 
 def _scrape_collection(

--- a/tests/test_acquire/fixtures/riyadussalihin_index_sample.html
+++ b/tests/test_acquire/fixtures/riyadussalihin_index_sample.html
@@ -1,0 +1,54 @@
+<!--
+Real sunnah.com /riyadussalihin index markup (book-list anchors), captured
+2026-06-16 for da#177. Trimmed to the book navigation. The KEY shape under
+test is the named book link href="/riyadussalihin/introduction" ("The Book
+of Miscellany") alongside the numbered /riyadussalihin/1..19 — the
+introduction holds 679 of the collection's 1,896 hadiths and was silently
+dropped by the old digits-only book enumerator.
+-->
+<html><body>
+<div class="book_titles">
+<a href="/riyadussalihin/introduction">
+<div class="book_number title_number"></div><div class="english english_book_name">The Book of Miscellany</div><div class="arabic arabic_book_name">كتاب المقدمات</div></a>
+<a href="/riyadussalihin/1">
+<div class="book_number title_number">1</div><div class="english english_book_name">The Book of Good Manners</div><div class="arabic arabic_book_name">كتاب الأدب</div></a>
+<a href="/riyadussalihin/2">
+<div class="book_number title_number">2</div><div class="english english_book_name">The Book About the Etiquette of Eating</div><div class="arabic arabic_book_name">كتـــــاب أدب الطعام</div></a>
+<a href="/riyadussalihin/3">
+<div class="book_number title_number">3</div><div class="english english_book_name">The Book of Dress</div><div class="arabic arabic_book_name">كتــــاب اللباس</div></a>
+<a href="/riyadussalihin/4">
+<div class="book_number title_number">4</div><div class="english english_book_name">The Book of the Etiquette of Sleeping, Lying and Sitting etc</div><div class="arabic arabic_book_name">كتاب آداب النوم</div></a>
+<a href="/riyadussalihin/5">
+<div class="book_number title_number">5</div><div class="english english_book_name">The Book of Greetings</div><div class="arabic arabic_book_name">كتاب السلام</div></a>
+<a href="/riyadussalihin/6">
+<div class="book_number title_number">6</div><div class="english english_book_name">The Book of Visiting the Sick</div><div class="arabic arabic_book_name">كتاب عيادة المريض وتشييع الميت والصلاة عليه وحضور دفنه</div></a>
+<a href="/riyadussalihin/7">
+<div class="book_number title_number">7</div><div class="english english_book_name">The Book of Etiquette of Traveling</div><div class="arabic arabic_book_name">كتاب آداب السفر</div></a>
+<a href="/riyadussalihin/8">
+<div class="book_number title_number">8</div><div class="english english_book_name">The Book of Virtues</div><div class="arabic arabic_book_name">كتاب الفضائل</div></a>
+<a href="/riyadussalihin/9">
+<div class="book_number title_number">9</div><div class="english english_book_name">The Book of I'tikaf</div><div class="arabic arabic_book_name">كتاب الاعتكاف</div></a>
+<a href="/riyadussalihin/10">
+<div class="book_number title_number">10</div><div class="english english_book_name">The Book of Hajj</div><div class="arabic arabic_book_name">كتاب الحج</div></a>
+<a href="/riyadussalihin/11">
+<div class="book_number title_number">11</div><div class="english english_book_name">The Book of Jihad</div><div class="arabic arabic_book_name">كتاب الجهاد</div></a>
+<a href="/riyadussalihin/12">
+<div class="book_number title_number">12</div><div class="english english_book_name">The Book of Knowledge</div><div class="arabic arabic_book_name">كتاب العلم</div></a>
+<a href="/riyadussalihin/13">
+<div class="book_number title_number">13</div><div class="english english_book_name">The Book of Praise and Gratitude to Allah</div><div class="arabic arabic_book_name">كتاب حمد الله تعالى وشكره</div></a>
+<a href="/riyadussalihin/14">
+<div class="book_number title_number">14</div><div class="english english_book_name">The Book of Supplicating Allah to Exalt the Mention of Allah's Messenger</div><div class="arabic arabic_book_name">كتاب الصلاة على رسول الله صلى الله عليه وسلم</div></a>
+<a href="/riyadussalihin/15">
+<div class="book_number title_number">15</div><div class="english english_book_name">The Book of the Remembrance of Allah</div><div class="arabic arabic_book_name">كتاب الأذكار</div></a>
+<a href="/riyadussalihin/16">
+<div class="book_number title_number">16</div><div class="english english_book_name">The Book of Du'a (Supplications)</div><div class="arabic arabic_book_name">كتاب الدعوات</div></a>
+<a href="/riyadussalihin/17">
+<div class="book_number title_number">17</div><div class="english english_book_name">The Book of the Prohibited actions</div><div class="arabic arabic_book_name">كتاب الأمور المنهي عنها</div></a>
+<a href="/riyadussalihin/18">
+<div class="book_number title_number">18</div><div class="english english_book_name">The Book of Miscellaneous ahadith of Significant Values</div><div class="arabic arabic_book_name">كتاب المنثورات والملح</div></a>
+<a href="/riyadussalihin/19">
+<div class="book_number title_number">19</div><div class="english english_book_name">The Book of Forgiveness</div><div class="arabic arabic_book_name">كتاب الاستغفار </div></a>
+</div>
+<a href="/riyadussalihin">Riyad as-Salihin (home)</a>
+<a href="/contactus">Contact</a>
+</body></html>

--- a/tests/test_acquire/test_sunnah_scraper.py
+++ b/tests/test_acquire/test_sunnah_scraper.py
@@ -3,20 +3,31 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 
 from src.acquire.sunnah_scraper import (
+    REQUEST_TIMEOUT,
     SCRAPE_COLLECTIONS,
+    USER_AGENT,
     _extract_collection_ref_number,
     _extract_hadith_from_row,
     _extract_in_book_ref,
     _get_book_numbers,
     _scrape_book_page,
+    _scrape_collection,
     run,
 )
+
+# Opt-in live leg: hits the real sunnah.com (keyless). Off by default so CI stays
+# offline-deterministic; set RUN_LIVE_SUNNAH_SCRAPE=1 to exercise the real parse
+# path end-to-end (the no-fixture-masking guard, main#671).
+_RUN_LIVE = os.getenv("RUN_LIVE_SUNNAH_SCRAPE") == "1"
+_LIVE_SKIP_REASON = "set RUN_LIVE_SUNNAH_SCRAPE=1 to run the live sunnah.com scrape leg"
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -112,6 +123,41 @@ class TestGetBookNumbers:
         books = _get_book_numbers(client, "nonexistent")
         assert books == []
 
+    def test_real_index_markup_includes_introduction(self) -> None:
+        """Real-upstream guard (da#177): the saved sunnah.com riyadussalihin
+        index lists a NAMED ``introduction`` book ("The Book of Miscellany")
+        alongside /1../19. The old digits-only enumerator dropped it, silently
+        truncating the collection by its first 679 hadiths."""
+        index_html = (FIXTURES_DIR / "riyadussalihin_index_sample.html").read_text(encoding="utf-8")
+        client = MagicMock(spec=httpx.Client)
+        client.get.return_value = _mock_response(index_html)
+
+        books = _get_book_numbers(client, "riyadussalihin")
+
+        # Named books first, then numbered books ascending.
+        assert books == ["introduction", *range(1, 20)]
+        # Non-book links (the /riyadussalihin home, /contactus) are excluded.
+        assert "" not in books
+
+    def test_folds_anchor_variant_and_skips_subpaths(self) -> None:
+        """A named book can appear with an #anchor (sunnah.com hisn:
+        ``introduction#C0.00``); fold it onto the bare segment and dedupe.
+        Multi-component hrefs (.../x/y) are not book pages and are skipped."""
+        html = """
+        <html><body>
+          <a href="/hisn/introduction">Introduction</a>
+          <a href="/hisn/introduction#C0.00">Introduction (anchor)</a>
+          <a href="/hisn/1">Book 1</a>
+          <a href="/hisn/1/5">A hadith permalink</a>
+          <a href="/hisn/">collection home</a>
+        </body></html>
+        """
+        client = MagicMock(spec=httpx.Client)
+        client.get.return_value = _mock_response(html)
+
+        books = _get_book_numbers(client, "hisn")
+        assert books == ["introduction", 1]
+
 
 class TestScrapeBookPage:
     def test_extracts_hadiths(self) -> None:
@@ -125,6 +171,35 @@ class TestScrapeBookPage:
         assert hadiths[0]["book_number"] == 1
         assert hadiths[0]["chapter_name_en"] == "The Book of Purification"
         assert hadiths[0]["chapter_name_ar"] == "كتاب الطهارة"
+
+    def test_named_introduction_segment(self) -> None:
+        """A named book segment ("introduction") builds the right URL and keys to
+        book 0; its hadith_number falls back to the collection-wide reference
+        because the in-book row reads "Introduction, Hadith N" (not "Book N")."""
+        intro_html = """
+        <html><body>
+        <div class="actualHadithContainer">
+          <div class="hadith_reference_sticky">Riyad as-Salihin 1</div>
+          <div class="arabic_hadith_full">إنما الأعمال بالنيات</div>
+          <div class="english_hadith_full">Actions are judged by intentions</div>
+          <table class="hadith_reference">
+            <tr><td>In-book reference</td><td>: Introduction, Hadith 1</td></tr>
+          </table>
+        </div>
+        </body></html>
+        """
+        client = MagicMock(spec=httpx.Client)
+        client.get.return_value = _mock_response(intro_html)
+
+        hadiths = _scrape_book_page(client, "riyadussalihin", "introduction")
+
+        client.get.assert_called_once_with("https://sunnah.com/riyadussalihin/introduction")
+        assert len(hadiths) == 1
+        # "Introduction, Hadith 1" doesn't match the "Book N" in-book pattern, so
+        # hadith_number falls back to the collection-wide ref (1), and book_number
+        # falls back to the named-segment key (0).
+        assert hadiths[0]["hadith_number"] == 1
+        assert hadiths[0]["book_number"] == 0
 
 
 class TestRun:
@@ -359,3 +434,36 @@ class TestRiyadussalihinFixture:
             for r in records
         }
         assert len(source_ids) == len(records)
+
+
+@pytest.mark.skipif(not _RUN_LIVE, reason=_LIVE_SKIP_REASON)
+class TestRiyadussalihinLiveUpstream:
+    """Live, opt-in scrape of the REAL sunnah.com riyadussalihin (no key needed).
+
+    This is the no-fixture-masking guard (main#671): a saved fixture proves the
+    parser handles known markup, but only a live fetch proves the *enumerator*
+    still discovers every book — the exact axis where the introduction book was
+    being dropped. Gated on RUN_LIVE_SUNNAH_SCRAPE=1 so CI stays offline.
+    """
+
+    def _client(self) -> httpx.Client:
+        return httpx.Client(
+            headers={"User-Agent": USER_AGENT}, timeout=REQUEST_TIMEOUT, follow_redirects=True
+        )
+
+    def test_introduction_is_enumerated(self) -> None:
+        with self._client() as client:
+            books = _get_book_numbers(client, "riyadussalihin")
+        assert "introduction" in books, "the introduction book must be discovered"
+        assert sum(1 for b in books if isinstance(b, int)) >= 19
+
+    def test_full_collection_reaches_expected_total(self, tmp_path: Path) -> None:
+        with self._client() as client:
+            out = _scrape_collection(client, "riyadussalihin", tmp_path)
+        assert out is not None
+        hadiths = json.loads(out.read_text(encoding="utf-8"))
+        # Riyad as-Salihin is 1,896 hadiths (679 in the introduction + 1,217 in
+        # books 1-19). Allow a small tolerance for upstream markup churn.
+        assert len(hadiths) >= 1890, f"expected ~1896, got {len(hadiths)}"
+        assert all(h.get("text_ar") and h.get("text_en") for h in hadiths)
+        assert all(h.get("hadith_number") is not None for h in hadiths)


### PR DESCRIPTION
## da#177 — Riyad as-Salihin: COMPLETE to 1,896 (decision: complete, not drop)

**Decision: complete.** sunnah.com is reachable and the full corpus parses cleanly, so per the wave's full-corpus goal I completed the collection rather than dropping the fragment.

### Root cause of the 47-fragment
The fragment was never a data-availability problem — it was a scraper enumeration bug. `_get_book_numbers` kept only **digit-only** URL segments, so sunnah.com's *named* first book `/riyadussalihin/introduction` ("The Book of Miscellany") was silently dropped. That book holds **679 of the 1,896** hadiths (the famous "actions are by intentions" is in it). The enumerator topped out at 1,217 (books 1–19); the legacy da#73 first-light then loaded only book 1 (47), which is the fragment that reached staging.

`679 (introduction) + 1,217 (books 1–19) = 1,896` ✓

### Code
- `_get_book_numbers` → `list[int | str]`: numeric books (sorted ints) **plus** named segments (introduction) as strings, ordered first. Folds `#anchor`/`?query` variants (e.g. hisn `introduction#C0.00`) and skips multi-component / home / empty hrefs.
- `_scrape_book_page` accepts a named URL segment and derives an int `book_key` (named → 0) for chapter numbering + the per-row `book_number` fallback. Introduction hadiths have no "Book N" in-book ref, so `hadith_number` falls back to the collection-wide reference (1–679), keeping every `source_id` unique.
- `run_slice.py --all-books`: reproducible full-collection live scrape (the path used here); added to the runbook examples.
- The fix is general (hisn / mishkat also have an `introduction`; shamail an `8b`) — a correctness win for the prod-cutover full corpus — but **only riyadussalihin was loaded** for this issue.

### Tests (no fixture-masking, main#671)
- `test_real_index_markup_includes_introduction` — a **real captured sunnah.com index** fixture asserts `introduction` is enumerated, named-first, alongside /1..19 (the exact axis the bug lived on).
- anchor-fold / subpath-skip unit coverage; named-segment scrape keying.
- opt-in live leg `TestRiyadussalihinLiveUpstream` (`RUN_LIVE_SUNNAH_SCRAPE=1`) asserts the real scrape reaches ≥1,890 with Arabic+English text and non-null numbers.
- Full local suite: **945 passed, 7 skipped** (Docker integration incl. the scraper multicollection test ran green). ruff + `mypy src/` clean.

### Data quality
Full scrape: **1,896 hadiths, 1,896 distinct source_ids, 0 collisions.** Strict staging validation passes every data-quality check (Arabic coverage 100%). `grade` is null because sunnah.com publishes no inline grade for this collection (nullable field, verified 0 grade markup on the pages). The only strict miss is a `row_count` drift vs the multi-collection `sunnah_scraped` baseline (10,028) — expected when validating one collection, not a defect.

### Staging load (via the da#174 reusable loader image, not a divergent loader)
1. Deleted the stale 47-fragment (its node ids ended `:0` — loaded pre-in-book-ordinal — so they would NOT have MERGE-coalesced and would have left duplicates).
2. Shipped the riyad parquet and ran `noorinalabs-graph-load:da174 load --skip-validation` on `noorinalabs_backend`.

Read-back on staging:
- `riyadussalihin` Hadith nodes = **1,896**
- `APPEARS_IN` edges = **1,896** (0 missing endpoints)
- `source_corpus='sunnah'` total = **1,896**, distinct ids = 1,896, **stale `:0` suffix = 0**
- admin sources unaffected (9 source_corpus values)

End state: **complete on staging, no fragment, no duplicates.**

Reviewers: @Kavitha-Sundaramurthy @Oyunbileg-Batbayar

Closes #177
