### PR TITLE
docs(README): document required pre-commit + pre-push hook install (#200)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# noorinalabs-data-acquisition
+
+Data source acquisition — scrapers, API connectors, downloaders; Python + PyArrow.
+
+This repo is the **acquisition** stage of the NoorinALabs data pipeline: it pulls
+raw hadith/rijal source material from upstream collections (web scrapers and API
+connectors), normalizes it into a stable on-disk form, and writes typed columnar
+artifacts (PyArrow/Parquet) for the downstream ingest platform to consume. Source
+code lives under `src/`, tests under `tests/`.
+
+## Git hooks (required)
+
+This repo mirrors its CI checks locally via [pre-commit](https://pre-commit.com/).
+After cloning, install BOTH hook stages once:
+
+```bash
+pre-commit install                       # commit-stage checks
+pre-commit install --hook-type pre-push  # push-stage checks
+```
+
+- **Commit stage** runs: `ruff-format`, `ruff-lint` (with `--fix`), `gitleaks`
+  secret-scan, and `actionlint` over the workflows.
+- **Pre-push stage** runs: `mypy` (strict, over `src/`) and the `pytest` unit
+  suite (`tests/`, with `ENVIRONMENT=test`, excluding integration tests).
+
+These mirror `.github/workflows/ci.yml` so failures surface locally before a PR
+(org-wide local⇄CI parity, noorinalabs-main#684). Never bypass with `--no-verify`.
+If `pre-commit install` "cowardly refuses" because `core.hooksPath` is set, run
+`git config --unset core.hooksPath` first.
+
+Documentation and config (markdown lint, cspell spellcheck, lychee link-check,
+YAML/JSON syntax, and a pinned `actionlint`) are additionally gated in CI by
+`.github/workflows/docs.yml`.


### PR DESCRIPTION
## Summary

Adds a top-level `README.md` for noorinalabs-data-acquisition. The repo had no
README. This provides the project title, a one-line description, a short
"what's here" overview, and a required **Git hooks** section.

## Git hooks section

Enumerates this repo's ACTUAL pre-commit configuration, per stage:

- **Commit stage:** `ruff-format`, `ruff-lint` (`--fix`), `gitleaks`, `actionlint`.
- **Pre-push stage:** `mypy` (strict, `src/`) and the `pytest` unit suite
  (`tests/`, `ENVIRONMENT=test`, excluding integration).

These mirror `.github/workflows/ci.yml` (local⇄CI parity, noorinalabs-main#684);
the README also points at the separate `docs.yml` doc/config gates.

Verified locally: `markdownlint-cli2` clean; commit + push hooks ran green
(gitleaks/mypy/pytest passed).

Reviewers: 2 required per charter.

Closes #200
