### PR TITLE
fix(resolve): scrub bare relational-pronoun deixis from the alias list (da#391)

### DIFF
--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -156,6 +156,7 @@ __all__ = [
     "clean_narrator_name_display",
     "asserted_name_tokens",
     "cleaner_removed_content",
+    "is_mubham_relational",
     "split_compound_narrators",
     "strip_markup",
 ]
@@ -326,6 +327,28 @@ _MUBHAM_RELATIONAL = frozenset(
         "زوجته",  # his wife          "زوجها" his/her spouse
         "زوجها",
         "عنه",  # "from him" — transmission particle, never a name
+        # da#391: the 1st-person-possessive (``-ي``) and vocative (``-اه``) kinship
+        # forms. The set above is exhaustively 3rd-person ("his/her …") plus the bare
+        # 1st-masc ``ابي``; a mention/alias phrased in the narrator's OWN voice
+        # ("امتاه" = "O mother!", "عمتي" = "my aunt", "جدي" = "my grandfather") is the
+        # same unnamed-relation reference and equally never a proper ism. Closed,
+        # kinship-only — no name adjudication. Attested as surviving aliases on the
+        # curated set (``عمتي``/``امتاه`` on the ʿĀʾisha chimera; ``جدي``×91, ``عمي``×32).
+        "امي",  # my mother
+        "ابني",  # my son            "ابنتي"/"بنتي" my daughter
+        "ابنتي",
+        "بنتي",
+        "جدي",  # my grandfather     "جدتي" my grandmother
+        "جدتي",
+        "اخي",  # my brother         "اختي" my sister
+        "اختي",
+        "عمي",  # my paternal uncle  "عمتي" my paternal aunt
+        "عمتي",
+        "خالي",  # my maternal uncle "خالتي" my maternal aunt
+        "خالتي",
+        "امتاه",  # O mother! (vocative) "اماه" variant
+        "اماه",
+        "ابتاه",  # O father! (vocative)
     }
 )
 
@@ -1367,6 +1390,27 @@ def _tokenize_and_strip_affixes(text: str) -> tuple[list[str], list[str], bool]:
             tokens.pop(0)
             raw_tokens.pop(0)
     return raw_tokens, tokens, stripped_number
+
+
+def is_mubham_relational(name_normalized: str | None) -> bool:
+    """True when the WHOLE name is a single bare relational-pronoun (mubham) token.
+
+    "his father", "my aunt", "O mother!" — an unnamed-relation reference, never a
+    person. This is exactly the drop :func:`clean_narrator_name` step 6 already applies
+    at NER/bio time; it is exposed so the resolve **alias-union** sites can apply the
+    SAME drop to the ``aliases`` ``list<string>`` — the field ``clean_narrator_name``
+    never reaches, and the da#391 blind spot (a relational deixis surviving as an alias
+    of a real narrator, so any alias lookup resolves the wrong person).
+
+    Normalizes internally (``normalize_arabic`` is idempotent) so a raw or already-
+    normalized alias both resolve. The single-token guard is the precision boundary:
+    a real multi-token kunya (``"ابي اسحاق"`` = Abū Isḥāq) returns ``False``, and the
+    lexicon is kinship-only, so no real single-token ism is ever matched.
+    """
+    if not name_normalized:
+        return False
+    tokens = normalize_arabic(name_normalized).split()
+    return len(tokens) == 1 and tokens[0] in _MUBHAM_RELATIONAL
 
 
 def clean_narrator_name(name_normalized: str | None) -> str | None:

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -28,7 +28,11 @@ import pyarrow.parquet as pq
 from src.models.enums import DatePrecision
 from src.parse.base import safe_str, write_parquet
 from src.parse.identity import make_canonical_id
