### PR TITLE
resolve(ner): explicit per-corpus routing for staged-but-unrouted corpora (da#365)

### DIFF
--- a/src/resolve/ner.py
+++ b/src/resolve/ner.py
@@ -41,31 +41,69 @@ _PHASE1_MENTION_SOURCES: dict[str, str] = {
 #
 # fawaz (da#271): extracted from its Arabic full text, NOT its English translation.
 # fawaz ships an empty ``isnad_raw_en``/``isnad_raw_ar`` but a fully-populated
-# voweled ``full_text_ar`` (the extractor falls back to full text when the isnad
-# column is empty). The old English path produced romanized names ("Anas bin
-# Malik") that never share canonical identity with the Arabic corpora — the da#271
-# cross-script under-merge — and, because the English "Narrated X:" pattern only
-# surfaces the lead companion, it recovered ~1 narrator/hadith versus the full
+# voweled ``full_text_ar`` (isnad+matn). The old English path produced romanized
+# names ("Anas bin Malik") that never share canonical identity with the Arabic
+# corpora -- the da#271 cross-script under-merge -- and, because the English
+# "Narrated X:" pattern only surfaces the lead companion, it recovered ~1
+# narrator/hadith versus the full
 # ~5-narrator Arabic chain. Extracting the Arabic text is strictly better than
 # transliterating Latin→Arabic (lossy: no short vowels, bin/ibn, apostrophes) or a
 # cross-script match-key hack: it yields genuinely Arabic names that merge natively
 # AND the complete isnad chain. (sunnah stays English below: its ``full_text_ar``
 # is a samāʿ/reading-certificate blob with biographical dates, not a clean isnad.)
-_ARABIC_SOURCES: set[str] = {"thaqalayn", "open_hadith", "fawaz"}
+#
+# NOTE (da#369): the full_text fallback that once mined fawaz's empty-isnad blob
+# is removed, so fawaz currently yields 0 mentions; it stays routed here (not an
+# unrouted hard-fail) pending the same da#366 isnad/matn split the
+# _SPLITTER_DEFERRED_SOURCES corpora below await.
+#
+# tusi (da#365): a pure routing miss -- ships a fully separated ``isnad_raw_ar``
+# (17,089 of 17,421 rows, 98.1%; ~99% carry a transmission phrase, 100% segment
+# cleanly), yet was in no route set and so contributed 0 mentions. It needs no
+# splitter -- extracted straight from its isnad column like any Arabic corpus. Its
+# ~332 null-isnad rows hit the da#369 null-skip, never the removed matn mine.
+_ARABIC_SOURCES: set[str] = {"thaqalayn", "open_hadith", "fawaz", "tusi"}
 
 # Sources with English text needing keyword-based extraction.
 _ENGLISH_SOURCES: set[str] = {"sunnah"}
 
-# Sources to skip entirely (no raw isnads).
-_SKIP_SOURCES: set[str] = {"muhaddithat"}
+# Sources whose isnad chains are embedded INSIDE ``full_text_ar`` with no separate
+# ``isnad_raw_ar`` column (halimbahae and bihar are both 100% null-isnad yet
+# isnad-bearing in full_text). They CANNOT be extracted until a validated
+# isnad/matn splitter (da#366) lands: routing them through NER today extracts
+# nothing (null isnad column), and reinstating the removed full_text fallback would
+# re-import the matn pollution da#369 deleted (main#352). They are EXPLICITLY routed
+# to this deferred bucket -- not left unrouted -- so the da#369 hard-fail does not
+# fire on a known-held corpus, while a *genuinely* unrouted corpus (in no bucket at
+# all) still fails loud. They contribute 0 mentions until da#366: better silent-but-
+# declared than matn-polluted (#928). The value is the issue blocking each corpus.
+_SPLITTER_DEFERRED_SOURCES: dict[str, str] = {
+    "halimbahae": "da#366",
+    "bihar": "da#366",
+}
+
+# Sources to skip entirely -- no isnad chain is reachable via NER over hadith rows.
+#   muhaddithat: bio/network data only, no raw isnads.
+#   mis (da#365): its ``hadiths_mis.parquet`` rows carry a null ``isnad_raw_ar`` and
+#     no ``full_text_ar``; mis's transmission chains are staged separately as
+#     ``network_edges_mis.parquet`` and loaded on their own path (da#364), never
+#     mined from raw isnad text here. Routed to skip (not unrouted) so the da#369
+#     hard-fail does not fire; it contributes 0 NER mentions by construction.
+_SKIP_SOURCES: set[str] = {"muhaddithat", "mis"}
 
 # The union of every corpus with an explicit NER route. A staged corpus outside
 # this set has no way to have its narrators extracted and MUST fail loud (da#369)
 # rather than be silently dropped or (pre-da#369) matn-mined via the removed
-# full_text fallback. da#365 layers the correct per-corpus routing on top of this
-# guard; the guard is what makes an unrouted corpus impossible to miss until then.
+# full_text fallback. da#365 completes the routing: every corpus that stages a
+# globbed NER input (hadiths_* / narrator_mentions_*) now declares a route --
+# extract (phase1 / arabic / english), splitter-deferred, or skip. A brand-new
+# staged corpus in none of these buckets still trips the guard.
 _ROUTED_CORPORA: frozenset[str] = frozenset(
-    set(_PHASE1_MENTION_SOURCES) | _ARABIC_SOURCES | _ENGLISH_SOURCES | _SKIP_SOURCES
+    set(_PHASE1_MENTION_SOURCES)
+    | _ARABIC_SOURCES
+    | _ENGLISH_SOURCES
+    | set(_SPLITTER_DEFERRED_SOURCES)
+    | _SKIP_SOURCES
 )
 
 
@@ -95,8 +133,9 @@ class UnroutedCorpusError(BaseException):
         super().__init__(
             f"staged corpora with no NER extraction route: {self.unrouted}. "
             f"Routed corpora: {self.routed}. Every staged corpus must be explicitly "
-            "opted in to a NER route (phase1 / arabic / english) or the skip list "
-            "(add per-corpus routing — da#365). NER never falls back to mining "
+            "opted in to a NER route (phase1 / arabic / english), the "
+            "splitter-deferred bucket (da#366), or the skip list — add a "
+            "per-corpus route (da#365). NER never falls back to mining "
             "full_text_ar (matn) for an unrouted or isnad-null corpus (da#369)."
         )
 
@@ -348,11 +387,22 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
         rows = _extract_from_hadiths(staging_dir, corpus, language="en")
         all_rows.extend(rows)
 
-    # Step 4: Log skipped sources.
+    # Step 4: Log deferred sources -- isnad-in-matn corpora explicitly held until
+    # the da#366 splitter lands. Routed (no hard-fail) but not extracted; logged
+    # loudly so their absence from the graph is visible, never a silent omission.
+    for corpus, blocked_on in sorted(_SPLITTER_DEFERRED_SOURCES.items()):
+        logger.info(
+            "ner_deferred_source",
+            corpus=corpus,
+            blocked_on=blocked_on,
+            reason="isnad_in_matn_needs_splitter",
+        )
+
+    # Step 5: Log skipped sources.
     for corpus in sorted(_SKIP_SOURCES):
         logger.info("ner_skip_source", corpus=corpus, reason="no_raw_isnads")
 
-    # Step 5: Per-source metrics summary.
+    # Step 6: Per-source metrics summary.
     source_counts: dict[str, int] = {}
     for r in all_rows:
         src = str(r["source_corpus"])
@@ -361,7 +411,7 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
         logger.info("ner_source_summary", source_corpus=src, total_mentions=count)
     logger.info("ner_total_mentions", total=len(all_rows))
 
-    # Step 6: Build output table.
+    # Step 7: Build output table.
     output_paths: list[Path] = []
 
     if all_rows:
@@ -389,7 +439,7 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
     else:
         logger.warning("ner_no_mentions", msg="No narrator mentions extracted from any source")
 
-    # Step 7: Name audit CSV.
+    # Step 8: Name audit CSV.
     if all_rows:
         audit_path = _write_name_audit_csv(all_rows, output_dir)
         output_paths.append(audit_path)

--- a/tests/test_resolve/test_ner.py
+++ b/tests/test_resolve/test_ner.py
@@ -481,21 +481,23 @@ class TestUnroutedCorpusHardFail:
         }
 
     def test_unrouted_staged_corpus_raises(self, tmp_path: Path) -> None:
-        """RED-FIRST: 'bihar' is a valid SourceCorpus with no NER route. Staged,
-        it must raise rather than be silently dropped. Pre-da#369 run() only ever
-        iterated the fixed route sets, so a bihar hadiths file was ignored with no
-        error (and, for a routed-but-isnad-null corpus, silently matn-mined)."""
+        """RED-FIRST: a staged corpus in NO route bucket must raise rather than be
+        silently dropped. Pre-da#369 run() only iterated the fixed route sets, so an
+        unrouted hadiths file was ignored with no error (and, for a routed-but-isnad-
+        null corpus, silently matn-mined). da#365 routed the four real offenders
+        (tusi / halimbahae / bihar / mis), so this uses a synthetic corpus name that
+        is in no bucket -- the contract must hold for any future unclassified corpus."""
         staging = tmp_path / "staging"
         staging.mkdir()
         output = tmp_path / "output"
         output.mkdir()
         write_hadiths(
-            staging / "hadiths_bihar.parquet",
-            [self._hadith("bihar", "حدثنا محمد عن علي")],
+            staging / "hadiths_uncharted.parquet",
+            [self._hadith("uncharted_corpus", "حدثنا محمد عن علي")],
         )
         with pytest.raises(UnroutedCorpusError) as excinfo:
             run(staging, output)
-        assert "bihar" in excinfo.value.unrouted
+        assert "uncharted_corpus" in excinfo.value.unrouted
         # The hard-fail fires before any mention output is written.
         assert not (output / "narrator_mentions_resolved.parquet").exists()
 
@@ -519,3 +521,131 @@ class TestUnroutedCorpusHardFail:
         # Must not raise; a routed corpus with a real isnad produces mentions.
         paths = run(staging, output)
         assert (output / "narrator_mentions_resolved.parquet") in paths
+
+
+# ---------------------------------------------------------------------------
+# Tests: per-corpus routing (da#365)
+# ---------------------------------------------------------------------------
+class TestPerCorpusRouting:
+    """da#365: every staged corpus that produces a globbed NER input declares an
+    explicit route, layered on top of da#369's unrouted-corpus hard-fail. The four
+    corpora that were staged-but-routed-nowhere (tusi / halimbahae / bihar / mis)
+    each get their correct destination: tusi -> Arabic extraction (real isnad
+    column); halimbahae + bihar -> splitter-deferred (isnad-in-matn, held for
+    da#366); mis -> skip (chains come from network_edges_mis.parquet, da#364)."""
+
+    @staticmethod
+    def _hadith(
+        source_corpus: str,
+        *,
+        isnad_ar: str | None = None,
+        full_text_ar: str | None = None,
+    ) -> dict:
+        return {
+            "source_id": f"{source_corpus}-1",
+            "source_corpus": source_corpus,
+            "collection_name": f"{source_corpus}-collection",
+            "isnad_raw_ar": isnad_ar,
+            "isnad_raw_en": None,
+            "full_text_ar": full_text_ar,
+            "full_text_en": None,
+            "matn_ar": None,
+            "matn_en": None,
+            "grade": None,
+            "sect": "shia",
+            "book_number": 1,
+            "chapter_number": 1,
+            "hadith_number": 1,
+            "chapter_name_ar": None,
+            "chapter_name_en": None,
+        }
+
+    # -- tusi: pure routing miss, real isnad column -> Arabic extraction ------
+    def test_tusi_routed_to_arabic(self) -> None:
+        from src.resolve.ner import _ARABIC_SOURCES
+
+        assert "tusi" in _ARABIC_SOURCES
+
+    def test_tusi_isnad_extracted_end_to_end(self, tmp_path: Path) -> None:
+        """RED-FIRST: before da#365, tusi was in no route set, so run() raised
+        UnroutedCorpusError and tusi's 17,089 real isnads yielded 0 mentions. Now a
+        staged tusi hadith with a populated isnad_raw_ar extracts through run()."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        output = tmp_path / "output"
+        output.mkdir()
+        write_hadiths(
+            staging / "hadiths_tusi.parquet",
+            [self._hadith("tusi", isnad_ar="حدثنا محمد عن علي")],
+        )
+        paths = run(staging, output)
+        resolved = output / "narrator_mentions_resolved.parquet"
+        assert resolved in paths
+        corpora = set(pq.read_table(resolved).column("source_corpus").to_pylist())
+        assert "tusi" in corpora
+
+    # -- halimbahae / bihar: isnad-in-matn, deferred pending da#366 -----------
+    def test_halimbahae_and_bihar_deferred_not_force_routed(self) -> None:
+        from src.resolve.ner import (
+            _ARABIC_SOURCES,
+            _ENGLISH_SOURCES,
+            _SPLITTER_DEFERRED_SOURCES,
+        )
+
+        assert "halimbahae" in _SPLITTER_DEFERRED_SOURCES
+        assert "bihar" in _SPLITTER_DEFERRED_SOURCES
+        # NOT force-routed into extraction on their null-isnad rows.
+        for corpus in ("halimbahae", "bihar"):
+            assert corpus not in _ARABIC_SOURCES
+            assert corpus not in _ENGLISH_SOURCES
+
+    def test_deferred_corpus_not_matn_mined_and_does_not_raise(self, tmp_path: Path) -> None:
+        """RED-FIRST: before da#365 a staged halimbahae hadiths file raised
+        UnroutedCorpusError. A splitter-dependent corpus staged with a null isnad but
+        an isnad-BEARING full_text_ar must (a) not raise and (b) yield 0 mentions --
+        the full_text (matn) is NOT mined (better silent than polluted, #928). Held
+        until the da#366 splitter lands."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        output = tmp_path / "output"
+        output.mkdir()
+        write_hadiths(
+            staging / "hadiths_halimbahae.parquet",
+            [self._hadith("halimbahae", isnad_ar=None, full_text_ar="حدثنا محمد عن علي")],
+        )
+        # Must not raise -- halimbahae is explicitly routed (deferred).
+        paths = run(staging, output)
+        resolved = output / "narrator_mentions_resolved.parquet"
+        if resolved.exists():
+            corpora = set(pq.read_table(resolved).column("source_corpus").to_pylist())
+            assert "halimbahae" not in corpora
+        else:
+            assert paths == []
+
+    # -- mis: skip; chains come from network_edges_mis.parquet (da#364) -------
+    def test_mis_routed_to_skip(self) -> None:
+        from src.resolve.ner import _SKIP_SOURCES
+
+        assert "mis" in _SKIP_SOURCES
+
+    def test_mis_staged_hadiths_yield_no_mentions_and_do_not_raise(self, tmp_path: Path) -> None:
+        """mis's hadiths_mis.parquet carries a null isnad; its transmission chains
+        are the separate network_edges_mis.parquet (da#364), not NER over hadith
+        rows. Staged, it must not raise and must contribute 0 NER mentions."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        output = tmp_path / "output"
+        output.mkdir()
+        write_hadiths(
+            staging / "hadiths_mis.parquet",
+            [self._hadith("mis", isnad_ar=None)],
+        )
+        paths = run(staging, output)
+        assert paths == []
+
+    # -- the whole staged offender set is routed -----------------------------
+    def test_all_issue_staged_corpora_are_routed(self) -> None:
+        from src.resolve.ner import _ROUTED_CORPORA
+
+        for corpus in ("tusi", "halimbahae", "bihar", "mis"):
+            assert corpus in _ROUTED_CORPORA


### PR DESCRIPTION
## Summary

NER corpus routing was a **silent allowlist**: four staged corpora — `tusi`, `halimbahae`, `bihar`, `mis` — appeared in none of the route sets, so `run()` never visited them and they contributed **zero** narrator mentions (~29% of loaded hadiths had no chain). da#369 (merged) already converted that silence into a loud `UnroutedCorpusError`; **this PR layers the correct per-corpus route on top** so the pipeline runs again with every staged corpus routed to its right destination.

## Routes (measured from each parser's `isnad_raw_ar` population at HEAD)

| corpus | route | why |
|---|---|---|
| `tusi` | `_ARABIC_SOURCES` (extract) | Pure routing miss — ships a fully separated `isnad_raw_ar` (17,089/17,421 rows, 98.1%). Extracts straight from its isnad column. Its ~332 null-isnad rows hit da#369's null-skip, never the removed matn mine. |
| `halimbahae`, `bihar` | **new** `_SPLITTER_DEFERRED_SOURCES` | Both 100% null-isnad with isnad-bearing `full_text_ar`. Recovering them needs the **da#366** isnad/matn splitter. Routed explicitly (no hard-fail) but **not extracted and not matn-mined** — better silent-but-declared than polluted (#928). Logged loudly (`ner_deferred_source`). |
| `mis` | `_SKIP_SOURCES` | `hadiths_mis.parquet` rows carry a null isnad; mis's transmission chains are the separate `network_edges_mis.parquet` (da#364), not NER over hadith rows. |

`itqan`/`muhaddithat` stage only bio/edge files (never globbed by `_discover_staged_corpora`), so they remain correctly out of scope. A **genuinely** unrouted corpus (in no bucket at all) still trips da#369's guard.

## Red-first evidence

Verified by reverting `ner.py` to HEAD with the new tests present — all 7 da#365 tests failed (`tusi`/`halimbahae`/`mis` raised `UnroutedCorpusError`; deferred-bucket import missing), then green after restoring the fix.

- `tusi` extracts end-to-end through `run()` (was `UnroutedCorpusError` → 0 mentions).
- A deferred corpus staged with an isnad-bearing `full_text_ar` does **not** raise and yields **0** mentions (full_text not mined).
- `mis` is skipped, yields 0, does not raise.
- da#369's unrouted-hard-fail test now uses a **synthetic** corpus (bihar is now routed) so the contract still holds for any future unclassified corpus.

## Deferred-corpus note

`halimbahae` + `bihar` (and, functionally, `fawaz`, whose empty-isnad blob is no longer mined after da#369) remain contributing 0 mentions until the **da#366** isnad/matn splitter lands. That is intentional under the #928 doctrine.

## Checks

`ruff check` + `ruff format --check` (src/ tests/), `mypy src/` (101 files), full non-integration pytest (2034 passed / 10 skipped) — all green locally and via pre-commit/pre-push hooks.

Closes #365

Suggested reviewers: Alejandra Reyes-Fuentes, Nikolaos Papadopoulos

🤖 Generated with [Claude Code](https://claude.com/claude-code)
