### PR TITLE
fix(resolve): remap merge_log canonical_ids through fuzzy-cluster collapse (da#313)

### DIFF
--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -565,9 +565,11 @@ def run_all(
             logger.info("resolve_step", step="cluster", status="running")
             canonical_path = output_dir / "narrators_canonical.parquet"
             mentions_path = output_dir / "narrator_mentions_resolved.parquet"
+            merge_log_path = output_dir / "merge_log.parquet"
             cluster_metrics = fuzzy_cluster.cluster_canonical_narrators(
                 canonical_path,
                 mentions_path=mentions_path if mentions_path.exists() else None,
+                merge_log_path=merge_log_path if merge_log_path.exists() else None,
                 staging_dir=staging_dir,
                 resume=resume,
                 stop_after=stop_after,

--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -275,6 +275,9 @@ class ClusterMetrics:
     multi_member_clusters: int
     cross_source_clusters: int
     mentions_remapped: int = 0
+    # da#313: merge_log rows whose absorbed canonical_id was routed to its cluster
+    # survivor, keeping the audit log join-consistent with narrators_canonical.
+    merge_log_remapped: int = 0
     # da#376: records that produced no blocking key and were therefore never offered to
     # `_can_merge`. Reported so "did not merge" can be told apart from "was never scored".
     unblockable_records: int = 0
@@ -286,11 +289,16 @@ class ClusterMetrics:
             if self.unblockable_records
             else ""
         )
+        merge_log = (
+            f", {self.merge_log_remapped} merge_log rows remapped"
+            if self.merge_log_remapped
+            else ""
+        )
         return (
             f"fuzzy-cluster: {self.input_records} → {self.output_records} canonical "
             f"({self.merged_records} merged into {self.multi_member_clusters} clusters, "
             f"{self.cross_source_clusters} cross-source); "
-            f"{self.mentions_remapped} mentions remapped{unblockable}"
+            f"{self.mentions_remapped} mentions remapped{merge_log}{unblockable}"
         )
 
 
@@ -1210,10 +1218,62 @@ def _remap_mention_canonical_ids(mentions_path: Path, remap: dict[str, str]) -> 
     return remapped
 
 
+def _remap_merge_log_canonical_ids(merge_log_path: Path, remap: dict[str, str]) -> int:
+    """Rewrite absorbed canonical ids on ``merge_log.parquet`` to the cluster survivor.
+
+    ``disambiguate`` records one merge_log row per bio-matched mention keyed on the
+    ``canonical_id`` it minted (da#356). When ``fuzzy_cluster`` later collapses that
+    id into a survivor it rewrites ``narrators_canonical.parquet`` (dropping the
+    absorbed row) and remaps the mentions, but left the merge_log pointing at the
+    dissolved ``nar:`` node — an orphaned reference (da#313). This routes each
+    absorbed ``canonical_id`` to the SAME survivor the mention now belongs to, so
+    the audit log stays join-consistent with the canonical set. It is identity
+    routing, not a filter: no row is dropped. Streams row-group by row-group,
+    preserving the on-disk schema; idempotent and bounded-memory. Returns the count
+    of rows remapped.
+    """
+    if not remap or not merge_log_path.exists():
+        return 0
+
+    pf = pq.ParquetFile(merge_log_path)
+    schema = pf.schema_arrow
+    id_idx = schema.get_field_index("canonical_id")
+    if id_idx < 0:
+        return 0
+    tmp_path = merge_log_path.with_name(merge_log_path.name + ".cluster.tmp")
+    writer = pq.ParquetWriter(tmp_path, schema, compression="snappy")
+    remapped = 0
+    try:
+        for rg_idx in range(pf.metadata.num_row_groups):
+            table = pf.read_row_group(rg_idx).cast(schema)
+            ids = table.column("canonical_id").to_pylist()
+            new_ids: list[str | None] = []
+            for cid in ids:
+                target = remap.get(cid) if cid is not None else None
+                if target is not None and target != cid:
+                    new_ids.append(target)
+                    remapped += 1
+                else:
+                    new_ids.append(cid)
+            # Preserve the on-disk field (canonical_id is non-nullable) — a bare
+            # column name would relax it to nullable and reject the write.
+            table = table.set_column(
+                id_idx, schema.field(id_idx), pa.array(new_ids, type=pa.string())
+            )
+            writer.write_table(table)
+    finally:
+        writer.close()
+
+    tmp_path.replace(merge_log_path)
+    logger.info("cluster_merge_log_remapped", path=str(merge_log_path), remapped=remapped)
+    return remapped
+
+
 def cluster_canonical_narrators(
     canonical_path: Path,
     *,
     mentions_path: Path | None = None,
+    merge_log_path: Path | None = None,
     threshold: float = _CLUSTER_RATIO_THRESHOLD,
     max_block_size: int | None = _DEFAULT_MAX_BLOCK_SIZE,
     staging_dir: Path | None = None,
@@ -1306,6 +1366,12 @@ def cluster_canonical_narrators(
     remapped = (
         _remap_mention_canonical_ids(mentions_path, remap) if mentions_path is not None else 0
     )
+    # da#313: the same absorbed→survivor remap MUST also be applied to the audit
+    # log, or merge_log rows keep referencing the dissolved nar: node the mentions
+    # were just moved off of. Symmetric with the mentions remap above.
+    merge_log_remapped = (
+        _remap_merge_log_canonical_ids(merge_log_path, remap) if merge_log_path is not None else 0
+    )
 
     metrics = ClusterMetrics(
         input_records=len(records),
@@ -1314,6 +1380,7 @@ def cluster_canonical_narrators(
         multi_member_clusters=multi_member,
         cross_source_clusters=cross_source,
         mentions_remapped=remapped,
+        merge_log_remapped=merge_log_remapped,
         unblockable_records=count_unblockable(records),
     )
     logger.info("cluster_canonical_complete", summary=metrics.summary())

--- a/tests/test_resolve/test_fuzzy_cluster.py
+++ b/tests/test_resolve/test_fuzzy_cluster.py
@@ -23,6 +23,7 @@ from rapidfuzz import fuzz
 from src.models.enums import DatePrecision
 from src.parse.identity import make_canonical_id
 from src.resolve import fuzzy_cluster as fc
+from src.resolve.disambiguate import _MERGE_LOG_SCHEMA
 from src.resolve.fuzzy_cluster import (
     _match_keys,
     cluster_assignment,
@@ -273,6 +274,75 @@ def test_mentions_remapped_to_survivor(tmp_path: Path) -> None:
     got = {r["mention_id"]: r["canonical_narrator_id"] for r in pq.read_table(mentions).to_pylist()}
     assert got["m1"] == survivor_id  # absorbed → survivor
     assert got["m2"] == survivor_id  # already on survivor — untouched
+
+
+def _build_cluster_fixture(out_dir: Path) -> tuple[Path, Path, str, str]:
+    """A two-record canonical set (``var`` absorbed into ``rep``) plus a merge_log
+    with one row on the absorbed id and one on the survivor. Returns the canonical
+    path, merge_log path, absorbed id and survivor id."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rep = _rec("محمد بن اسماعيل البخاري", source_corpora=["itqan"], mention_count=10)
+    var = _rec("محمد بن اسماعيل", source_corpora=["sanadset"], mention_count=2)
+    survivor_id = make_canonical_id(normalize_arabic("محمد بن اسماعيل البخاري"))
+    absorbed_id = var["canonical_id"]
+
+    canonical = out_dir / "narrators_canonical.parquet"
+    _write_canonical(canonical, [rep, var])
+
+    merge_log = out_dir / "merge_log.parquet"
+    log_rows = {
+        "canonical_id": [absorbed_id, survivor_id],
+        "mention_id": ["m1", "m2"],
+        "mention_text": ["محمد بن اسماعيل", "محمد بن اسماعيل البخاري"],
+        "merge_stage": ["fuzzy", "exact"],
+        "score": [0.95, 1.0],
+    }
+    pq.write_table(pa.table(log_rows, schema=_MERGE_LOG_SCHEMA), merge_log)
+    return canonical, merge_log, absorbed_id, survivor_id
+
+
+def _merge_log_orphans(canonical: Path, merge_log: Path) -> list[str]:
+    live = set(pq.read_table(canonical).column("canonical_id").to_pylist())
+    return [c for c in pq.read_table(merge_log).column("canonical_id").to_pylist() if c not in live]
+
+
+def test_merge_log_orphaned_without_remap(tmp_path: Path) -> None:
+    """Control (da#313 red witness): clustering that rewrites the canonical set but
+    is NOT told about the merge_log leaves the absorbed id dangling in the log."""
+    canonical, merge_log, absorbed_id, _survivor = _build_cluster_fixture(tmp_path / "curated")
+
+    cluster_canonical_narrators(canonical)  # merge_log_path omitted
+
+    orphans = _merge_log_orphans(canonical, merge_log)
+    assert orphans == [absorbed_id]  # the absorbed id no longer exists as a canonical node
+
+
+def test_merge_log_remapped_to_survivor(tmp_path: Path) -> None:
+    """da#313: passing ``merge_log_path`` routes every absorbed id to its cluster
+    survivor, so no merge_log row references a dissolved node — and no row is
+    dropped (identity routing, not a silent filter)."""
+    canonical, merge_log, absorbed_id, survivor_id = _build_cluster_fixture(tmp_path / "curated")
+
+    metrics = cluster_canonical_narrators(canonical, merge_log_path=merge_log)
+    assert metrics.merge_log_remapped == 1
+
+    rows = pq.read_table(merge_log).to_pylist()
+    assert len(rows) == 2  # both rows preserved — nothing filtered
+    by_mention = {r["mention_id"]: r["canonical_id"] for r in rows}
+    assert by_mention["m1"] == survivor_id  # absorbed → survivor
+    assert by_mention["m2"] == survivor_id  # already on survivor — untouched
+    assert _merge_log_orphans(canonical, merge_log) == []
+    assert absorbed_id not in by_mention.values()
+
+
+def test_merge_log_remap_is_idempotent(tmp_path: Path) -> None:
+    """A second clustering pass over the already-collapsed set remaps nothing."""
+    canonical, merge_log, _absorbed, _survivor = _build_cluster_fixture(tmp_path / "curated")
+
+    cluster_canonical_narrators(canonical, merge_log_path=merge_log)
+    second = cluster_canonical_narrators(canonical, merge_log_path=merge_log)
+    assert second.merge_log_remapped == 0
+    assert _merge_log_orphans(canonical, merge_log) == []
 
 
 def test_empty_and_missing_inputs_are_noops(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

`fuzzy_cluster.cluster_canonical_narrators` collapses cross-source name variants into a survivor record — it rewrites `narrators_canonical.parquet` (dropping the absorbed rows) and remaps the **mention** rows so NARRATED edges follow the merge. It never applied that same absorbed→survivor remap to **`merge_log.parquet`**, so every merge_log row keyed on an absorbed `canonical_id` (da#356 records one row per bio-matched mention) was left referencing a `nar:` node the loader no longer creates — an **orphaned canonical_id**.

This is the da#313 orphan mechanism, re-measured at HEAD. The issue's original count (211,619) predates da#356/#376/#371 re-minting every `nar:` id, so the number is superseded; the **mechanism** is what's fixed here.

## Root cause

`cluster_canonical_narrators` builds `remap: absorbed_id → survivor_id`, calls `_remap_mention_canonical_ids(mentions_path, remap)`, but had no equivalent for the merge_log. Absorbed ids vanish from the rewritten canonical table → merge_log dangles.

## Fix

- `_remap_merge_log_canonical_ids` — mirrors `_remap_mention_canonical_ids` exactly: streams row-group by row-group, routes each absorbed `canonical_id` in merge_log to its cluster survivor, preserving the on-disk non-nullable `canonical_id` field. **Identity routing, not a filter — no row is dropped.**
- `cluster_canonical_narrators` gains optional `merge_log_path`; `run_all` passes `merge_log.parquet` when present.
- `ClusterMetrics.merge_log_remapped` reports the count.

## Red-first evidence

On a fixture where `محمد بن اسماعيل` is absorbed into `محمد بن اسماعيل البخاري`:

| | merge_log canonical_ids | orphans vs canonical |
|---|---|---|
| current code (no `merge_log_path`) | `[absorbed, survivor]` | **1** |
| after fix (`merge_log_path` passed) | `[survivor, survivor]` | **0** (`merge_log_remapped=1`, 2 rows preserved) |

## Tests (`tests/test_resolve/test_fuzzy_cluster.py`)

- `test_merge_log_orphaned_without_remap` — red witness / control: clustering that omits `merge_log_path` leaves the absorbed id dangling.
- `test_merge_log_remapped_to_survivor` — absorbed→survivor; control row already on the survivor untouched; both rows preserved; zero orphans.
- `test_merge_log_remap_is_idempotent` — a second pass over the collapsed set remaps nothing.

Full `tests/test_resolve/` green (486 passed, 6 skipped); ruff + mypy clean.

## Note on the downstream scrub

`scripts/scrub_matn_canonical.py` already *drops* merge_log rows whose canonical_id no longer survives (da#311/#312) — a post-hoc mitigation. This PR fixes the root cause upstream, so the scrub finds nothing to drop.

Closes #313