-from src.parse.name_quality import clean_narrator_name, cleaner_removed_content
+from src.parse.name_quality import (
+    clean_narrator_name,
+    cleaner_removed_content,
+    is_mubham_relational,
+)
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
 from src.resolve.sect_affiliation import (
     derive_sect_affiliation,
@@ -59,11 +63,14 @@ class _AliasMergeStats(NamedTuple):
 
     Every alias row lands in exactly one bucket, so
     ``added + skipped_duplicate + skipped_empty + skipped_source +
-    unmatched_pollution + unmatched_no_bio`` equals the alias-row count — no alias
-    is ever silently dropped again. ``unmatched_pollution`` (the alias's bio was
-    itself cleaner-dropped, so no canonical node was minted to anchor to) and
-    ``skipped_source`` are *explained* non-attachments; ``unmatched_no_bio`` is the
-    one that warrants a look and is logged at warning level when non-zero.
+    skipped_deixis + unmatched_pollution + unmatched_no_bio`` equals the alias-row
+    count — no alias is ever silently dropped again. ``unmatched_pollution`` (the
+    alias's bio was itself cleaner-dropped, so no canonical node was minted to anchor
+    to) and ``skipped_source`` are *explained* non-attachments; ``skipped_deixis``
+    (da#391 — the alias is a bare relational-pronoun, "خالته"/"عمتي"/"امتاه", the same
+    unnamed-relation deixis the cleaner drops from a NAME) is the alias-list analogue
+    of that pollution drop; ``unmatched_no_bio`` is the one that warrants a look and
+    is logged at warning level when non-zero.
     """
 
     added: int
@@ -72,6 +79,7 @@ class _AliasMergeStats(NamedTuple):
     skipped_source: int
     skipped_duplicate: int
     skipped_empty: int
+    skipped_deixis: int
 
 
 def _load_existing_canonical(path: Path) -> dict[str, dict[str, Any]]:
@@ -127,6 +135,7 @@ def _merge_aliases(
     skipped_source = 0
     skipped_duplicate = 0
     skipped_empty = 0
+    skipped_deixis = 0
     for af in alias_files:
         for row in pq.read_table(af).to_pylist():
             if sources is not None and safe_str(row.get("source")) not in sources:
@@ -136,6 +145,14 @@ def _merge_aliases(
             variant = safe_str(row.get("alias_normalized"))
             if not norm or not variant:
                 skipped_empty += 1
+                continue
+            # da#391: a bare relational-pronoun variant ("خالته"/"عمتي"/"امتاه") is the
+            # unnamed-relation deixis clean_narrator_name drops from a NAME; the aliases
+            # list<string> is the blind spot it never reaches (the third and final
+            # alias-union site, alongside disambiguate + fuzzy_cluster). Drop it here,
+            # accounted, so it cannot survive as an alias of a real narrator.
+            if is_mubham_relational(variant):
+                skipped_deixis += 1
                 continue
             # Re-key on the cleaned form the promoter minted the node under (da#389).
             cleaned = clean_narrator_name(norm)
@@ -165,6 +182,7 @@ def _merge_aliases(
         skipped_source=skipped_source,
         skipped_duplicate=skipped_duplicate,
         skipped_empty=skipped_empty,
+        skipped_deixis=skipped_deixis,
     )
 
 
@@ -379,5 +397,6 @@ def promote_bios_to_canonical(
         aliases_skipped_source=alias_stats.skipped_source,
         aliases_skipped_duplicate=alias_stats.skipped_duplicate,
         aliases_skipped_empty=alias_stats.skipped_empty,
+        aliases_skipped_deixis=alias_stats.skipped_deixis,
     )
     return canonical_path

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -26,6 +26,7 @@ from rapidfuzz.distance import Levenshtein
 from src.models.enums import DatePrecision
 from src.parse.base import safe_str, write_parquet
 from src.parse.identity import make_canonical_id
+from src.parse.name_quality import is_mubham_relational
 from src.resolve._checkpoint import (
     CheckpointController,
     checkpoint_dir,
@@ -1038,8 +1039,16 @@ def _upsert_canonical(
     # The mention's own surface, and (da#356) the matched bio's spelling, both stay
     # searchable as aliases. Pre-fix the *correct* spelling was demoted to an alias
     # of a corrupt-bio-named node; now the corrupt spelling is the alias.
+    # da#391: a bare relational-pronoun surface ("خالته"/"عمتي"/"امتاه") is dropped
+    # here — clean_narrator_name already drops it from the NAME at NER time, but the
+    # aliases list<string> is the blind spot it never reaches, so the deixis survives
+    # as an alias of a real narrator. Same closed kinship lexicon, no name adjudication.
     for candidate_alias in (alias, bio_alias):
-        if candidate_alias and candidate_alias != norm_name:
+        if (
+            candidate_alias
+            and candidate_alias != norm_name
+            and not is_mubham_relational(candidate_alias)
+        ):
             aliases = rec.get("aliases")
             if isinstance(aliases, list) and candidate_alias not in aliases:
                 aliases.append(candidate_alias)

--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -79,6 +79,7 @@ from rapidfuzz import fuzz, process
 from src.models.enums import DatePrecision
 from src.parse.base import safe_str, write_parquet
 from src.parse.identity import make_canonical_id
+from src.parse.name_quality import is_mubham_relational
 from src.resolve._checkpoint import (
     CheckpointController,
     checkpoint_dir,
@@ -1146,12 +1147,20 @@ def _merge_cluster(members: list[dict[str, Any]]) -> dict[str, Any]:
                 merged[field_name] = rec.get(field_name)
 
         # A non-representative spelling becomes an alias; carry existing aliases.
+        # da#391: skip a bare relational-pronoun surface ("خالته"/"عمتي"/"امتاه") —
+        # the aliases list<string> is the blind spot clean_narrator_name never reaches,
+        # so the deixis would otherwise survive as an alias of a real narrator.
         rec_norm = safe_str(rec.get("name_ar_normalized"))
-        if rec_norm and rec_norm != rep_norm and rec_norm not in aliases:
+        if (
+            rec_norm
+            and rec_norm != rep_norm
+            and rec_norm not in aliases
+            and not is_mubham_relational(rec_norm)
+        ):
             aliases.append(rec_norm)
         for a in rec.get("aliases") or []:
             av = safe_str(a)
-            if av and av != rep_norm and av not in aliases:
+            if av and av != rep_norm and av not in aliases and not is_mubham_relational(av):
                 aliases.append(av)
 
     merged["aliases"] = aliases

--- a/tests/test_parse/test_name_quality.py
+++ b/tests/test_parse/test_name_quality.py
@@ -7,10 +7,56 @@ import pytest
 from src.parse.name_quality import (
     clean_narrator_name,
     clean_narrator_name_display,
+    is_mubham_relational,
     split_compound_narrators,
     strip_markup,
 )
 from src.utils.arabic import normalize_arabic
+
+
+class TestIsMubhamRelational:
+    """The da#391 alias-list scrub predicate — exposes the step-6 bare-relational
+    drop so the resolve alias-union sites can apply the SAME lexicon to the
+    ``aliases`` ``list<string>`` the cleaner never reaches."""
+
+    # 3rd-person forms already in the lexicon + the da#391 1st-person/vocative set.
+    @pytest.mark.parametrize(
+        "deixis",
+        [
+            "ابيه",  # his father
+            "خالته",  # his maternal aunt
+            "عمته",  # his paternal aunt
+            # da#391 1st-person possessive (-ي) and vocative (-اه) additions
+            "عمتي",  # my paternal aunt (survived on the ʿĀʾisha chimera)
+            "امتاه",  # O mother! (survived on the ʿĀʾisha chimera)
+            "جدي",  # my grandfather
+            "عمي",  # my paternal uncle
+            "خالتي",  # my maternal aunt
+            "اماه",  # O mother! (variant)
+            "ابتاه",  # O father!
+            # normalization is applied internally — a diacritized surface still matches
+            "خَالَتُهُ",
+        ],
+    )
+    def test_bare_relational_is_mubham(self, deixis: str) -> None:
+        assert is_mubham_relational(deixis) is True
+
+    # PRECISION: the single-token boundary — a real multi-token kunya that merely
+    # CONTAINS a relational token, a real ism, and empty input are never mubham.
+    @pytest.mark.parametrize(
+        "not_deixis",
+        [
+            "ابي اسحاق",  # Abū Isḥāq — real narrator, not "my father"
+            "عاءشه بنت سعد",  # a real nasab
+            "عاءشه",  # a real ism
+            "هشام",  # a real (male) ism
+            "سعد",
+            "",
+            None,
+        ],
+    )
+    def test_real_name_or_empty_is_not_mubham(self, not_deixis: str | None) -> None:
+        assert is_mubham_relational(not_deixis) is False
 
 
 class TestStripMarkup:

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -1032,6 +1032,73 @@ def test_merge_aliases_counts_recovered_and_pollution_dropped(tmp_path: Path) ->
     assert canonical_map[cid_635]["aliases"] == [normalize_arabic(_ITQAN_635_ALIAS)]
 
 
+def test_merge_aliases_drops_bare_relational_deixis(tmp_path: Path) -> None:
+    """da#391: a bare relational-pronoun alias ("عمتي" = "my aunt") never attaches.
+
+    The alias-list is the blind spot ``clean_narrator_name`` never reaches: the same
+    unnamed-relation deixis it drops from a NAME would otherwise survive as an alias of
+    a real narrator (on the ʿĀʾisha chimera: ``امتاه``/``خالته``/``عمتي``). It is dropped
+    here, ACCOUNTED as ``skipped_deixis`` (not silent), and the sum-invariant holds.
+    RED on pre-da#391 code: the variant is appended raw and ``skipped_deixis`` does not
+    exist. A legitimate co-anchored variant on the SAME node still attaches, proving the
+    scrub is surgical.
+    """
+    from src.resolve.bio_promote import _AliasMergeStats, _merge_aliases
+
+    staging = tmp_path / "staging"
+    staging.mkdir()
+
+    real_variant = normalize_arabic(_ITQAN_635_ALIAS)
+    anchor = normalize_arabic(_ITQAN_635_BIO_NAME)
+    _write_aliases(
+        staging,
+        "itqan",
+        [
+            # bare relational deixis → dropped, counted as skipped_deixis
+            {
+                "bio_id": "itqan:635",
+                "source": "itqan",
+                "canonical_name_ar_normalized": anchor,
+                "alias": "عمتي",
+                "alias_normalized": normalize_arabic("عمتي"),
+            },
+            # a real co-anchored variant on the same node still attaches
+            {
+                "bio_id": "itqan:635",
+                "source": "itqan",
+                "canonical_name_ar_normalized": anchor,
+                "alias": _ITQAN_635_ALIAS,
+                "alias_normalized": real_variant,
+            },
+        ],
+    )
+
+    cleaned_635 = clean_narrator_name(anchor)
+    assert cleaned_635 is not None
+    cid_635 = make_canonical_id(cleaned_635)
+    canonical_map: dict[str, dict[str, Any]] = {
+        cid_635: {"canonical_id": cid_635, "name_ar_normalized": cleaned_635, "aliases": []}
+    }
+
+    stats = _merge_aliases(staging, canonical_map, {cid_635}, sources={"itqan"})
+    assert isinstance(stats, _AliasMergeStats)
+    assert stats.skipped_deixis == 1
+    assert stats.added == 1
+    # the deixis token is gone; only the real variant remains on the node
+    assert canonical_map[cid_635]["aliases"] == [real_variant]
+    # sum-invariant: every one of the 2 alias rows lands in exactly one bucket
+    total = (
+        stats.added
+        + stats.skipped_duplicate
+        + stats.skipped_empty
+        + stats.skipped_source
+        + stats.skipped_deixis
+        + stats.unmatched_pollution
+        + stats.unmatched_no_bio
+    )
+    assert total == 2
+
+
 def test_unmatched_no_bio_is_counted_and_warns(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_resolve/test_disambiguate.py
+++ b/tests/test_resolve/test_disambiguate.py
@@ -21,6 +21,7 @@ from src.resolve.disambiguate import (
     _geographic_filter,
     _make_canonical_id,
     _temporal_filter,
+    _upsert_canonical,
 )
 
 
@@ -426,3 +427,27 @@ class TestCrossrefMatchBlocked:
         index = _build_blocking_index(candidates)
         matches = _crossref_match_blocked("", index)
         assert matches == []
+
+
+class TestUpsertAliasDeixisScrub:
+    """da#391: the mention/bio alias-union in ``_upsert_canonical`` never appends a
+    bare relational-pronoun. The ``aliases`` ``list<string>`` is the blind spot
+    ``clean_narrator_name`` never reaches; a deixis surface ("خالته") would otherwise
+    become a searchable alias of a real narrator. A real bio_alias still attaches."""
+
+    def test_bare_relational_alias_is_not_appended(self) -> None:
+        canonical_map: dict[str, dict[str, str | int | list[str] | None]] = {}
+        cid = _make_canonical_id("عاءشه بنت سعد")
+        _upsert_canonical(
+            canonical_map,
+            cid,
+            norm_name="عاءشه بنت سعد",
+            name_ar="عائشة بنت سعد",
+            name_en=None,
+            alias="خالته",  # خالته — his maternal aunt (deixis)
+            candidate=None,
+            bio_alias="عاءشه ابنه ابي بكر",  # real variant
+        )
+        aliases = canonical_map[cid]["aliases"]
+        assert aliases == ["عاءشه ابنه ابي بكر"]
+        assert "خالته" not in aliases  # deixis dropped

--- a/tests/test_resolve/test_fuzzy_cluster.py
+++ b/tests/test_resolve/test_fuzzy_cluster.py
@@ -218,6 +218,29 @@ def test_merged_record_routes_through_make_canonical_id(tmp_path: Path) -> None:
     assert merged["external_id"] == "320"
 
 
+def test_merge_cluster_drops_bare_relational_alias() -> None:
+    """da#391: the cluster alias-union never carries a bare relational-pronoun.
+
+    A member's own spelling and its existing aliases both become aliases of the
+    survivor — the ``list<string>`` blind spot ``clean_narrator_name`` never reaches.
+    A deixis token ("خالته") riding in a member's alias list, or as a member's whole
+    name, must not propagate into the merged aliases; a real variant spelling still
+    does. RED on pre-da#391 code: ``خالته`` is appended unconditionally.
+    """
+    rep = _rec("محمد بن اسماعيل البخاري", mention_count=10)
+    var = _rec(
+        "محمد بن اسماعيل",
+        mention_count=2,
+        aliases=[normalize_arabic("خالته"), normalize_arabic("محمد البخاري")],
+    )
+
+    merged = fc._merge_cluster([rep, var])
+
+    assert normalize_arabic("محمد بن اسماعيل") in merged["aliases"]  # real variant kept
+    assert normalize_arabic("محمد البخاري") in merged["aliases"]  # real alias kept
+    assert normalize_arabic("خالته") not in merged["aliases"]  # deixis dropped
+
+
 def test_clustering_is_idempotent(tmp_path: Path) -> None:
     """Re-running on an already-clustered table changes nothing."""
     a = _rec("احمد بن حنبل الشيباني", source_corpora=["itqan"], death_year_ah=241, mention_count=5)


### PR DESCRIPTION
## Summary

`Closes #391`. Zero-inference containment for the **relational-deixis-in-aliases** sub-defect of the ʿĀʾisha chimera (`nar:489a30cf` on the pre-fix artifact): the alias whose own form is `امتاه`/`خالته`/`عمتي` — an unnamed-relation reference the pipeline already drops from a NAME — survives as a searchable alias of a real narrator.

Root cause: `clean_narrator_name` drops a bare relational-pronoun from a name at NER/bio time, but the three alias-union sites append alias surfaces **raw**. The `aliases` `list<string>` is the blind spot the cleaner never reaches.

## Change (owner-approved scope)

- Expose `is_mubham_relational()` in `name_quality` — the existing step-6 whole-name drop, reusing the same `_MUBHAM_RELATIONAL` lexicon (single source of truth).
- Apply it at **all three** alias-union sites:
  - `disambiguate._upsert_canonical`
  - `fuzzy_cluster._merge_cluster`
  - `bio_promote._merge_aliases` — the da#94 itqan alias-table feed the issue traced; accounted as a new `skipped_deixis` bucket so the module's sum-invariant still holds (no silent drop).
- Extend the lexicon with the closed **1st-person-possessive (`-ي`) and vocative (`-اه`)** kinship forms the 3rd-person-only set missed (`عمتي`/`امتاه`/`جدي`/`عمي`/…). Closed, kinship-only — no name adjudication.

## Measurement + instrument control (#928 doctrine)

Measured on the **stale** curated artifact (129,234 nodes; it predates da#356/#376/#371, so these are the pre-fix defect shape, not a HEAD count):

- **Red-first:** 1,112 canonical nodes carry ≥1 bare-relational alias across 28 distinct tokens (1,593 alias-strings dropped) — a **class**, not a singleton, riding the top-mention nodes (`ابن عبس` mc=50,962; `عبد الله` mc=19,412; `مالك` mc=17,187 carry `ابيه`/`ابي`).
- **Separation control (proves the instrument):** the predicate strikes **only** whole single-token deixis — **0** multi-token hits — so a real kunya like `ابي اسحاق` is never touched.
- **Scope control:** the scrub is alias-only; the 9 nodes whose *own name* is a deixis token (a separate da#247 **NAME-level** residual) are left untouched — not created or worsened here.
- **Target:** the ʿĀʾisha cluster's 27 aliases → drops exactly `['امتاه','خالته','عمتي']`, keeps 24.

## Explicitly NOT in scope (deferred, per owner)

The other two sub-defects of #391 — **over-merge** (distinct persons folded onto one node; corpus-wide, e.g. `ابن عبس` absorbing `ابن عباس`) and **cross-gender absorption** (`هشام`) — are node-**identity** decisions (da#356/#376 crossref/fuzzy), not alias-list content. They cannot be un-merged by an alias scrub and must not be threshold-tuned. Their status is da#356/#376 **efficacy**, confirmable only by the gated re-run — deferred to that verification.

## Tests

Red-first unit tests at each of the 4 surfaces (pre-fix appends the deixis raw):
- `TestIsMubhamRelational` (predicate + precision boundary)
- `TestUpsertAliasDeixisScrub` (disambiguate)
- `test_merge_cluster_drops_bare_relational_alias` (fuzzy_cluster)
- `test_merge_aliases_drops_bare_relational_deixis` (bio_promote + sum-invariant)

Full affected suites (429), `ruff format --check`, `ruff check`, and `mypy --strict` all green; pre-push mypy + full pytest pass. Rebased onto current main (da#405 untracked the structural index, so it is no longer part of this diff).

Suggested reviewers: **Kavitha Sundaramurthy**, **Jean-Claude Habimana**.
