### PR TITLE
security(deps): pin bleach>=6.4.0 to clear kaggle transitive advisories (#188)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ dependencies = [
     "structlog>=24.1",
     "python-dotenv>=1.0",
     "kaggle>=1.6",
+    # Direct floor on the bleach transitive (pulled in via kaggle) to clear
+    # GHSA-gj48-438w-jh9v + GHSA-8rfp-98v4-mmr6 (noorinalabs-main#703). The 3rd
+    # advisory GHSA-g75f-g53v-794x (ReDoS) has no fixed release; da runs no
+    # pip-audit gate so no --ignore-vuln is required here.
+    "bleach>=6.4.0",
     "beautifulsoup4>=4.12",
     "lxml>=5.1",
     "tqdm>=4.66",

--- a/uv.lock
+++ b/uv.lock
@@ -52,14 +52,14 @@ wheels = [
 
 [[package]]
 name = "bleach"
-version = "6.3.0"
+version = "6.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
 ]
 
 [[package]]
@@ -594,6 +594,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "bleach" },
     { name = "httpx" },
     { name = "kafka-python" },
     { name = "kaggle" },
@@ -638,6 +639,7 @@ ml = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
+    { name = "bleach", specifier = ">=6.4.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "kafka-python", specifier = ">=2.3.1" },
     { name = "kaggle", specifier = ">=1.6" },


### PR DESCRIPTION
## What

Add an explicit direct floor `bleach>=6.4.0` to `pyproject.toml` and re-lock.

## Why

Split per-repo from the org-wide bleach advisory-drift sweep (tracker
**noorinalabs-main#703**). da was resolving **bleach 6.3.0** transitively via
`kaggle`. Pinning the direct floor means the vulnerable version can no longer be
pulled in, clearing:
- GHSA-gj48-438w-jh9v
- GHSA-8rfp-98v4-mmr6

The 3rd advisory **GHSA-g75f-g53v-794x** (ReDoS) has no fixed release. da runs
**no pip-audit / security gate** (verified: no audit step in any
`.github/workflows/*.yml`), so this is hygiene, not gate-blocking, and **no
`--ignore-vuln` is required** — the bump alone is sufficient. If da later adds a
`pip-audit --strict` gate, mirror ingest-platform's documented `--ignore-vuln`
for the ReDoS advisory at that time.

## Changes

- `pyproject.toml`: add `bleach>=6.4.0` (with a comment explaining the
  transitive-via-kaggle pin + the no-gate / ReDoS rationale).
- `uv.lock`: bleach **6.3.0 → 6.4.0**, no other package changed.

## Verification

- lock diff is bleach-only (no collateral resolution churn)
- `ruff format --check` + `ruff check` — clean
- `uv run mypy src/` — Success, no issues
- `uv run pytest -m "not integration"` — **897 passed, 5 skipped**

Closes #188
