### PR TITLE
tech-debt(ci-parity): mirror cspell into pre-commit + classify cspell kind (rollout of main#684)

### DIFF
--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -23,11 +23,15 @@ step vs a `ruff` pre-commit `id:`). We normalize both sides to a small set of
 kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
-    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build
+    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
+    cspell
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
-understand.
+understand. Closing a blind spot here means ADDING the kind to
+`_KIND_PATTERNS` (cf. `cspell`, noorinalabs-main#684) so a CI job that runs it
+starts demanding a pre-commit mirror — an un-classified CI check is silently
+un-mirrored, which is the exact divergence this gate exists to prevent.
 
 Input Language
 ==============
@@ -64,6 +68,14 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "actionlint": ("actionlint",),
     "pip-audit": ("pip-audit", "pip audit"),
     "build": ("build-and-validate", "build-and-test", "npm run build", "docker build"),
+    # `cspell` closes the spell-check blind spot (noorinalabs-main#684): the CI
+    # `Spellcheck (cspell)` job (.github/workflows/docs.yml) runs the
+    # `streetsidesoftware/cspell-action` (or a `cspell` CLI), but until this kind
+    # existed an un-classified spell gate produced ZERO drift signal — a repo
+    # could enforce cspell in CI with no pre-commit mirror, so new domain
+    # vocabulary failed only after push. Patterns cover the action ref, the
+    # bundled-CLI step name, and the generic job/step word.
+    "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -1,0 +1,143 @@
+"""Tests for pre_commit_ci_sync — the pre-commit <-> CI drift gate (#327).
+
+Focused on the noorinalabs-main#684 cspell rollout for this repo: the CI
+`Spellcheck (cspell)` job (.github/workflows/docs.yml) must classify as the
+`cspell` kind, a pre-commit cspell hook must classify too, and the real repo
+config must mirror the COMPLETE CI check-set across ALL workflows (no harmful
+drift).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Helper lives at .claude/lib/pre_commit_ci_sync.py; this test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pre_commit_ci_sync import (  # noqa: E402
+    check_repo,
+    compute_drift,
+    kinds_from_ci,
+    kinds_from_precommit,
+)
+
+# .claude/lib/tests/test_*.py -> parents[3] is the repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class CspellKindClassification(unittest.TestCase):
+    """#684: the spell-check blind spot. A CI Spellcheck job must classify as
+    the `cspell` kind on EITHER expression — the `streetsidesoftware/cspell-action`
+    `uses:` ref, a bundled-CLI `cspell` step/run, or the generic `spellcheck`
+    word — and a pre-commit cspell hook must classify too, so a CI spell gate
+    with no local mirror produces harmful drift instead of silence."""
+
+    def test_cspell_action_uses_ref_classified(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    name: Spellcheck (cspell)
+    steps:
+      - name: cspell
+        uses: streetsidesoftware/cspell-action@de2a73e # v8.4.0
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_cspell_cli_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  spell:
+    steps:
+      - run: npx cspell --config .cspell.json "**/*.md"
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_generic_spellcheck_word_classified(self) -> None:
+        # A repo that names the step/run with the generic word still registers.
+        self.assertIn("cspell", kinds_from_ci("      - run: make spellcheck\n"))
+
+    def test_precommit_cspell_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+"""
+        self.assertIn("cspell", kinds_from_precommit(cfg))
+
+    def test_ci_cspell_without_precommit_is_harmful_drift(self) -> None:
+        # The exact divergence #684 exists to catch: CI enforces cspell, the
+        # pre-commit config does not mirror it.
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("cspell", harmful)
+
+    def test_ci_cspell_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("cspell", harmful)
+
+
+class RealRepoCspellParity(unittest.TestCase):
+    """Guards on this repo's actual committed config — the rollout must stay
+    enforced, not just pass on synthetic fixtures."""
+
+    def _workflow_paths(self) -> list[Path]:
+        wf_dir = _REPO_ROOT / ".github" / "workflows"
+        return sorted(p for p in wf_dir.glob("*.y*ml") if p.is_file())
+
+    def test_ci_enforces_cspell(self) -> None:
+        # Guard against the docs.yml cspell job being removed/renamed without the
+        # mirror+kind being revisited: the kind must actually appear in CI.
+        ci_kinds: set[str] = set()
+        for path in self._workflow_paths():
+            ci_kinds |= kinds_from_ci(path.read_text(encoding="utf-8"))
+        self.assertIn("cspell", ci_kinds)
+
+    def test_precommit_mirrors_all_workflows(self) -> None:
+        # The CI gate globs ALL workflow files (#684), so this repo must have no
+        # harmful drift across the full set — in particular docs.yml carries the
+        # cspell + actionlint jobs. This is the gate exactly as the
+        # `Pre-commit ⇄ CI sync-drift gate` CI job runs it.
+        precommit = _REPO_ROOT / ".pre-commit-config.yaml"
+        self.assertTrue(precommit.is_file(), "repo must have a pre-commit config")
+        ci_paths = self._workflow_paths()
+        self.assertTrue(ci_paths, "repo must have workflow files")
+        harmful, _ = check_repo(precommit, ci_paths)
+        self.assertEqual(
+            harmful,
+            set(),
+            f"pre-commit must mirror ALL CI workflows; missing locally: {sorted(harmful)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,10 @@ jobs:
     # Fails the build if a check this CI enforces (ruff/mypy/pytest/…) is NOT
     # mirrored in .pre-commit-config.yaml — the machine-enforcement that keeps
     # the local-hooks mirror from rotting (Phase-3 end-state #6 / main#327).
-    # The gate is scoped to THIS workflow (the code-CI surface); docs.yml gates
-    # a separate artifact class and is intentionally not mirrored by pre-commit
-    # beyond the actionlint hook.
+    # Per noorinalabs-main#684 the gate globs ALL workflows (ci.yml AND
+    # docs.yml), so the docs.yml `Spellcheck (cspell)` + actionlint jobs are
+    # demanded in the pre-commit mirror too — local "clean" must mirror the
+    # COMPLETE CI check-set, not a subset.
     steps:
       - uses: actions/checkout@v6
 
@@ -131,5 +132,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Check pre-commit ⇄ ci.yml drift
-        run: python3 .claude/lib/pre_commit_ci_sync.py . --ci .github/workflows/ci.yml
+      - name: Check pre-commit ⇄ CI drift (all workflows)
+        run: python3 .claude/lib/pre_commit_ci_sync.py .
+
+      - name: Sync-gate unit tests
+        # Lock the classifier behaviour (incl. the #684 cspell kind) and guard
+        # docs.yml's cspell job from silent removal. unittest avoids a pytest
+        # dependency in this lightweight job.
+        run: python3 -m unittest discover -s .claude/lib/tests -p "test_*.py" -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,8 @@
 #
 # Stage split:
 #   pre-commit (fast, every commit) — ruff-format, ruff-lint over the repo, plus
-#     gitleaks secret-scan and pinned actionlint on workflows.
+#     gitleaks secret-scan, pinned actionlint on workflows, and pinned cspell
+#     over the authored-prose set.
 #   pre-push   (heavier, every push) — mypy strict + the pytest suite. These run
 #     the whole src/ + tests surface, so they're push-time not commit-time to
 #     keep the commit loop snappy while still catching everything before the
@@ -28,12 +29,21 @@
 #     here mirrors ci.yml's unit `test` job).
 #   * actionlint runs via the rhysd/actionlint pre-commit mirror pinned to
 #     v1.7.12 so the same workflow-lint runs locally that docs.yml runs in CI.
+#   * cspell runs via the streetsidesoftware/cspell-cli mirror pinned to v8.4.0
+#     to match the exact cspell the `streetsidesoftware/cspell-action@…v8.4.0`
+#     CI step (docs.yml `Spellcheck (cspell)`) bundles — same engine +
+#     dictionaries on both sides. `--config .cspell.json` reuses the same
+#     dictionaries + ignore rules CI loads; the `files` regex is the equivalent
+#     of the CI action's authored-prose glob set.
 #
-# The kind-level mirror (ruff-lint, ruff-format, mypy, pytest present on both
-# sides) is enforced in CI by `.claude/lib/pre_commit_ci_sync.py` — if a future
-# edit drops one side, that gate fails the build. The gate is scoped to ci.yml
-# (the code-CI workflow); docs.yml gates a separate artifact class (markdown/
-# config/actionlint) that pre-commit covers via the actionlint mirror.
+# The kind-level mirror (ruff-lint, ruff-format, mypy, pytest, actionlint, and
+# now cspell present on both sides) is enforced in CI by
+# `.claude/lib/pre_commit_ci_sync.py` — if a future edit drops one side, that
+# gate fails the build. Per noorinalabs-main#684 the gate now globs ALL
+# workflows (ci.yml AND docs.yml), so the docs.yml cspell + actionlint jobs are
+# demanded here too — local "clean" must mirror the COMPLETE CI check-set, not a
+# subset. (The remaining docs.yml jobs — markdownlint, lychee, YAML/JSON
+# syntax — are not yet classified kinds, so the gate stays silent on them.)
 
 repos:
   # --- Ruff formatter & linter (mirror of ci.yml Lint job) ---
@@ -60,6 +70,23 @@ repos:
     hooks:
       - id: actionlint
         name: actionlint
+
+  # --- Spellcheck (pinned cspell mirror of docs.yml `Spellcheck (cspell)`) ---
+  # Pinned to v8.4.0 of cspell-cli to match the exact cspell the
+  # `streetsidesoftware/cspell-action@…v8.4.0` CI step bundles (same engine +
+  # dictionaries). `language: node`, so pre-commit provisions its own node/cspell
+  # env (no system cspell required). `--config .cspell.json` reuses the CI
+  # dictionaries + ignore rules; `files` is the regex equivalent of the CI
+  # action's authored-prose glob set (docs/, CLAUDE.md, RUNBOOK.md, the team
+  # charter). New domain vocabulary then fails `pre-commit run` locally instead
+  # of only surfacing as a CI red after push (#684).
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+        args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
+        files: ^(docs/.*\.md|CLAUDE\.md|RUNBOOK\.md|\.claude/team/charter\.md)$
 
   # --- Heavier checks run at pre-push (mirror CI's Type Check + Test jobs).
   #     Run as `local`/`system` hooks via `uv run` so the pinned tools from


### PR DESCRIPTION
## What & why

Rollout of **noorinalabs-main#684** (full local⇄CI tooling parity + no force-merging) to `noorinalabs-data-acquisition`.

The CI `Spellcheck (cspell)` job in `.github/workflows/docs.yml` runs `streetsidesoftware/cspell-action@…v8.4.0`, but there was **no pre-commit mirror** for it, and the sync-drift gate was scoped to `ci.yml` only. Net effect: a new domain word failed **only after push**, and the drift gate stayed silent on the gap (an un-classified CI check is silently un-mirrored — the exact divergence the gate exists to prevent).

## Changes

- **`.claude/lib/pre_commit_ci_sync.py`** — classify the `cspell` kind (`("cspell", "spellcheck", "streetsidesoftware/cspell")`) so a CI spell gate with no local mirror is *harmful drift*, not silence.
- **`.pre-commit-config.yaml`** — add the `streetsidesoftware/cspell-cli` mirror **pinned to v8.4.0** (matches the cspell the `cspell-action@v8.4.0` CI step bundles → same engine + dictionaries), scoped to the CI action's authored-prose globs (`docs/**/*.md`, `CLAUDE.md`, `RUNBOOK.md`, `.claude/team/charter.md`) with `--config .cspell.json`.
- **`.github/workflows/ci.yml`** — widen the sync-drift gate to glob **ALL** workflows (`pre_commit_ci_sync.py .`, dropping the `--ci ci.yml` scope) so the `docs.yml` cspell **and** actionlint jobs are demanded in the pre-commit mirror; add a sync-gate unit-test step. (Matches the parent canonical invocation.)
- **`.claude/lib/tests/test_pre_commit_ci_sync.py`** — new; locks the cspell classification and the real-repo no-drift parity across all workflows.

## Pinned version

`streetsidesoftware/cspell-cli` **v8.4.0** — exactly the cspell bundled by the `streetsidesoftware/cspell-action@de2a73e…` (v8.4.0) the CI Spellcheck job uses.

## Verification

- `python3 .claude/lib/pre_commit_ci_sync.py .` → `OK: pre-commit config mirrors all CI-enforced checks.`
- `python3 -m unittest discover -s .claude/lib/tests` → 8/8 green.
- `pre-commit run --all-files` → ruff-format / ruff-lint / gitleaks / actionlint / **cspell** all Passed.
- Pre-push mypy + pytest green on push.

Closes #210
Part of noorinalabs-main#684

🤖 Generated with [Claude Code](https://claude.com/claude-code)
