### PR TITLE
da#190: fall back matn_ar to full_text_ar (fix textless Hadith nodes)

### DIFF
--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -267,10 +267,18 @@ def _load_hadiths(
                 total_skipped += 1
                 continue
             hid = hadith_node_id(sid)
+            # Fall back to the raw full text when a source supplies no separated
+            # matn: halimbahae / open_hadith / bihar populate ``full_text_ar``
+            # only (they do not split isnad from matn). The loader persists
+            # matn_ar — not full_text_ar — so without this the Hadith node lands
+            # textless on the graph (da#190).
+            matn_ar = _val(row, "matn_ar", "")
+            if not (matn_ar and str(matn_ar).strip()):
+                matn_ar = _val(row, "full_text_ar", "")
             batch.append(
                 {
                     "id": hid,
-                    "matn_ar": _val(row, "matn_ar", ""),
+                    "matn_ar": matn_ar,
                     "matn_en": _val(row, "matn_en"),
                     "isnad_raw_ar": _val(row, "isnad_raw_ar"),
                     "isnad_raw_en": _val(row, "isnad_raw_en"),

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -318,6 +319,46 @@ class TestLoadHadiths:
         hadith_result = results[1]
         assert hadith_result.node_type == "Hadith"
         assert hadith_result.created + hadith_result.merged == 2
+
+    def _hadith_batch_rows(self, mock_client: MockNeo4jClient) -> list[dict[str, Any]]:
+        for _query, batch in mock_client.calls:
+            if (
+                isinstance(batch, list)
+                and batch
+                and isinstance(batch[0], dict)
+                and str(batch[0].get("id", "")).startswith("hdt:")
+            ):
+                return batch
+        return []
+
+    def test_matn_ar_falls_back_to_full_text_ar(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """Sources that only populate full_text_ar (halimbahae/open_hadith/bihar)
+        must not land textless: matn_ar falls back to full_text_ar (da#190)."""
+        write_hadiths(
+            staging_dir,
+            [
+                {"source_id": "h-empty", "matn_ar": "", "full_text_ar": "النص الكامل"},
+                {"source_id": "h-none", "matn_ar": None, "full_text_ar": "نص آخر"},
+            ],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        rows = {r["id"]: r["matn_ar"] for r in self._hadith_batch_rows(mock_client)}
+        assert rows["hdt:h-empty"] == "النص الكامل"
+        assert rows["hdt:h-none"] == "نص آخر"
+
+    def test_matn_ar_preserved_when_present(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """A real matn_ar is never overwritten by full_text_ar."""
+        write_hadiths(
+            staging_dir,
+            [{"source_id": "h-1", "matn_ar": "المتن", "full_text_ar": "الإسناد والمتن"}],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        rows = {r["id"]: r["matn_ar"] for r in self._hadith_batch_rows(mock_client)}
+        assert rows["hdt:h-1"] == "المتن"
 
     def test_adds_hdt_prefix(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path


### PR DESCRIPTION
## Summary
Fixes textless Hadith nodes for corpora that populate `full_text_ar` only (halimbahae, open_hadith, bihar) — they don't separate isnad from matn, and the graph loader persists `matn_ar` (not `full_text_ar`), so those nodes landed with empty text.

Found by the pre-cutover corpus-integrity audit: all **124,338** open_hadith+halimbahae Hadith nodes on staging had empty `matn_ar`. open_hadith has since been dropped as a confirmed exact duplicate of halimbahae (audit remediation A); halimbahae (62,169) remains and this unblocks its text.

## Change
`src/graph/load_nodes.py` — in the Hadith row-prep, fall back `matn_ar := full_text_ar` when `matn_ar` is empty/whitespace. A present `matn_ar` is never overwritten. Future-proofs bihar (da#95), same pattern.

## Tests
- `test_matn_ar_falls_back_to_full_text_ar` — empty/None matn_ar populated from full_text_ar.
- `test_matn_ar_preserved_when_present` — real matn_ar untouched.
Full suite: 899 passed / 5 skipped. ruff + mypy clean.

## After merge
Re-load halimbahae with the fixed loader so its `matn_ar` is populated on staging (done out-of-band on staging for validation; will be re-run from the merged image for the cutover).

Closes #190
Reviewers requested: Kavitha Sundaramurthy, Kwesi Boateng

🤖 Generated with [Claude Code](https://claude.com/claude-code)
