### PR TITLE
da#191: encode canonical corpus composition in the pipeline (per-source dedup)

### DIFF
--- a/src/acquire/__init__.py
+++ b/src/acquire/__init__.py
@@ -24,6 +24,12 @@ def run_all(raw_dir: Path) -> dict[str, Path | None]:
     results: dict[str, Path | None] = {}
     for adapter in SOURCE_REGISTRY:
         name = adapter.slug
+        if not adapter.active:
+            # Inactive sources (e.g. open_hadith — a confirmed duplicate, da#191)
+            # are never acquired. The registry row is retained for the coverage
+            # invariant only.
+            logger.info("acquire_skipped_inactive", source=name)
+            continue
         try:
             logger.info("acquiring", source=name)
             path = adapter.acquire(raw_dir)

--- a/src/adapters.py
+++ b/src/adapters.py
@@ -93,6 +93,11 @@ class SourceAdapter:
     acquire_fn: str = "run"
     parse_fn: str = "run"
     raw_subdir: str | None = None
+    # Whether this source participates in acquire/parse run_all. An adapter row is
+    # retained for every SourceCorpus (the coverage invariant), but a source that
+    # is a confirmed duplicate of another is marked inactive so it is never
+    # acquired/parsed/loaded — see ``src.parse.composition`` (da#191).
+    active: bool = True
 
     def acquire(self, raw_dir: Path) -> Path | None:
         """Download this source's raw data, returning its output path (or ``None``)."""
