### PR TITLE
docs: add per-repo zsh Shell environment note to CLAUDE.md (#759)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,10 @@ make clean              # Remove staging data and caches
 - Arabic text utilities are pure Python: diacritics stripping, alif/hamza/taa marbuta normalization
 - Staging data uses PyArrow schemas as intermediate between raw data and graph nodes
 
+### Shell environment
+
+The development shell is **zsh** (not bash). Write zsh-safe terminal commands and avoid bash-only idioms (`declare -A`, `${!arr[@]}`, and unquoted `?`/`*` globs such as `…?ref=main` URLs, which zsh pathname-expands). Prefer POSIX-portable constructs; use `bash -c '...'` explicitly when bash is genuinely required. Canonical do/don't list: org `docs/TOOLCHAIN.md` "Shell environment" section + `ontology/conventions.md` in `noorinalabs-main`.
+
 ## Configuration
 
 Copy `.env.example` to `.env`. Key variables:


### PR DESCRIPTION
## Summary
Adds a concise **Shell environment** subsection to this repo's `CLAUDE.md` (under Code Conventions) documenting that the development shell is **zsh** (not bash). Agents should write zsh-safe terminal commands, avoid bash-only idioms (`declare -A`, `${!arr[@]}`, unquoted `?`/`*` globs such as `…?ref=main` URLs), prefer POSIX-portable constructs, and use `bash -c '...'` explicitly when bash is genuinely required. Points to the canonical org `docs/TOOLCHAIN.md` "Shell environment" section + `ontology/conventions.md` in `noorinalabs-main`.

Minimal, additive (4 lines); no restructure.

Part of #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNK9q1SAds2ZmHQ88oLvxn
