### PR TITLE
Investigation(da#202): ADR-003 sanadset orphan-node + narrator-pollution remediation (A/B)

### DIFF
--- a/docs/adr/003-sanadset-orphan-remediation.md
+++ b/docs/adr/003-sanadset-orphan-remediation.md
@@ -1,11 +1,41 @@
 # ADR-003: `sanadset` orphan-node + narrator-pollution remediation
 
-## Status: Proposed — awaiting owner A/B decision (P7W19, da#202)
+## Status: Accepted — Path B (owner decision, 2026-06-25, P7W19, da#202)
 
-> This ADR is an **investigation + A/B recommendation**, not an accepted
-> decision. The remediation it scopes (a per-source purge) is irreversible on
-> live graph state and is **owner-run only**. Nothing here has been executed.
-> Meta-issue: noorinalabs/noorinalabs-main#723. Keystone: da#202.
+> The owner has chosen **Path B** (parse, segment, and link `sanadset`) over the
+> investigation's lean Path-A recommendation, and **deferred** it to a later wave
+> — see § Decision Outcome below. The body that follows is the original
+> investigation + A/B analysis (verified by two reviewers at the Proposed head);
+> it is retained unedited as the decision's rationale. **No remediation executes
+> on the basis of this ADR**: Path A's live-graph purge is *not* taken, and Path
+> B's pipeline work is sequenced into separate, owner-tracked sub-issues. Any
+> future per-source purge remains irreversible on live state and **owner-run
+> only**. Meta-issue: noorinalabs/noorinalabs-main#723. Keystone: da#202.
+
+## Decision Outcome (owner, 2026-06-25)
+
+**Decision: Path B — parse, segment, and link `sanadset`, deferred to W3+ of
+Phase 7.** The owner elected to *preserve* the corpus's collection breadth by
+re-linking it, rather than purge it (Path A). The investigation's lean
+recommendation was Path A; this decision overrides it deliberately, accepting the
+higher effort/risk in exchange for not discarding `sanadset`'s collection
+coverage beyond the canonical six books.
+
+Path B is **not** undertaken in P7W19. It is decomposed into three sequenced
+sub-issues in `noorinalabs-data-acquisition`, tracked under keystone da#202 (which
+remains open as the Path-B epic):
+
+| Order | Issue | Work | Note |
+|------:|-------|------|------|
+| 1 | da#220 (B2) | Cross-edition canonical-identity dedup | **Prerequisite** — must land before B1 loads to prod, else the 650k raw hadiths double-count the canonical spine |
+| 2 | da#219 (B1) | Emit `collections_sanadset.parquet` (`book_id` → collection linkage) | Mechanically feasible from the already-acquired `books.csv` |
+| 3 | da#221 (B3) | Narrator re-segmentation of the `<NAR>` mention firehose | Addresses the polluted `Narrator` table / near-absent `STUDIED_UNDER` |
+
+The read-only blast-radius inventory query shipped here
+(`queries/validation/sanadset_orphan_inventory.cypher`) stays useful for sizing
+that future work. Until Path B lands, the `sanadset` orphans remain in the live
+graph (no purge); the orphan condition is a known, owner-accepted state tracked
+by da#202.
 
 ## Context
 