@@ -190,6 +195,12 @@ SOURCE_REGISTRY: tuple[SourceAdapter, ...] = (
         reachable=True,
         license_note="Open-Hadith-Data (mhashim6) — open GitHub, 9 books incl. the Six Books.",
         description="Open-Hadith-Data — 9 Sunni books.",
+        # Confirmed 100% duplicate of `halimbahae` (identical 9 collections, same
+        # per-collection counts, identical normalized matn) — pre-cutover audit
+        # da#191. Dropped entirely: halimbahae carries the same books with full
+        # tashkeel + a clear ODbL license. Adapter retained for the coverage
+        # invariant; inactive so it is never acquired/parsed/loaded.
+        active=False,
     ),
     SourceAdapter(
         slug="muhaddithat",

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -34,6 +34,7 @@ from typing import Any
 import pyarrow.parquet as pq
 import yaml
 
+from src.parse.composition import is_canonical_hadith
 from src.parse.identity import (
     chain_node_id,
     collection_node_id,
@@ -266,6 +267,16 @@ def _load_hadiths(
                 all_errors.append(f"{fp.name} row {i}: invalid source_id={sid!r}")
                 total_skipped += 1
                 continue
+            # Canonical corpus composition (da#191): skip Hadith whose
+            # (source_corpus, collection) duplicates the chosen canonical edition
+            # — halimbahae/fawaz non-unique books, the mis Sahih Muslim matn copy.
+            # One enforcement point so a fresh run_all (the production path) yields
+            # the deduped graph without manual surgery.
+            if not is_canonical_hadith(
+                _val(row, "source_corpus", ""), _val(row, "collection_name", "")
+            ):
+                total_skipped += 1
+                continue
             hid = hadith_node_id(sid)
             # Fall back to the raw full text when a source supplies no separated
             # matn: halimbahae / open_hadith / bihar populate ``full_text_ar``
@@ -356,6 +367,12 @@ def _load_collections(
             cid = row.get("collection_id")
             if not cid or not isinstance(cid, str):
                 all_errors.append(f"{fp.name} row {i}: invalid collection_id={cid!r}")
+                total_skipped += 1
+                continue
+            # Canonical composition (da#191): drop Collection nodes for non-canonical
+            # (source_corpus, collection) pairs so they don't outlive their Hadith.
+            # The collection slug is the last ``:``-segment of collection_id.
+            if not is_canonical_hadith(_val(row, "source_corpus", ""), cid.rsplit(":", 1)[-1]):
                 total_skipped += 1
                 continue
             full_id = collection_node_id(cid)

--- a/src/parse/__init__.py
+++ b/src/parse/__init__.py
@@ -31,6 +31,11 @@ def run_all(raw_dir: Path, staging_dir: Path) -> dict[str, list[Path]]:
     results: dict[str, list[Path]] = {}
     for adapter in SOURCE_REGISTRY:
         name = adapter.slug
+        if not adapter.active:
+            # Inactive sources (e.g. open_hadith — a confirmed duplicate, da#191)
+            # are never parsed. The registry row is retained for coverage only.
+            logger.info("parse_skipped_inactive", source=name)
+            continue
         try:
             logger.info("parsing", source=name)
             output_files = _normalize_output(adapter.parse(raw_dir, staging_dir))

--- a/src/parse/composition.py
+++ b/src/parse/composition.py
@@ -1,0 +1,59 @@
+"""Canonical corpus composition — the owner-confirmed dedup, encoded (da#191).
+
+Several acquired corpora overlap. The pre-cutover corpus-integrity audit found:
+
+* ``open_hadith`` is a 100% duplicate of ``halimbahae`` (handled in the registry:
+  ``open_hadith`` is marked ``active=False`` so it is never acquired/parsed);
+* the six canonical Sunni books (Bukhari, Muslim, Abu Dawud, Tirmidhi, Nasa'i,
+  Ibn Majah) are loaded by ``lk`` AND ``halimbahae`` AND ``fawaz``, and Sahih
+  Muslim again by ``mis``.
+
+Loading every copy would double-count hadith on production. The owner-confirmed
+composition (relayed via the Program Director) keeps each book once:
+
+* ``lk`` — the six-books canonical spine (richest metadata: separated
+  ``matn_ar`` + ``matn_en`` + ``grade``). Loads all its collections.
+* ``halimbahae`` — its UNIQUE books only (Musnad Ahmad, Darimi, Malik).
+* ``fawaz`` — its UNIQUE collections only (Nawawi, Dehlawi, Qudsi).
+* ``mis`` — its multi-isnad CHAINS only. Its Sahih Muslim matn duplicates ``lk``,
+  so NO ``mis`` Hadith nodes are loaded (``network_edges_mis`` still loads as
+  narrator-transmission edges).
+* every other source — all collections (value ``None``).
+
+This is the **per-source** half of the dedup and is the deterministic part that
+MUST hold before the production load. Cross-edition canonical-identity dedup
+(same hadith by collection+number across editions) is a tracked fast-follow.
+
+This module is the single source of truth, consumed by the graph node loader
+(``src.graph.load_nodes``) so a fresh ``run_all`` (the path production uses)
+produces the deduped graph without manual surgery.
+"""
+
+from __future__ import annotations
+
+# source_corpus -> allowed collection slugs.
+#   None           = load all collections for this source (the default for any
+#                    source not listed here).
+#   frozenset(...) = load only these collections.
+#   frozenset()    = load NO Hadith nodes for this source (e.g. ``mis``: its
+#                    chains/edges still load via the edge loader).
+HADITH_COMPOSITION: dict[str, frozenset[str] | None] = {
+    "halimbahae": frozenset({"musnad_ahmad_ibn-hanbal", "sunan_al-darimi", "maliks_muwataa"}),
+    "fawaz": frozenset({"nawawi", "dehlawi", "qudsi"}),
+    "mis": frozenset(),
+    # open_hadith is dropped at the registry (active=False); listed here as a
+    # defence-in-depth no-op in case its parquet is ever present in a staging dir.
+    "open_hadith": frozenset(),
+}
+
+
+def is_canonical_hadith(source_corpus: str, collection_name: str) -> bool:
+    """Return True if a ``(source_corpus, collection_name)`` Hadith belongs in the
+    canonical (production) graph, per :data:`HADITH_COMPOSITION`.
+
+    A source not present in the composition map loads all of its collections.
+    """
+    allowed = HADITH_COMPOSITION.get(source_corpus)
+    if allowed is None:
+        return source_corpus not in HADITH_COMPOSITION
+    return collection_name in allowed

--- a/tests/integration/test_mis_lightup.py
+++ b/tests/integration/test_mis_lightup.py
@@ -1,12 +1,14 @@
-"""Live-Neo4j proof that MIS loads as real Hadith nodes + multi-isnad edges (da#97).
+"""Live-Neo4j proof that MIS contributes multi-isnad edges only — no Hadith nodes
+(da#97; composition per da#191).
 
 Exercises the slice end-to-end against a live ``neo4j:5`` container:
 
-    parse (mis.run) -> load Hadith nodes (load_all_nodes) -> load network edges
+    parse (mis.run) -> load_all_nodes (composition drops mis Hadith) -> load edges
 
-and asserts (a) the Hadith nodes land with canonical ``hdt:`` ids and the
-``mis`` / ``sunni`` provenance, and (b) the **multiplicity** survives all the way
-to graph relationships — a hadith with three isnads yields the chain-specific
+and asserts (a) MIS loads ZERO Hadith nodes — its Sahih Muslim matn duplicates
+the ``lk`` canonical edition, so the canonical composition (da#191) keeps MIS for
+its multi-isnad CHAINS only — and (b) the **multiplicity** still survives all the
+way to graph relationships — a hadith with three isnads yields the chain-specific
 edges (``A->D``, ``E->B``) that would be gone had the parallel asanid been
 collapsed.
 
@@ -81,7 +83,7 @@ def _make_mis_fixture(raw_dir: Path) -> None:
 
 @pytest.mark.integration
 class TestMisLoadLive:
-    def test_mis_loads_hadith_nodes_and_multi_isnad_edges(
+    def test_mis_loads_no_hadith_nodes_but_multi_isnad_edges_survive(
         self, neo4j_client, tmp_path: Path
     ) -> None:
         raw = tmp_path / "raw"
@@ -91,20 +93,16 @@ class TestMisLoadLive:
         curated.mkdir()
         _make_mis_fixture(raw)
 
-        hadiths_path, edges_path = mis.run(raw, staging)
+        _hadiths_path, edges_path = mis.run(raw, staging)
 
-        # --- Hadith nodes via the production node loader ---------------------
-        results = load_all_nodes(neo4j_client, staging, curated, strict=False)
-        hadith_result = next(r for r in results if r.node_type == "Hadith")
-        assert not hadith_result.validation_errors
-
-        hadith_nodes = neo4j_client.execute_read(
-            "MATCH (h:Hadith) RETURN h.id AS id, h.source_corpus AS corpus, h.sect AS sect"
-        )
-        assert len(hadith_nodes) == 2
-        assert all(n["id"].startswith("hdt:mis:sahih_muslim:") for n in hadith_nodes)
-        assert all(n["corpus"] == "mis" for n in hadith_nodes)
-        assert all(n["sect"] == "sunni" for n in hadith_nodes)
+        # --- MIS contributes NO Hadith nodes (composition, da#191) ----------
+        # Its Sahih Muslim matn duplicates the lk canonical edition, so the node
+        # loader drops every mis Hadith; MIS is kept for its multi-isnad chains.
+        load_all_nodes(neo4j_client, staging, curated, strict=False)
+        mis_hadith_nodes = neo4j_client.execute_read(
+            "MATCH (h:Hadith {source_corpus: 'mis'}) RETURN count(h) AS n"
+        )[0]["n"]
+        assert mis_hadith_nodes == 0
 
         # --- Multi-isnad edges into the live graph --------------------------
         edge_rows = pq.read_table(edges_path).to_pylist()

--- a/tests/integration/test_open_hadith_lightup.py
+++ b/tests/integration/test_open_hadith_lightup.py
@@ -1,11 +1,16 @@
-"""Live-Neo4j light-up for the Open-Hadith adapter (da#87).
+"""Live-Neo4j proof that the Open-Hadith corpus is EXCLUDED by the canonical
+composition (da#191).
 
-Parses small REAL Open-Hadith-Data samples (Musnad Ahmad + Sunan al-Nasai,
-mhashim6/Open-Hadith-Data) through the real batch loaders into a live ``neo4j:5``
-container and asserts the corpus lands as a usable graph: Hadith **and**
-Collection nodes (one Collection per book, the gap this light-up closes), all
-``sect=sunni`` / ``source_corpus=open_hadith`` tagged, with ``APPEARS_IN`` edges
-resolving each hadith to its own book — no dangling edges.
+Open-Hadith was a confirmed 100% duplicate of ``halimbahae`` (pre-cutover audit).
+It is dropped from the production graph: marked ``active=False`` in the registry
+so ``run_all`` never acquires/parses it, and — defence in depth — the node loader
+filters it out via :data:`src.parse.composition.HADITH_COMPOSITION`. This test
+parses the committed Open-Hadith samples directly and asserts that loading their
+parquet yields ZERO graph nodes, so a stray ``hadiths_open_hadith.parquet`` in a
+staging dir can never re-introduce the duplicate.
+
+Originally (da#87) this light-up asserted Open-Hadith loaded as a usable graph;
+that behaviour was intentionally reversed by the da#191 dedup.
 
 Skips cleanly when Docker is unreachable (see ``tests/integration/conftest.py``).
 """
@@ -17,18 +22,10 @@ from pathlib import Path
 
 import pytest
 
-from src.graph.load_edges import load_all_edges
 from src.graph.load_nodes import load_all_nodes
 from src.parse import open_hadith
 
 _FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "open_hadith"
-
-# Real committed slices: 3 hadiths from each of two books.
-EXPECTED_PER_COLLECTION = {
-    "col:open_hadith:musnad_ahmad_ibn-hanbal": 3,
-    "col:open_hadith:sunan_al-nasai": 3,
-}
-EXPECTED_HADITHS = sum(EXPECTED_PER_COLLECTION.values())
 
 
 @pytest.fixture
@@ -45,47 +42,21 @@ def staged_open_hadith(tmp_path: Path) -> Path:
 
 
 @pytest.mark.integration
-class TestOpenHadithLightUpLive:
-    def test_hadith_and_collection_nodes_load_tagged(
+class TestOpenHadithExcludedByComposition:
+    def test_open_hadith_loads_no_nodes(
         self, neo4j_client, staged_open_hadith: Path, tmp_path: Path
     ) -> None:
-        """Both books' Hadith + Collection nodes land, sunni / open_hadith tagged."""
+        """Loading Open-Hadith parquet yields no Hadith or Collection nodes —
+        the corpus is dropped as a duplicate of halimbahae (da#191)."""
         curated = tmp_path / "curated"
         curated.mkdir()
         load_all_nodes(neo4j_client, staged_open_hadith, curated, strict=False)
 
-        collections = neo4j_client.execute_read(
-            "MATCH (c:Collection) "
-            "RETURN c.id AS id, c.sect AS sect, c.source_corpus AS corpus ORDER BY c.id"
-        )
-        assert [c["id"] for c in collections] == sorted(EXPECTED_PER_COLLECTION)
-        assert all(c["sect"] == "sunni" and c["corpus"] == "open_hadith" for c in collections)
-
-        tally = neo4j_client.execute_read(
-            "MATCH (h:Hadith) RETURN count(h) AS total, "
-            "sum(CASE WHEN h.sect = 'sunni' AND h.source_corpus = 'open_hadith' THEN 1 ELSE 0 END) "
-            "AS tagged"
-        )[0]
-        assert tally["total"] == EXPECTED_HADITHS
-        assert tally["tagged"] == EXPECTED_HADITHS
-
-    def test_appears_in_resolves_each_hadith_to_its_book(
-        self, neo4j_client, staged_open_hadith: Path, tmp_path: Path
-    ) -> None:
-        """APPEARS_IN edges land (closing the no-Collection gap) and route each
-        hadith to its own book — no dangling edges."""
-        curated = tmp_path / "curated"
-        curated.mkdir()
-        load_all_nodes(neo4j_client, staged_open_hadith, curated, strict=False)
-        load_all_edges(neo4j_client, staged_open_hadith, curated, strict=False)
-
-        per_collection = neo4j_client.execute_read(
-            "MATCH (:Hadith)-[:APPEARS_IN]->(c:Collection) "
-            "RETURN c.id AS coll, count(*) AS n ORDER BY c.id"
-        )
-        assert {r["coll"]: r["n"] for r in per_collection} == EXPECTED_PER_COLLECTION
-
-        total_edges = neo4j_client.execute_read(
-            "MATCH (:Hadith)-[r:APPEARS_IN]->(:Collection) RETURN count(r) AS n"
+        open_hadith_hadiths = neo4j_client.execute_read(
+            "MATCH (h:Hadith {source_corpus: 'open_hadith'}) RETURN count(h) AS n"
         )[0]["n"]
-        assert total_edges == EXPECTED_HADITHS
+        open_hadith_collections = neo4j_client.execute_read(
+            "MATCH (c:Collection {source_corpus: 'open_hadith'}) RETURN count(c) AS n"
+        )[0]["n"]
+        assert open_hadith_hadiths == 0
+        assert open_hadith_collections == 0

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -177,3 +177,24 @@ class TestRunAllDerivesFromRegistry:
 
 def test_source_adapter_is_dataclass_instance() -> None:
     assert all(isinstance(a, SourceAdapter) for a in SOURCE_REGISTRY)
+
+
+class TestActiveComposition:
+    """Inactive sources (confirmed duplicates) are retained for the coverage
+    invariant but never acquired/parsed (da#191)."""
+
+    def test_open_hadith_is_inactive(self) -> None:
+        assert get_adapter("open_hadith").active is False
+
+    def test_open_hadith_still_has_an_adapter(self) -> None:
+        # Coverage invariant must still hold — the row is retained, just inactive.
+        assert SourceCorpus.OPEN_HADITH in {a.corpus for a in SOURCE_REGISTRY}
+
+    def test_open_hadith_is_the_only_inactive_source(self) -> None:
+        inactive = {a.slug for a in SOURCE_REGISTRY if not a.active}
+        assert inactive == {"open_hadith"}
+
+    def test_run_all_skips_inactive(self) -> None:
+        for mod in ("src.acquire", "src.parse"):
+            source = inspect.getsource(import_module(mod).run_all)
+            assert "adapter.active" in source

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -360,6 +360,41 @@ class TestLoadHadiths:
         rows = {r["id"]: r["matn_ar"] for r in self._hadith_batch_rows(mock_client)}
         assert rows["hdt:h-1"] == "المتن"
 
+    def test_composition_skips_non_canonical_collections(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """Non-canonical (source, collection) Hadith are skipped at load (da#191):
+        halimbahae keeps only its unique books; mis loads no Hadith nodes."""
+        write_hadiths(
+            staging_dir,
+            [
+                # halimbahae unique book -> kept
+                {
+                    "source_id": "hb-kept",
+                    "source_corpus": "halimbahae",
+                    "collection_name": "musnad_ahmad_ibn-hanbal",
+                    "matn_ar": "متن",
+                },
+                # halimbahae six-book duplicate of lk -> dropped
+                {
+                    "source_id": "hb-drop",
+                    "source_corpus": "halimbahae",
+                    "collection_name": "sahih_al-bukhari",
+                    "matn_ar": "متن",
+                },
+                # mis -> no Hadith nodes at all
+                {
+                    "source_id": "mis-drop",
+                    "source_corpus": "mis",
+                    "collection_name": "Sahih Muslim",
+                    "matn_ar": "متن",
+                },
+            ],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        ids = {r["id"] for r in self._hadith_batch_rows(mock_client)}
+        assert ids == {"hdt:hb-kept"}
+
     def test_adds_hdt_prefix(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
     ) -> None:

--- a/tests/test_parse/test_composition.py
+++ b/tests/test_parse/test_composition.py
@@ -1,0 +1,44 @@
+"""Tests for the canonical corpus composition (da#191)."""
+
+from __future__ import annotations
+
+from src.parse.composition import HADITH_COMPOSITION, is_canonical_hadith
+
+
+class TestIsCanonicalHadith:
+    def test_unlisted_source_loads_all_collections(self) -> None:
+        # lk is the six-books spine — not in the composition map, so all kept.
+        assert is_canonical_hadith("lk", "bukhari")
+        assert is_canonical_hadith("lk", "muslim")
+        # sanadset / thaqalayn / tusi / sunnah likewise load everything.
+        assert is_canonical_hadith("sanadset", "sanadset")
+        assert is_canonical_hadith("thaqalayn", "Al-Kafi-Volume-1-Kulayni")
+
+    def test_halimbahae_keeps_only_unique_books(self) -> None:
+        for keep in ("musnad_ahmad_ibn-hanbal", "sunan_al-darimi", "maliks_muwataa"):
+            assert is_canonical_hadith("halimbahae", keep)
+        for drop in (
+            "sahih_al-bukhari",
+            "sahih_muslim",
+            "sunan_al-nasai",
+            "sunan_abu-dawud",
+            "sunan_ibn-maja",
+            "sunan_al-tirmidhi",
+        ):
+            assert not is_canonical_hadith("halimbahae", drop)
+
+    def test_fawaz_keeps_only_unique_collections(self) -> None:
+        for keep in ("nawawi", "dehlawi", "qudsi"):
+            assert is_canonical_hadith("fawaz", keep)
+        for drop in ("bukhari", "muslim", "nasai", "abudawud", "ibnmajah", "tirmidhi", "malik"):
+            assert not is_canonical_hadith("fawaz", drop)
+
+    def test_mis_loads_no_hadith_nodes(self) -> None:
+        # mis contributes chains/edges only — its Sahih Muslim matn duplicates lk.
+        assert not is_canonical_hadith("mis", "Sahih Muslim")
+
+    def test_open_hadith_dropped_entirely(self) -> None:
+        # Defence-in-depth: dropped at the registry (active=False), and any leftover
+        # parquet is a no-op here.
+        assert not is_canonical_hadith("open_hadith", "sahih_al-bukhari")
+        assert HADITH_COMPOSITION["open_hadith"] == frozenset()

--- a/tests/test_parse/test_provenance_conformance.py
+++ b/tests/test_parse/test_provenance_conformance.py
@@ -47,7 +47,17 @@ _ALL_SCHEMA_NAMES = frozenset(
 # Parse modules that are framework, not per-source parsers — excluded from the
 # "every parser emits a provenance-bearing schema" coverage assertion.
 _NON_PARSER_MODULES = frozenset(
-    {"__init__", "base", "schemas", "validate", "narrator_extraction", "identity"}
+    {
+        "__init__",
+        "base",
+        "schemas",
+        "validate",
+        "narrator_extraction",
+        "identity",
+        # da#191: declares the canonical corpus composition (which source/collection
+        # pairs load) — not a per-source parser, emits no parquet.
+        "composition",
+    }
 )
 
 


### PR DESCRIPTION
## Summary
Encodes the owner-confirmed canonical corpus composition **in the pipeline**, so a fresh `run_all` (the path production uses) produces a duplicate-free graph without the manual graph surgery used on staging.

Pre-cutover audit found duplicate corpora: `open_hadith` ≡ `halimbahae` (100%), and the six canonical Sunni books loaded by `lk` + `halimbahae` + `fawaz` + `mis`. Loading every copy double-counts hadith on prod.

## Change
- **`src/parse/composition.py`** (new) — single source of truth `HADITH_COMPOSITION` + `is_canonical_hadith()`:
  - `lk` = six-books canonical spine (all collections; richest metadata).
  - `halimbahae` → unique books only (Musnad Ahmad, Darimi, Malik).
  - `fawaz` → unique collections only (Nawawi, Dehlawi, Qudsi).
  - `mis` → no Hadith nodes (its Sahih Muslim matn duplicates lk; `network_edges_mis` still loads as chains).
  - every other source → all collections.
- **`src/adapters.py`** — add `SourceAdapter.active` (default True); `open_hadith` marked `active=False` (confirmed dup). Registry row retained for the `SourceCorpus` coverage invariant.
- **`src/acquire`, `src/parse` run_all** — skip inactive adapters.
- **`src/graph/load_nodes.py`** — enforce the composition at load: skip non-canonical `(source_corpus, collection)` Hadith + Collection rows. One enforcement point.

## Scope
This is the deterministic **per-source** composition (the part that MUST hold before prod). Cross-edition canonical-identity dedup (same hadith by collection+number across editions) is a tracked fast-follow — flagged to the Program Director.

## Tests
Composition unit tests; load_nodes skips non-canonical collections + mis; adapters active-flag + coverage invariant; provenance-conformance excludes the new framework module. **Full suite 924 passed / 7 skipped**; ruff + mypy clean.

## Validation
This is the dedup encoding for the `run_all` dress-rehearsal staging load (the prod-cutover sign-off artifact), which follows.

Closes #191
Reviewers requested: Kavitha Sundaramurthy, Kwesi Boateng

🤖 Generated with [Claude Code](https://claude.com/claude-code)
