### PR TITLE
Reify isnad-chain identity: build TRANSMITTED_TO per-chain, not per-hadith (da#282)

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -126,6 +126,21 @@ def _val(row: dict[str, Any], key: str, default: Any = None) -> Any:
     return default if v is None else v
 
 
+def _chain_index(row: dict[str, Any]) -> int:
+    """Per-hadith isnad-chain ordinal for a mention row (da#282).
+
+    Chain edges are grouped by ``(hadith_id, chain_index)`` — never by hadith
+    alone — so a hadith carrying more than one transmission sequence (today: lk's
+    Arabic + English isnads, each numbered from position 0) does not have its
+    chains flattened into one position-sorted list, which fabricated narrator
+    adjacencies that exist in no actual chain. A missing/None ``chain_index``
+    (legacy pre-da#282 file, or a single-isnad producer that left it unset)
+    coalesces to 0, so single-chain hadiths are unaffected.
+    """
+    v = row.get("chain_index")
+    return int(v) if v is not None else 0
+
+
 # ---------------------------------------------------------------------------
 # 1. TRANSMITTED_TO — consecutive narrator pairs in each chain
 # ---------------------------------------------------------------------------
@@ -247,7 +262,9 @@ def _load_transmitted_to(
         logger.warning("transmitted_to_files_missing", dir=str(staging_dir))
         return EdgeLoadResult("TRANSMITTED_TO", 0, 0, 0)
 
-    # Group mentions by hadith.
+    # Group mentions by (hadith_id, chain_index) so each isnad-chain is sequenced
+    # on its own (da#282). Keying on hadith alone flattened every chain of a
+    # multi-isnad hadith into one position-sorted list — see ``_chain_index``.
     #
     # Curated mention-links (provenance-bearing rows from the muhaddithat orphan
     # producer, da#228) are NARRATED-ONLY by contract and MUST NOT enter chain-pair
@@ -263,7 +280,7 @@ def _load_transmitted_to(
     # (the correct edge) while never fabricating a transmission pair. A normal
     # chain mention has no ``provenance`` column (row.get → None), so this only
     # ever excludes curated links.
-    by_hadith: dict[str, list[dict[str, Any]]] = {}
+    by_chain: dict[tuple[str, int], list[dict[str, Any]]] = {}
     dropped_noncanonical = 0
     for fp in files:
         rows = _read_parquet_rows(fp)
@@ -285,7 +302,7 @@ def _load_transmitted_to(
                 continue
             if row.get("provenance"):
                 continue  # curated NARRATED-only link — never a transmission pair
-            by_hadith.setdefault(hid, []).append(row)
+            by_chain.setdefault((hid, _chain_index(row)), []).append(row)
 
     # Build all chain pairs. Validate the group's hadith id ONCE up front: every
     # pair _build_chain_pairs emits re-derives it, so a malformed id would raise
@@ -294,7 +311,7 @@ def _load_transmitted_to(
     # leaves batches 1..N-1 already written to Neo4j.
     all_pairs: list[dict[str, Any]] = []
     malformed_ids = 0
-    for hid, mentions in by_hadith.items():
+    for (hid, _cidx), mentions in by_chain.items():
         try:
             hadith_node_id(hid)
         except DoubledCorpusPrefixError:
@@ -389,10 +406,16 @@ def _load_narrated(
         logger.warning("narrated_files_missing", dir=str(staging_dir))
         return EdgeLoadResult("NARRATED", 0, 0, 0)
 
-    # Find position-0 narrator per hadith (lowest position_in_chain). The winning
-    # mention's ``provenance`` (present only on curated orphan-links, da#228; null
-    # for ordinary chain mentions) rides along so it lands on the NARRATED edge.
-    first_narrators: dict[str, tuple[int, str, str | None]] = {}  # hid -> (pos, nid, provenance)
+    # Find the position-0 narrator of EACH chain (lowest position_in_chain within
+    # a (hadith_id, chain_index) group), not per hadith (da#282). A multi-isnad
+    # hadith is narrated by the first narrator of every one of its chains; keying on
+    # hadith alone dropped all but one chain's opener. Distinct chains that share a
+    # first narrator (e.g. lk's Arabic + English isnads) still MERGE to one edge, so
+    # this never inflates NARRATED. The winning mention's ``provenance`` (present
+    # only on curated orphan-links, da#228; null for ordinary chain mentions) rides
+    # along so it lands on the NARRATED edge.
+    # (hadith_id, chain_index) -> (pos, nid, provenance)
+    first_narrators: dict[tuple[str, int], tuple[int, str, str | None]] = {}
     dropped_noncanonical = 0
     for fp in files:
         rows = _read_parquet_rows(fp)
@@ -411,12 +434,13 @@ def _load_narrated(
                 # here (its edges come from ``network_edges_mis.parquet``).
                 dropped_noncanonical += 1
                 continue
-            if hid not in first_narrators or pos < first_narrators[hid][0]:
-                first_narrators[hid] = (pos, nid, row.get("provenance"))
+            key = (hid, _chain_index(row))
+            if key not in first_narrators or pos < first_narrators[key][0]:
+                first_narrators[key] = (pos, nid, row.get("provenance"))
 
     batch: list[dict[str, Any]] = []
     malformed_ids = 0
-    for hid, (_pos, nid, provenance) in first_narrators.items():
+    for (hid, _cidx), (_pos, nid, provenance) in first_narrators.items():
         try:
             full_hid = hadith_node_id(hid)
         except DoubledCorpusPrefixError:

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -576,8 +576,10 @@ def _load_chains(
     """Load Chain nodes from the *resolved* narrator-mention master.
 
     Chains are synthesized from narrator-mention parquet: each unique
-    (hadith_id, chain_index=0) tuple produces a Chain node whose ``narrator_ids``
-    is the per-hadith mention sequence (ordered by ``position_in_chain``).
+    (hadith_id, chain_index) tuple produces a Chain node whose ``narrator_ids`` is
+    that chain's mention sequence (ordered by ``position_in_chain``). ``chain_index``
+    is the per-hadith isnad ordinal (da#282) — a hadith with multiple transmission
+    sequences yields one Chain node per chain rather than a single flattened one.
 
     Reads ``narrator_mentions_resolved*.parquet`` from ``curated_dir`` — NOT the
     raw ``narrator_mentions_*.parquet`` in ``staging_dir``. The canonical
@@ -603,7 +605,13 @@ def _load_chains(
     # Accumulate only the (position, canonical_id) pairs we need per hadith —
     # the resolved master is ~3.2M rows, so keeping whole row dicts would bloat
     # memory needlessly (see the streaming work in load_edges for the same reason).
-    seen_hadiths: dict[str, list[tuple[int, str]]] = {}
+    # Key by (hadith_id, chain_index) so each isnad-chain becomes its own Chain
+    # node (da#282). Keying on hadith alone flattened a multi-isnad hadith's chains
+    # (today: lk's Arabic + English isnads, each numbered from position 0) into one
+    # position-sorted ``narrator_ids`` list, corrupting the chain member order.
+    # ``chain_index`` is None/absent for single-chain producers and legacy files →
+    # coalesces to 0, leaving single-isnad hadiths unchanged.
+    seen_chains: dict[tuple[str, int], list[tuple[int, str]]] = {}
     for fp in files:
         for row in _read_parquet_rows(fp):
             hid = row.get("source_hadith_id") or row.get("hadith_id")
@@ -622,18 +630,19 @@ def _load_chains(
             if row.get("provenance"):
                 continue
             pos = row.get("position_in_chain") or 0
-            seen_hadiths.setdefault(hid, []).append((pos, nid))
+            cidx = row.get("chain_index") or 0
+            seen_chains.setdefault((hid, cidx), []).append((pos, nid))
 
     batch: list[dict[str, Any]] = []
     errors: list[str] = []
     skipped = 0
     malformed = 0
 
-    for hid, mentions in seen_hadiths.items():
+    for (hid, chain_index), mentions in seen_chains.items():
         # da#355: both constructors route through ``bare_source_id``, so a malformed
         # hadith id raises here too. Quarantine the chain rather than abort the load.
         try:
-            chn_id = chain_node_id(hid, 0)
+            chn_id = chain_node_id(hid, chain_index)
             chain_hadith_id = hadith_node_id(hid)
         except DoubledCorpusPrefixError as exc:
             if strict:
@@ -647,7 +656,7 @@ def _load_chains(
             {
                 "id": chn_id,
                 "hadith_id": chain_hadith_id,
-                "chain_index": 0,
+                "chain_index": chain_index,
                 "full_chain_text_ar": None,
                 "full_chain_text_en": None,
                 "chain_length": len(narrator_ids),

--- a/src/parse/lk_corpus.py
+++ b/src/parse/lk_corpus.py
@@ -184,6 +184,11 @@ def _parse_single_csv(
                         "source_hadith_id": source_id,
                         "source_corpus": "lk",
                         "position_in_chain": span.position,
+                        # The English isnad is a SEPARATE chain from the Arabic isnad
+                        # of the same hadith (da#282): both are numbered from position
+                        # 0, so they must not share a chain bucket or the loader
+                        # interleaves them and fabricates cross-language adjacencies.
+                        "chain_index": 1,
                         "name_ar": None,
                         "name_en": span.name,
                         "name_ar_normalized": None,
@@ -202,6 +207,10 @@ def _parse_single_csv(
                         "source_hadith_id": source_id,
                         "source_corpus": "lk",
                         "position_in_chain": span.position,
+                        # Arabic isnad = chain 0 (the English isnad above is chain 1).
+                        # Separate ordinals keep the two same-hadith sequences from
+                        # being flattened together (da#282).
+                        "chain_index": 0,
                         "name_ar": span.name,
                         "name_en": None,
                         "name_ar_normalized": normalize_arabic(span.name),

--- a/src/parse/sanadset.py
+++ b/src/parse/sanadset.py
@@ -356,6 +356,10 @@ def _extract_narrator_mentions(
                     "source_hadith_id": source_hadith_id,
                     "source_corpus": _SOURCE_CORPUS,
                     "position_in_chain": position,
+                    # Sanadset carries one sanad (chain) per hadith row, so every
+                    # mention is chain 0 (da#282). Explicit rather than defaulted so
+                    # the column is never null on this high-volume producer.
+                    "chain_index": 0,
                     "name_ar": name_ar,
                     "name_en": None,
                     "name_ar_normalized": name_ar_normalized,
@@ -427,6 +431,9 @@ def _mentions_from_names(
                 "source_hadith_id": source_hadith_id,
                 "source_corpus": _SOURCE_CORPUS,
                 "position_in_chain": position,
+                # One sanad per hadith row → chain 0 (da#282); matches the
+                # ``<NAR>``-tag path in _extract_narrator_mentions.
+                "chain_index": 0,
                 "name_ar": name,
                 "name_en": None,
                 "name_ar_normalized": normalize_arabic(name),

--- a/src/parse/schemas.py
+++ b/src/parse/schemas.py
@@ -64,6 +64,20 @@ NARRATOR_MENTION_SCHEMA = pa.schema(
         pa.field("source_hadith_id", pa.string(), nullable=False),
         pa.field("source_corpus", pa.string(), nullable=False),
         pa.field("position_in_chain", pa.int32(), nullable=False),
+        # Which isnad-chain WITHIN this hadith the mention belongs to (da#282).
+        # ``position_in_chain`` alone is ambiguous once a single ``source_hadith_id``
+        # carries more than one transmission sequence — e.g. ``lk`` emits both an
+        # Arabic and an English isnad for one hadith, each numbered from position 0,
+        # so grouping by hadith and sorting by position interleaves two chains and
+        # fabricates cross-chain narrator adjacencies. ``chain_index`` is the
+        # per-hadith chain ordinal (0 for a single-isnad hadith; 0/1 for lk's ar/en
+        # lanes) that the graph loaders group on so a chain's edges are built WITHIN
+        # the chain, never across a hadith's chains. It also matches
+        # ``Chain.chain_index`` / ``identity.chain_node_id(hadith_id, chain_index)``.
+        # Nullable: a producer that does not set it (or a legacy file) reads back as
+        # None, which every consumer coalesces to 0 (single chain) — so single-isnad
+        # data is unaffected.
+        pa.field("chain_index", pa.int32(), nullable=True),
         pa.field("name_ar", pa.string(), nullable=True),
         pa.field("name_en", pa.string(), nullable=True),
         pa.field("name_ar_normalized", pa.string(), nullable=True),

--- a/src/resolve/muhaddithat_links.py
+++ b/src/resolve/muhaddithat_links.py
@@ -238,6 +238,10 @@ def build_muhaddithat_mention_links(
                 "hadith_id": link.hadith_id,
                 "source_corpus": _SOURCE_CORPUS,
                 "position_in_chain": 0,
+                # Curated orphan link is a single NARRATED-only node, never a chain
+                # pair — chain 0 (da#282). Required now that the superset schema
+                # carries ``chain_index`` and the array build reads every field.
+                "chain_index": 0,
                 "name_raw": link.name_en,
                 "name_normalized": normalize_arabic(link.name_ar),
                 "canonical_narrator_id": cid,

--- a/src/resolve/ner.py
+++ b/src/resolve/ner.py
@@ -177,6 +177,12 @@ def _load_phase1_mentions(
     rows: list[dict[str, str | int | None]] = []
     dropped = 0
 
+    # Chain identity (da#282): sanadset/lk emit ``chain_index`` on their mention
+    # rows; carry it through so the loader groups per-chain, not per-hadith. Read
+    # defensively so a legacy pre-da#282 parse file (no such column) still loads —
+    # a missing column reads back as chain 0 (single chain).
+    has_chain_index = "chain_index" in table.column_names
+
     for i in range(table.num_rows):
         name_ar = safe_str(table.column("name_ar")[i].as_py())
         name_en = safe_str(table.column("name_en")[i].as_py())
@@ -196,12 +202,14 @@ def _load_phase1_mentions(
         name_normalized = cleaned
         name_raw = strip_markup(name_raw) or name_raw
 
+        chain_index = table.column("chain_index")[i].as_py() if has_chain_index else 0
         rows.append(
             {
                 "mention_id": str(uuid.uuid4()),
                 "hadith_id": table.column("source_hadith_id")[i].as_py(),
                 "source_corpus": corpus,
                 "position_in_chain": table.column("position_in_chain")[i].as_py(),
+                "chain_index": chain_index if chain_index is not None else 0,
                 "name_raw": name_raw,
                 "name_normalized": name_normalized,
                 "canonical_narrator_id": None,
@@ -294,6 +302,10 @@ def _extract_from_hadiths(
                         "hadith_id": hadith_id,
                         "source_corpus": corpus,
                         "position_in_chain": span.position,
+                        # One isnad column per hadith → a single linear chain
+                        # (the segmenter does not split parallel sub-chains), so
+                        # chain 0 (da#282).
+                        "chain_index": 0,
                         "name_raw": name_raw,
                         "name_normalized": name_normalized,
                         "canonical_narrator_id": None,
@@ -422,6 +434,7 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
             "position_in_chain": pa.array(
                 [r["position_in_chain"] for r in all_rows], type=pa.int32()
             ),
+            "chain_index": pa.array([r.get("chain_index", 0) for r in all_rows], type=pa.int32()),
             "name_raw": pa.array([r["name_raw"] for r in all_rows], type=pa.string()),
             "name_normalized": pa.array([r["name_normalized"] for r in all_rows], type=pa.string()),
             "canonical_narrator_id": pa.array(

--- a/src/resolve/schemas.py
+++ b/src/resolve/schemas.py
@@ -13,7 +13,10 @@ __all__ = [
     "PARALLEL_LINKS_SCHEMA",
 ]
 
-RESOLVE_SCHEMA_VERSION = 1
+# v2 (da#282): added ``chain_index`` — the per-hadith isnad-chain ordinal the
+# graph loaders group on so TRANSMITTED_TO / NARRATED / Chain are built WITHIN a
+# chain, never flattened across a hadith's multiple chains.
+RESOLVE_SCHEMA_VERSION = 2
 
 NARRATOR_MENTIONS_RESOLVED_SCHEMA = pa.schema(
     [
@@ -21,6 +24,15 @@ NARRATOR_MENTIONS_RESOLVED_SCHEMA = pa.schema(
         pa.field("hadith_id", pa.string(), nullable=False),
         pa.field("source_corpus", pa.string(), nullable=False),
         pa.field("position_in_chain", pa.int32(), nullable=False),
+        # Per-hadith isnad-chain ordinal (da#282). Carries the parse-layer
+        # ``NARRATOR_MENTION_SCHEMA.chain_index`` through resolution so the edge /
+        # chain loaders can group by (hadith_id, chain_index) instead of hadith_id
+        # alone. Without it, a hadith with more than one transmission sequence (today:
+        # lk's Arabic + English isnads, each numbered from position 0) is flattened
+        # into one position-sorted list, fabricating narrator adjacencies that exist
+        # in no actual chain. Nullable → None coalesces to 0 (single chain), so
+        # single-isnad hadiths and legacy files are unaffected.
+        pa.field("chain_index", pa.int32(), nullable=True),
         pa.field("name_raw", pa.string(), nullable=True),
         pa.field("name_normalized", pa.string(), nullable=True),
         pa.field("canonical_narrator_id", pa.string(), nullable=True),

--- a/tests/test_graph/conftest.py
+++ b/tests/test_graph/conftest.py
@@ -200,6 +200,8 @@ def write_narrator_mentions(
         "position_in_chain": pa.array(
             [r.get("position_in_chain", 0) for r in rows], type=pa.int32()
         ),
+        # da#282: per-hadith isnad-chain ordinal (defaults to 0 = single chain).
+        "chain_index": pa.array([r.get("chain_index", 0) for r in rows], type=pa.int32()),
         "name_ar": pa.array([r.get("name_ar") for r in rows], type=pa.string()),
         "name_en": pa.array([r.get("name_en") for r in rows], type=pa.string()),
         "name_ar_normalized": pa.array(
@@ -228,6 +230,9 @@ def write_narrator_mentions_resolved(
         "position_in_chain": pa.array(
             [r.get("position_in_chain", 0) for r in rows], type=pa.int32()
         ),
+        # da#282: per-hadith isnad-chain ordinal. Defaults to 0 (single chain) so
+        # existing fixtures need only set it when they exercise multi-chain grouping.
+        "chain_index": pa.array([r.get("chain_index", 0) for r in rows], type=pa.int32()),
         "name_raw": pa.array([r.get("name_raw") for r in rows], type=pa.string()),
         "name_normalized": pa.array([r.get("name_normalized") for r in rows], type=pa.string()),
         "canonical_narrator_id": pa.array(

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -241,6 +241,203 @@ class TestLoadTransmittedTo:
         assert tt_result.missing_endpoints == 1
 
 
+class TestChainIdentityNoCrossChainFabrication:
+    """da#282: TRANSMITTED_TO adjacencies are built WITHIN an isnad-chain, never
+    across a hadith's multiple chains.
+
+    A single ``hadith_id`` may carry more than one transmission sequence — today
+    ``lk`` emits both an Arabic and an English isnad for one hadith, each numbered
+    from ``position_in_chain = 0``. Grouping mentions by hadith and sorting by
+    position interleaves the chains and MERGEs narrator pairs that appear in no
+    actual chain. ``chain_index`` distinguishes the chains so the loader groups by
+    ``(hadith_id, chain_index)``.
+    """
+
+    @staticmethod
+    def _merged_pairs(mock_client: MockNeo4jClient) -> set[tuple[str, str]]:
+        """The (from_id, to_id) pairs MERGEd as TRANSMITTED_TO edges."""
+        pairs: set[tuple[str, str]] = set()
+        for query, payload in mock_client.calls:
+            if "MERGE (n1)-[:TRANSMITTED_TO" in query and isinstance(payload, list):
+                for row in payload:
+                    pairs.add((row["from_id"], row["to_id"]))
+        return pairs
+
+    def test_two_chains_one_hadith_no_cross_chain_edge(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        # Every endpoint exists — enough True rows to cover any pairing the loader
+        # builds (2 within-chain with the fix; 3 interleaved without it).
+        mock_client.set_read_results([{"from_exists": True, "to_exists": True} for _ in range(6)])
+        # One hadith, TWO isnad-chains. chain 0: A -> B. chain 1: C -> D. Both
+        # chains start at position 0, exactly the lk ar/en shape.
+        write_narrator_mentions_resolved(
+            curated_dir,
+            [
+                {
+                    "mention_id": "m0",
+                    "hadith_id": "h1",
+                    "chain_index": 0,
+                    "position_in_chain": 0,
+                    "canonical_narrator_id": "nar:A",
+                },
+                {
+                    "mention_id": "m1",
+                    "hadith_id": "h1",
+                    "chain_index": 0,
+                    "position_in_chain": 1,
+                    "canonical_narrator_id": "nar:B",
+                },
+                {
+                    "mention_id": "m2",
+                    "hadith_id": "h1",
+                    "chain_index": 1,
+                    "position_in_chain": 0,
+                    "canonical_narrator_id": "nar:C",
+                },
+                {
+                    "mention_id": "m3",
+                    "hadith_id": "h1",
+                    "chain_index": 1,
+                    "position_in_chain": 1,
+                    "canonical_narrator_id": "nar:D",
+                },
+            ],
+        )
+        load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        pairs = self._merged_pairs(mock_client)
+
+        # Within-chain adjacencies are present …
+        assert ("nar:A", "nar:B") in pairs
+        assert ("nar:C", "nar:D") in pairs
+        # … and NO cross-chain adjacency was fabricated. Under the pre-da#282
+        # per-hadith flatten these are exactly the edges that appeared:
+        # sorted [A(0), C(0), B(1), D(1)] -> (A,C), (C,B), (B,D).
+        assert ("nar:A", "nar:C") not in pairs
+        assert ("nar:C", "nar:B") not in pairs
+        assert ("nar:B", "nar:D") not in pairs
+        assert pairs == {("nar:A", "nar:B"), ("nar:C", "nar:D")}
+
+    def test_single_isnad_hadith_unaffected(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """A single-chain hadith (all chain_index 0) builds the same edges as before."""
+        mock_client.set_read_results([{"from_exists": True, "to_exists": True} for _ in range(4)])
+        write_narrator_mentions_resolved(
+            curated_dir,
+            [
+                {
+                    "mention_id": "m0",
+                    "hadith_id": "h1",
+                    "chain_index": 0,
+                    "position_in_chain": 0,
+                    "canonical_narrator_id": "nar:A",
+                },
+                {
+                    "mention_id": "m1",
+                    "hadith_id": "h1",
+                    "chain_index": 0,
+                    "position_in_chain": 1,
+                    "canonical_narrator_id": "nar:B",
+                },
+                {
+                    "mention_id": "m2",
+                    "hadith_id": "h1",
+                    "chain_index": 0,
+                    "position_in_chain": 2,
+                    "canonical_narrator_id": "nar:C",
+                },
+            ],
+        )
+        load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        assert self._merged_pairs(mock_client) == {("nar:A", "nar:B"), ("nar:B", "nar:C")}
+
+    def test_absent_chain_index_defaults_to_single_chain(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """A legacy row that omits chain_index (→ null) coalesces to chain 0, so a
+        pre-da#282 file still builds one contiguous chain rather than fragmenting."""
+        mock_client.set_read_results([{"from_exists": True, "to_exists": True} for _ in range(4)])
+        # Explicit None → a genuine null chain_index column in the parquet, the
+        # legacy pre-da#282 shape; the loader must coalesce it to chain 0.
+        write_narrator_mentions_resolved(
+            curated_dir,
+            [
+                {
+                    "mention_id": "m0",
+                    "hadith_id": "h1",
+                    "chain_index": None,
+                    "position_in_chain": 0,
+                    "canonical_narrator_id": "nar:A",
+                },
+                {
+                    "mention_id": "m1",
+                    "hadith_id": "h1",
+                    "chain_index": None,
+                    "position_in_chain": 1,
+                    "canonical_narrator_id": "nar:B",
+                },
+            ],
+        )
+        load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        assert self._merged_pairs(mock_client) == {("nar:A", "nar:B")}
+
+    def test_two_chains_narrated_dedupes_to_one_when_openers_match(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """Both chains of a hadith emit a NARRATED edge from their position-0
+        narrator; when the openers resolve to the same canonical (the lk ar/en
+        case) they MERGE to one edge, so per-chain NARRATED never inflates."""
+        mock_client.set_read_results(
+            [{"narrator_exists": True, "hadith_exists": True} for _ in range(4)]
+        )
+        write_narrator_mentions_resolved(
+            curated_dir,
+            [
+                # chain 0 opener and chain 1 opener are the SAME canonical narrator.
+                {
+                    "mention_id": "m0",
+                    "hadith_id": "h1",
+                    "chain_index": 0,
+                    "position_in_chain": 0,
+                    "canonical_narrator_id": "nar:A",
+                },
+                {
+                    "mention_id": "m1",
+                    "hadith_id": "h1",
+                    "chain_index": 0,
+                    "position_in_chain": 1,
+                    "canonical_narrator_id": "nar:B",
+                },
+                {
+                    "mention_id": "m2",
+                    "hadith_id": "h1",
+                    "chain_index": 1,
+                    "position_in_chain": 0,
+                    "canonical_narrator_id": "nar:A",
+                },
+                {
+                    "mention_id": "m3",
+                    "hadith_id": "h1",
+                    "chain_index": 1,
+                    "position_in_chain": 1,
+                    "canonical_narrator_id": "nar:C",
+                },
+            ],
+        )
+        results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        narrated = next(r for r in results if r.edge_type == "NARRATED")
+        # Two chain-openers, both nar:A -> hdt:h1 → one MERGEd edge after dedup.
+        narrated_targets = {
+            (row["narrator_id"], row["hadith_id"])
+            for query, payload in mock_client.calls
+            if "NARRATED" in query and isinstance(payload, list)
+            for row in payload
+        }
+        assert ("nar:A", "hdt:h1") in narrated_targets
+        assert narrated.created >= 1
+
+
 class TestLoadNarrated:
     def test_first_narrator_per_hadith(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -679,6 +679,67 @@ class TestLoadChains:
         assert h1["chain_length"] == 2
         assert h1["is_complete"] is True
 
+    def test_multi_chain_hadith_yields_one_chain_node_per_chain(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """da#282: a hadith carrying two isnad-chains (distinct ``chain_index``,
+        each numbered from position 0 — the lk ar/en shape) produces ONE Chain node
+        per chain, each keyed ``chn:<hadith>-<chain_index>`` with only its own
+        members — not a single flattened node interleaving both chains.
+        """
+        write_narrator_mentions_resolved(
+            curated_dir,
+            [
+                {
+                    "mention_id": "m0",
+                    "hadith_id": "h-1",
+                    "chain_index": 0,
+                    "position_in_chain": 0,
+                    "canonical_narrator_id": "nar:A",
+                },
+                {
+                    "mention_id": "m1",
+                    "hadith_id": "h-1",
+                    "chain_index": 0,
+                    "position_in_chain": 1,
+                    "canonical_narrator_id": "nar:B",
+                },
+                {
+                    "mention_id": "m2",
+                    "hadith_id": "h-1",
+                    "chain_index": 1,
+                    "position_in_chain": 0,
+                    "canonical_narrator_id": "nar:C",
+                },
+                {
+                    "mention_id": "m3",
+                    "hadith_id": "h-1",
+                    "chain_index": 1,
+                    "position_in_chain": 1,
+                    "canonical_narrator_id": "nar:D",
+                },
+            ],
+        )
+        results = load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        chain_result = results[3]
+        assert chain_result.created + chain_result.merged == 2  # two chains, one hadith
+
+        chain_batches = [
+            batch
+            for _query, batch in mock_client.calls
+            if isinstance(batch, list)
+            and batch
+            and "id" in batch[0]
+            and str(batch[0]["id"]).startswith("chn:")
+        ]
+        by_id = {row["id"]: row for batch in chain_batches for row in batch}
+        c0 = by_id[chain_node_id("h-1", 0)]
+        c1 = by_id[chain_node_id("h-1", 1)]
+        assert c0["narrator_ids"] == ["nar:A", "nar:B"]
+        assert c0["chain_index"] == 0
+        assert c1["narrator_ids"] == ["nar:C", "nar:D"]
+        assert c1["chain_index"] == 1
+
     def test_chains_exclude_provenance_orphan_links(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
     ) -> None:

--- a/tests/test_parse/test_lk_parser.py
+++ b/tests/test_parse/test_lk_parser.py
@@ -189,6 +189,32 @@ class TestLkParser:
         assert table.schema == NARRATOR_MENTION_SCHEMA
         assert table.num_rows > 0
 
+    def test_arabic_and_english_isnads_are_separate_chains(self, tmp_path: Path) -> None:
+        """da#282: lk emits an Arabic AND an English isnad for one hadith, each
+        numbered from position 0. They MUST carry distinct ``chain_index`` values
+        (ar=0, en=1) so the graph loader does not flatten the two same-hadith
+        sequences into one chain and fabricate cross-language narrator adjacencies.
+        """
+        raw_dir = tmp_path / "raw"
+        lk_dir = raw_dir / "lk"
+        lk_dir.mkdir(parents=True)
+        staging_dir = tmp_path / "staging"
+
+        _make_lk_csv(lk_dir / "albukhari.csv", _sample_rows())
+        run(raw_dir, staging_dir)
+
+        rows = pq.read_table(staging_dir / "narrator_mentions_lk.parquet").to_pylist()
+        # Row 1 of the sample carries both an English and an Arabic isnad.
+        ar = [r for r in rows if ":ar:" in r["mention_id"]]
+        en = [r for r in rows if ":en:" in r["mention_id"]]
+        assert ar, "expected Arabic-isnad mentions"
+        assert en, "expected English-isnad mentions"
+        assert all(r["chain_index"] == 0 for r in ar)
+        assert all(r["chain_index"] == 1 for r in en)
+        # The two chains of one hadith share a source_hadith_id but differ in chain.
+        shared = {r["source_hadith_id"] for r in ar} & {r["source_hadith_id"] for r in en}
+        assert shared, "a hadith with both isnads should appear in both chains"
+
     def test_no_csv_raises(self, tmp_path: Path) -> None:
         raw_dir = tmp_path / "raw"
         lk_dir = raw_dir / "lk"

--- a/tests/test_parse/test_schemas.py
+++ b/tests/test_parse/test_schemas.py
@@ -76,6 +76,7 @@ class TestSampleData:
             "source_hadith_id": ["lk:bukhari:1:1"],
             "source_corpus": ["lk"],
             "position_in_chain": [0],
+            "chain_index": [1],
             "name_ar": [None],
             "name_en": ["Abu Hurayra"],
             "name_ar_normalized": [None],

--- a/tests/test_resolve/test_disambiguate_resume.py
+++ b/tests/test_resolve/test_disambiguate_resume.py
@@ -88,7 +88,9 @@ def _mention_rows(n_hadiths: int) -> list[dict[str, object]]:
 def _write_mentions(output_dir: Path, rows: list[dict[str, object]]) -> None:
     cols: dict[str, pa.Array] = {}
     for field in NARRATOR_MENTIONS_RESOLVED_SCHEMA:
-        cols[field.name] = pa.array([r[field.name] for r in rows], type=field.type)
+        # ``.get`` so a row need not enumerate every (nullable) column, e.g.
+        # ``chain_index`` added in da#282 — absent → null → coalesces to chain 0.
+        cols[field.name] = pa.array([r.get(field.name) for r in rows], type=field.type)
     pq.write_table(
         pa.table(cols, schema=NARRATOR_MENTIONS_RESOLVED_SCHEMA),
         output_dir / "narrator_mentions_resolved.parquet",

--- a/tests/test_resolve/test_ner.py
+++ b/tests/test_resolve/test_ner.py
@@ -30,6 +30,7 @@ def _write_narrator_mentions_parquet(path: Path, rows: list[dict]) -> Path:
         "source_hadith_id": pa.array([r["source_hadith_id"] for r in rows], type=pa.string()),
         "source_corpus": pa.array([r["source_corpus"] for r in rows], type=pa.string()),
         "position_in_chain": pa.array([r["position_in_chain"] for r in rows], type=pa.int32()),
+        "chain_index": pa.array([r.get("chain_index", 0) for r in rows], type=pa.int32()),
         "name_ar": pa.array([r.get("name_ar") for r in rows], type=pa.string()),
         "name_en": pa.array([r.get("name_en") for r in rows], type=pa.string()),
         "name_ar_normalized": pa.array(

--- a/tests/test_resolve/test_schemas.py
+++ b/tests/test_resolve/test_schemas.py
@@ -37,6 +37,7 @@ class TestSampleData:
             "hadith_id": pa.array(["h-1"], type=pa.string()),
             "source_corpus": pa.array(["sunnah"], type=pa.string()),
             "position_in_chain": pa.array([0], type=pa.int32()),
+            "chain_index": pa.array([0], type=pa.int32()),
             "name_raw": pa.array(["Abu Hurayra"], type=pa.string()),
             "name_normalized": pa.array(["abu hurayra"], type=pa.string()),
             "canonical_narrator_id": pa.array([None], type=pa.string()),


### PR DESCRIPTION
## What

Reify **isnad-chain identity** so `TRANSMITTED_TO` (and `NARRATED`, and the `Chain` node) is built **within a chain**, never flattened across a hadith's multiple chains. `Closes #282`.

## The bug (measured)

`TRANSMITTED_TO` grouped mentions by `hadith_id` and sorted by `position_in_chain`. When one `hadith_id` carries **more than one transmission sequence**, sorting interleaves them and MERGEs narrator pairs that exist in no actual chain.

**Data-shape audit (the issue's `which parsers segment multiple isnads?`):**
- The Arabic/English segmenter **linearizes** one isnad string — no parser emits genuinely-distinct parallel isnads as separate position sequences today.
- The one real present-day case of `>1` position-0 sequence under one `hadith_id` is **`lk`**: it emits an Arabic isnad **and** an English isnad for the same hadith, each numbered from `position 0`. Interleaved → fabricated cross-language adjacencies (length-mismatched chains make this resolution-independent).
- `sanadset`, thaqalayn/ner isnad-column: one sequence per hadith → unaffected.

## The fix (zero-inference)

Add **`chain_index`** (per-hadith isnad ordinal) — matches existing `Chain.chain_index` / `chain_node_id(hadith_id, chain_index)`:
- `NARRATOR_MENTION_SCHEMA` + `NARRATOR_MENTIONS_RESOLVED_SCHEMA`, `RESOLVE_SCHEMA_VERSION` 1→2. Nullable → coalesces to 0.
- Producers: **lk `ar=0`/`en=1`** (preserving the upstream distinction, not inventing one); `sanadset=0`; ner isnad-column `=0`; ner phase1 loader carries the parse column through; muhaddithat link `=0`.
- Consumers grouped by `(hadith_id, chain_index)`: `_load_transmitted_to`, `_load_narrated`, `load_nodes._load_chains` (one Chain node per chain now, not hardcoded 0).
- Cast-passthrough consumers (`disambiguate`, `narrator_split`, `fuzzy_cluster`) + row-filter scrubs preserve the column unchanged.

`chain_index` is **never all-zero on real data** (lk emits 1) — not an inert schema add.

## Red-first evidence

`test_two_chains_one_hadith_no_cross_chain_edge`: hadith with chain 0 = `A→B`, chain 1 = `C→D` (both start at position 0, the lk shape).
- **Pre-fix (per-hadith flatten, reproduced by neutralizing grouping):** pairs = `{(A,C),(C,B),(B,D)}` — all fabricated; real `(A,B)`/`(C,D)` absent.
- **Post-fix:** pairs = `{(A,B),(C,D)}` exactly.

Pinned unaffected: single-isnad (all `chain_index=0`) and legacy **null** `chain_index` (coalesce→0). NARRATED: both chain openers emit, MERGE-dedupe to one edge when they share a canonical (lk ar/en). lk producer test asserts `ar→0`,`en→1` under one `source_hadith_id`.

## Behavioral note for reviewers

For lk hadiths with both isnads this creates **one Chain node per language** (`chn:<h>-0` ar, `chn:<h>-1` en) instead of one flattened node; edges MERGE-dedupe so counts don't inflate. Correct consequence of preserving the two sequences — flag if the owner prefers same-isnad-across-languages deduped to one chain (separate concern).

## Out of scope (flagged follow-ups)

`disambiguate._adjacent_death_years` and `narrator_split` estimate death years from `(hadith_id, position±1)` neighbors — still hadith-scoped, so a multi-isnad hadith can pick a cross-chain neighbor. Pre-existing; not broken here; `chain_index` makes the fix trivial. Touches da#376 death-year territory — surfacing for an owner/architect call. Wiring `Chain` nodes into edges (the issue's other half) also remains open.

## Green
`pytest` (2084 passed, 10 skipped), `ruff check`, `ruff format --check`, `mypy --strict` clean locally; pre-commit + pre-push hooks passed.

Suggested reviewers: Jean-Claude Habimana, Kavitha Sundaramurthy.