--- a/docs/adr/003-sanadset-orphan-remediation.md
+++ b/docs/adr/003-sanadset-orphan-remediation.md
@@ -1,0 +1,190 @@
+# ADR-003: `sanadset` orphan-node + narrator-pollution remediation
+
+## Status: Proposed — awaiting owner A/B decision (P7W19, da#202)
+
+> This ADR is an **investigation + A/B recommendation**, not an accepted
+> decision. The remediation it scopes (a per-source purge) is irreversible on
+> live graph state and is **owner-run only**. Nothing here has been executed.
+> Meta-issue: noorinalabs/noorinalabs-main#723. Keystone: da#202.
+
+## Context
+
+Production validation of the live graph (Admin -> Data Management, 2026-06-19)
+found that ~85% of all `Hadith` nodes are orphans — present, but linked to no
+`Collection`. The provenance breakdown by `source_corpus`:
+
+| source        | hadiths | collections |
+|---------------|--------:|------------:|
+| `sanadset`    | 650,986 |           0 |
+| `lk`          |  33,981 |           6 |
+| `thaqalayn`   |  33,190 |          33 |
+| `halimbahae`  |  31,324 |           3 |
+| `tusi`        |  17,421 |           2 |
+| `sunnah`      |   1,896 |           1 |
+| `fawaz`       |     122 |           3 |
+
+The six non-`sanadset` sources (~117,934 hadiths, ~69,067 `APPEARS_IN`-linked)
+are the real curated corpus and look structurally correct. `sanadset`
+(650,986 hadiths, **0** collections) is the entire orphan population and is also
+the source of the polluted `Narrator` table (132,999 nodes; isnad phrase
+fragments stored as narrator names; `STUDIED_UNDER` near-absent at 186 edges).
+
+## Root cause (with code references)
+
+The defect is a **missing parser output**, compounded by a **non-creating edge
+match** and **masked by a test fixture**. Three coupled facts:
+
+1. **`parse_sanadset` never emits a collections file.**
+   `src/parse/sanadset.py` (`parse_sanadset`) writes exactly three staging
+   files — `hadiths_sanadset.parquet`, `narrator_mentions_sanadset.parquet`,
+   and `narrators_bio_kaggle.parquet`. It does **not** write a
+   `collections_sanadset.parquet`. Every other loaded parser does
+   (`fawaz`, `halimbahae`, `lk_corpus`, `sunnah_api`, `sunnah_scraped`,
+   `thaqalayn`, `tusi`, `bihar`, `open_hadith` all emit `collections_*`).
+   The `Hadith` nodes are still tagged with a `collection_name` derived from the
+   CSV filename stem (`collection_name = csv_file.stem.lower()...`), but no
+   matching `Collection` is ever produced.
+
+2. **`Collection` nodes load only from `collections_*.parquet`, and `APPEARS_IN`
+   uses a non-creating `MATCH`.**
+   `_load_collections` (`src/graph/load_nodes.py`) ingests only
+   `collections_*.parquet`, so zero `sanadset` `Collection` nodes exist. The
+   edge loader `_APPEARS_IN_QUERY` (`src/graph/load_edges.py`) is
+   `MATCH (h:Hadith)... MATCH (c:Collection)... MERGE (h)-[:APPEARS_IN]->(c)` —
+   a **non-creating** match on the collection endpoint (deliberate: endpoints
+   are matched, not merged, to avoid dangling references). `_APPEARS_IN_CHECK`
+   reports `collection_exists = false` for every `sanadset` row, so all 650,986
+   `APPEARS_IN` edges are skipped as missing endpoints. Result: 650,986 hadiths,
+   0 collections.
+
+3. **The canonical-composition gate admits all of `sanadset`.**
+   `HADITH_COMPOSITION` (`src/parse/composition.py`) lists per-source dedup
+   rules for `halimbahae`, `fawaz`, `mis`, and `open_hadith`. `sanadset` is
+   **not listed**, and the default for an unlisted source is "load ALL
+   collections" (`is_canonical_hadith` returns `True`). So all 650,986
+   `sanadset` hadiths are admitted as `Hadith` nodes with **no** dedup against
+   the canonical six Sunni books that are already loaded (with richer metadata)
+   via `lk` / `halimbahae` / `fawaz`.
+
+Two corroborating signals in the codebase:
+
+- **The validate baseline codifies the gap.** `DEFAULT_BASELINES`
+  (`src/parse/validate.py`) has a `collections_*` baseline for every loaded
+  source **except** `sanadset` — and it expects `narrator_mentions_sanadset`
+  `row_count = 2,789,517`. That 2.79M-mention firehose, parsed at face value
+  from coarse `<NAR>` tags by `_extract_narrator_mentions`, is what pollutes the
+  resolved narrator table.
+- **A test fixture masks the production gap.**
+  `tests/integration/test_sanadset_lightup.py` proves `APPEARS_IN` lands for
+  `sanadset` — but only because it imports `write_collections` from the test
+  `conftest` and **fabricates** a `sanadset` `Collection` out of band. Production
+  has no such step, so the green test never exercised the real (absent)
+  collection-emission path. (Cf. the org memory "test-mock injection masks
+  production failure".)
+
+Narrator pollution and the near-absent `STUDIED_UNDER` (186) are the same root:
+`sanadset` mentions are flat per-`<NAR>` extractions fed straight into narrator
+resolution (`_PHASE1_MENTION_SOURCES` in `src/resolve/ner.py`), while
+teacher-student edges are derived from transmission/network edges that this flat
+corpus does not provide.
+
+## Decision options
+
+### Path A — purge `sanadset` from the live graph (owner-run, irreversible)
+
+**Mechanics.** App-side Admin -> Data Management -> "Danger Zone — Per-source
+Purge" deletes the whole `sanadset` source corpus from the live graph (its
+`Hadith` nodes, their edges, and `Narrator` nodes reachable only through
+`sanadset`). To stop the next `run_all` re-introducing the orphans, pair the
+purge with a one-line code change: mark the `sanadset` adapter `active=False` in
+`src/adapters.py`, or register `sanadset: frozenset()` in
+`src/parse/composition.py` so no `sanadset` `Hadith` nodes load.
+
+**Effort.** Low — one admin action + a one-line registry/composition change and
+a fixture-honesty fix to `test_sanadset_lightup.py`.
+
+**Blast radius.** Removes ~650,986 `Hadith` nodes (85% of all hadiths), the bulk
+of `NARRATED` edges sourced from `sanadset`, and the `sanadset`-exclusive
+(polluted) `Narrator` nodes. The curated six sources (~117,934 hadiths,
+~69,067 `APPEARS_IN`) are untouched. Collateral to quantify **before** purging
+(use `queries/validation/sanadset_orphan_inventory.cypher`): `TRANSMITTED_TO`
+edges and resolved narrators that derive from `sanadset` mentions would also go.
+
+**Reversibility.** Irreversible on **live state**, but the corpus is
+deterministically re-acquirable from Mendeley Data (`5xth87zwb5` v4, pinned
+SHA-256 in `src/acquire/sanadset.py`). The loss is the graph state, not the
+source — a future segmentation pipeline (Path B) could re-load it.
+
+**What is lost.** Any unique `sanadset` content not covered by the curated six
+books. `sanadset` spans more collections (via `books.csv`) than the curated
+spine, so that breadth is lost until Path B is built.
+
+### Path B — parse, segment, and link `sanadset` (high effort, high risk)
+
+**Mechanics.** (1) Add a `_parse_books` branch to `parse_sanadset` that reads
+the **already-downloaded** `books.csv` (acquired alongside `sanadset.csv` —
+`_MENDELEY_FILES` in `src/acquire/sanadset.py`) and emits
+`collections_sanadset.parquet` (`COLLECTION_SCHEMA`), mapping each hadith's
+`book_id` -> book -> collection slug so `collection_node_id` matches.
+(2) Register `sanadset` in `composition.py` to dedup the canonical six books
+already loaded via `lk` / `halimbahae` / `fawaz`, else double-count.
+(3) Improve `<NAR>` segmentation / narrator cleanup to fix pollution.
+(4) Fix `test_sanadset_lightup.py` to exercise the real collection-emitting
+path instead of `write_collections`.
+
+**Does the source even support it?** Partially. Collection structure **exists**
+(`books.csv` + per-hadith `book_id`), so collection linkage is mechanically
+feasible. But clean narrator segmentation and cross-edition dedup are **not**
+supported out of the box.
+
+**Effort.** High. Requires the cross-edition canonical-identity dedup that
+`composition.py`'s own docstring calls a "tracked fast-follow" — never built —
+to avoid duplicating the canonical spine; plus narrator re-segmentation R&D.
+
+**Risk.** High. Without cross-edition dedup, linking 650k raw hadiths
+double-counts the six books already loaded with richer metadata. The narrator
+pollution is intrinsic to the dataset's coarse tagging and only partially
+recoverable.
+
+## Recommendation
+
+**Path A — purge `sanadset` from the live graph, paired with deactivating the
+`sanadset` adapter in code so it does not re-load.** Rationale:
+
+- The curated six Sunni books are **already** loaded with richer, deduplicated
+  metadata via `lk` / `halimbahae` / `fawaz`; `sanadset` is a largely-redundant
+  raw corpus.
+- The 650k `sanadset` orphans contribute **0** linked collections and pollute
+  the narrator table with a 2.79M coarse-mention firehose.
+- Path B's prerequisites (cross-edition dedup + narrator re-segmentation) are
+  large, not-yet-built efforts to rehabilitate that redundant corpus.
+- Path A is **reversible-in-practice**: `sanadset` is deterministically
+  re-acquirable from Mendeley if a future pipeline justifies a clean re-load.
+
+This recommendation is **not** self-executing. The purge is owner-run and
+irreversible on live state, so the decision is surfaced as an explicit A/B for
+the owner to pick. **Do not execute remediation on the basis of this ADR alone.**
+
+## Consequences
+
+**Positive (Path A).** Removes 85% orphan `Hadith` nodes and the bulk of the
+polluted narrator table in one action; the live graph becomes a clean view of
+the curated corpus; cheap to do and cheap to reverse-via-re-acquire.
+
+**Negative / trade-offs (Path A).** Loses `sanadset`'s collection breadth beyond
+the six canonical books until a Path-B pipeline exists; some `TRANSMITTED_TO`
+edges and resolved narrators derived from `sanadset` mentions are removed
+(quantify first via the inventory query).
+
+**If Path B is chosen instead.** No data is lost, but it gates a clean switch-over
+on cross-edition dedup + narrator re-segmentation — neither built yet — and risks
+compounding duplication of the canonical spine if shipped without the dedup.
+
+## Related
+
+- da#202 — keystone: `sanadset` orphan nodes + polluted narrator table (prod).
+- noorinalabs/noorinalabs-main#723 — meta: corpus/graph data-quality (Phase 7).
+- da#153 — orphan-scale evidence.
+- da#191 — canonical corpus composition (`src/parse/composition.py`).
+- `queries/validation/sanadset_orphan_inventory.cypher` — read-only blast-radius
+  inventory to run before any purge.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,3 +5,4 @@ We use Michael Nygard's ADR format. Each decision gets a numbered file.
 ## Index
 - [ADR-001](001-local-hook-policy-dispatcher-style.md) — Local hook policy: data-acquisition stays dispatcher-style
 - [ADR-002](002-multi-source-adapter-registry.md) — Multi-source adapter registry: one declared contract for ingest sources
+- [ADR-003](003-sanadset-orphan-remediation.md) — `sanadset` orphan-node + narrator-pollution remediation (investigation + A/B)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,4 +5,4 @@ We use Michael Nygard's ADR format. Each decision gets a numbered file.
 ## Index
 - [ADR-001](001-local-hook-policy-dispatcher-style.md) — Local hook policy: data-acquisition stays dispatcher-style
 - [ADR-002](002-multi-source-adapter-registry.md) — Multi-source adapter registry: one declared contract for ingest sources
-- [ADR-003](003-sanadset-orphan-remediation.md) — `sanadset` orphan-node + narrator-pollution remediation (investigation + A/B)
+- [ADR-003](003-sanadset-orphan-remediation.md) — `sanadset` orphan-node + narrator-pollution remediation (Accepted — Path B, deferred; da#202)

--- a/queries/validation/sanadset_orphan_inventory.cypher
+++ b/queries/validation/sanadset_orphan_inventory.cypher
@@ -1,0 +1,51 @@
+// sanadset orphan-node / narrator-pollution inventory (da#202, P7W19).
+//
+// READ-ONLY. Every statement is MATCH/RETURN/count — NO writes, NO deletes.
+// Run each block independently (split on the blank lines) to characterize the
+// sanadset blast radius BEFORE any owner-run per-source purge. These numbers
+// quantify Path A loss and Path B scope for ADR-003.
+
+// 1. Hadith nodes per source_corpus, and how many are collection-linked.
+//    Confirms the orphan scale: sanadset hadiths with 0 APPEARS_IN edges.
+MATCH (h:Hadith)
+OPTIONAL MATCH (h)-[a:APPEARS_IN]->(:Collection)
+WITH h.source_corpus AS source,
+     count(DISTINCT h) AS hadiths,
+     count(a) AS appears_in_edges
+RETURN source, hadiths, appears_in_edges,
+       hadiths - appears_in_edges AS orphan_hadiths
+ORDER BY hadiths DESC;
+
+// 2. Collection nodes per source_corpus.
+//    Expectation: sanadset has 0 Collection nodes (no collections_sanadset
+//    parquet is ever emitted by parse_sanadset).
+MATCH (c:Collection)
+RETURN c.source_corpus AS source, count(c) AS collections
+ORDER BY collections DESC;
+
+// 3. Narrators reachable ONLY through sanadset hadiths (Path A would remove
+//    these; they are the bulk of the polluted narrator table). A narrator is
+//    sanadset-exclusive if every hadith it NARRATED has source_corpus sanadset.
+MATCH (n:Narrator)-[:NARRATED]->(h:Hadith)
+WITH n,
+     count(h) AS total_h,
+     sum(CASE WHEN h.source_corpus = 'sanadset' THEN 1 ELSE 0 END) AS sanadset_h
+WHERE total_h = sanadset_h
+RETURN count(n) AS sanadset_exclusive_narrators;
+
+// 4. TRANSMITTED_TO edges whose endpoints are sanadset-exclusive narrators
+//    (Path A collateral on the teacher-student graph). Bounded sample.
+MATCH (a:Narrator)-[t:TRANSMITTED_TO]->(b:Narrator)
+WHERE NOT EXISTS {
+        MATCH (a)-[:NARRATED]->(h:Hadith) WHERE h.source_corpus <> 'sanadset'
+      }
+RETURN count(t) AS transmitted_to_from_sanadset_only_narrators;
+
+// 5. Distinct sanadset collection_name values carried on Hadith nodes but with
+//    no backing Collection node. These are the would-be collections Path B
+//    must materialize from books.csv (book_id -> book -> collection slug).
+MATCH (h:Hadith {source_corpus: 'sanadset'})
+RETURN DISTINCT h.collection_name AS unlinked_collection_name,
+       count(*) AS hadiths
+ORDER BY hadiths DESC
+LIMIT 100;


### PR DESCRIPTION
## Summary

Investigation + A/B recommendation for the P7W19 keystone data-quality defect
da#202: `sanadset` bulk-loaded as **650,986 Hadith nodes with 0 collections**
(~85% of all hadiths are orphans) plus a polluted narrator table.

**This PR is investigation only — no remediation is executed.** The purge it
scopes is irreversible on live graph state and is **owner-run only**.

Part of #202
Part of noorinalabs/noorinalabs-main#723

## Root cause (code references in ADR-003)

1. `parse_sanadset` (`src/parse/sanadset.py`) never emits
   `collections_sanadset.parquet` — every other loaded parser emits
   `collections_*`.
2. `_load_collections` (`src/graph/load_nodes.py`) loads `Collection` nodes only
   from `collections_*.parquet`, and `_APPEARS_IN_QUERY`
   (`src/graph/load_edges.py`) **matches** (non-creating) the `Collection`
   endpoint → all 650,986 `APPEARS_IN` edges are skipped as missing endpoints →
   0 collections.
3. `HADITH_COMPOSITION` (`src/parse/composition.py`) omits `sanadset`; the
   default admits all 650k with **no** dedup against the curated six Sunni books
   already loaded (richer metadata) via `lk` / `halimbahae` / `fawaz`.
4. Corroboration: `src/parse/validate.py` baseline codifies the gap (no
   `collections_sanadset` entry; expects 2,789,517 `sanadset` mentions — the
   narrator-pollution firehose). The lightup integration test
   (`tests/integration/test_sanadset_lightup.py`) **masks** the gap by
   fabricating collections via `write_collections`.

## Deliverables (all non-destructive)

- `docs/adr/003-sanadset-orphan-remediation.md` — root cause + Path A (purge) vs
  Path B (parse/segment/link) + recommendation.
- `queries/validation/sanadset_orphan_inventory.cypher` — **READ-ONLY**
  blast-radius inventory to run before any owner-run purge.
- `docs/adr/README.md` — index entry.

## Recommendation

**Path A — purge `sanadset` from the live graph, paired with deactivating the
`sanadset` adapter in code** so it does not re-load. The curated six books are
already loaded with richer, deduplicated metadata; the orphans add 0 linked
collections and pollute the narrator table; Path B's prerequisites
(cross-edition dedup + narrator re-segmentation) are large, unbuilt efforts to
rehabilitate a redundant raw corpus. Path A is reversible-in-practice via
deterministic re-acquisition from Mendeley.

**AWAITING OWNER A/B DECISION — do not merge as a remediation.**

## Checks

- pre-commit (cspell, gitleaks, markdownlint), mypy strict, pytest
  (924 passed / 7 skipped) all green locally before push.

## Reviewers

- Primary: Oyunbileg Batbayar
- Secondary: Nikolaos Papadopoulos
