### PR TITLE
fix(resolve): fail loud on a missing required input instead of a success-shaped empty (da#361)

### DIFF
--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING
 from src.exit_codes import EXIT_STAGE_FAILED
 from src.resolve._checkpoint import EXIT_STOPPED_AT_LIMIT, StopAfterReached
 from src.resolve._deps import EXIT_MISSING_DEPENDENCY, MissingDependencyError
+from src.resolve._inputs import MissingInputError
 from src.resolve._provenance import DetectorProvenance, DetectorStatus, read_provenance
 from src.resolve.ner import EXIT_UNROUTED_CORPUS, UnroutedCorpusError
 from src.utils.logging import get_logger
@@ -46,6 +47,7 @@ __all__ = [
     "RESOLVE_STEP_ORDER",
     "RESUMABLE_STEPS",
     "MissingDependencyError",
+    "MissingInputError",
     "ResolveMetrics",
     "ResolveStageError",
     "StageErrored",

--- a/src/resolve/_inputs.py
+++ b/src/resolve/_inputs.py
@@ -1,0 +1,107 @@
+"""Required-input guards for resolve stages (da#361).
+
+Companion to :mod:`src.resolve._deps` (da#309), one layer up. ``_deps`` guards a
+missing *dependency* (an unimportable module); this guards a missing *input*
+artifact (a parquet an upstream stage should have produced).
+
+The defect class (da#361)
+-------------------------
+Several ``src/resolve`` stages returned a success-shaped empty result — ``[]`` /
+``None`` / a zero-row parquet — when a **required** input artifact was absent. A
+missing input means an upstream stage did not run (or ran against the wrong
+directory): an upstream defect. It is NOT the same thing as an input that ran and
+legitimately produced nothing, yet the two were indistinguishable to every caller
+and to the process exit status — the same silent success #309 fixed for
+dependencies and #360 fixed for a swallowed raise.
+
+Distinguishing the two is the whole point, so this guard fires **only on
+absence**, never on a present-but-empty input. Each call site keeps its honest
+empty return for the true-negative case (input present, genuinely zero rows) and
+delegates only the *absence* decision here.
+
+Why ``Exception``, not ``BaseException``
+----------------------------------------
+:class:`~src.resolve._deps.MissingDependencyError` subclasses ``BaseException`` so
+it **sails past** ``run_all``'s per-stage ``except Exception`` and maps to its own
+exit code (``4``). :class:`MissingInputError` makes the opposite choice **on
+purpose**: a missing input is exactly the "a stage could not do its job"
+condition da#360's machinery already models. A plain ``Exception`` is *caught* by
+``run_all`` and recorded as a :class:`~src.resolve.StageErrored`, which makes
+``run_all`` raise :class:`~src.resolve.ResolveStageError` at the end → exit
+:data:`~src.exit_codes.EXIT_STAGE_FAILED` (11). So a stage that raises on a
+missing input is aggregated with every other failed stage rather than aborting
+the best-effort sweep, and needs no new exit code.
+
+da#360 is the reason raising is meaningful at all here: before it, ``run_all``
+swallowed the raise, logged ``resolve_step_failed`` and marched on to
+``resolve_pipeline_complete``, exiting 0. Raising a missing-input error into that
+old orchestrator would have been swallowed exactly like the empty return it
+replaces — which is precisely why da#361's "Proposed direction" made this depend
+on da#360.
+"""
+
+from __future__ import annotations
+
+__all__ = ["MissingInputError", "require_input"]
+
+
+class MissingInputError(Exception):
+    """An enabled resolve stage's **required** input artifact is absent.
+
+    Distinct from a genuinely empty input (input present, zero rows), which each
+    stage still reports as an honest success. The message names *which* stage,
+    *which* input, *which* upstream stage should have produced it, and *what to
+    run* — so an operator can act without reading the traceback.
+
+    A plain ``Exception`` (not ``BaseException``) so ``run_all`` catches it as a
+    :class:`~src.resolve.StageErrored`; see this module's docstring for why.
+    """
+
+    def __init__(
+        self,
+        *,
+        stage: str,
+        input_desc: str,
+        produced_by: str,
+        remediation: str,
+    ) -> None:
+        self.stage = stage
+        self.input_desc = input_desc
+        self.produced_by = produced_by
+        self.remediation = remediation
+        super().__init__(self._render())
+
+    def _render(self) -> str:
+        return (
+            f"resolve stage {self.stage!r} is missing its required input "
+            f"({self.input_desc}), normally produced by {self.produced_by}. This is an "
+            f"upstream defect, not an empty result: continuing would write a "
+            f"success-shaped empty output indistinguishable from a genuine negative. "
+            f"Remediation: {self.remediation}"
+        )
+
+
+def require_input(
+    *,
+    stage: str,
+    present: bool,
+    input_desc: str,
+    produced_by: str,
+    remediation: str,
+) -> None:
+    """Raise :class:`MissingInputError` when a required input is absent.
+
+    ``present`` is the caller's own presence check — ``path.exists()`` for a
+    single artifact, ``bool(list(dir.glob(pattern)))`` for a globbed set. Passing
+    the boolean (rather than a path) keeps this one helper serving both the
+    single-file and glob sites, and — critically — lets the caller draw the line
+    between ABSENT (raise here) and PRESENT-BUT-EMPTY (the caller's own honest
+    empty return), which is the distinction da#361 exists to preserve.
+    """
+    if not present:
+        raise MissingInputError(
+            stage=stage,
+            input_desc=input_desc,
+            produced_by=produced_by,
+            remediation=remediation,
+        )

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -33,6 +33,7 @@ from src.parse.name_quality import (
     cleaner_removed_content,
     is_mubham_relational,
 )
+from src.resolve._inputs import require_input
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
 from src.resolve.sect_affiliation import (
     derive_sect_affiliation,
@@ -216,10 +217,20 @@ def promote_bios_to_canonical(
     surface for no recovery-time saving. Recovery re-runs it via
     ``resolve --from-step bio_promote``.
     """
+    # Required input: the bio shards this stage exists to promote. da#361: their
+    # total absence means parse never produced them (or ran against the wrong dir)
+    # — an upstream defect, not an empty result — so raise rather than return a
+    # success-shaped ``None``. Shards present but carrying no promotable rows (all
+    # source-filtered / name-quality-dropped) is a genuine empty and still returns
+    # ``None`` honestly further down.
     bio_files = sorted(staging_dir.glob("narrators_bio_*.parquet"))
-    if not bio_files:
-        logger.warning("bio_promote_no_bio_files", staging_dir=str(staging_dir))
-        return None
+    require_input(
+        stage="bio_promote",
+        present=bool(bio_files),
+        input_desc=f"narrators_bio_*.parquet under {staging_dir}",
+        produced_by="parse (bio adapters)",
+        remediation="re-run `parse`; there are no bio shards to promote",
+    )
 
     canonical_path = output_dir / "narrators_canonical.parquet"
     canonical_map = _load_existing_canonical(canonical_path)

--- a/src/resolve/date_reconcile.py
+++ b/src/resolve/date_reconcile.py
@@ -478,6 +478,12 @@ def reconcile_canonical_dates(
     Returns the canonical path, or ``None`` when it does not yet exist (the stage
     is a no-op until disambiguate/bio_promote have produced the table).
     """
+    # OPTIONAL input (da#361): unlike the raising sites, ``narrators_canonical.parquet``
+    # is a legitimately optional input HERE. This stage is a pure date-enricher: with
+    # no canonical table there are simply no narrators to date, so an absent table is
+    # an honest no-op, not an upstream defect. Confirmed as intended (da#361 carved
+    # date_reconcile + tabaqa_dates out of the fail-loud set): it does NOT call
+    # ``require_input`` and returns ``None`` by design. See module docstring.
     canonical_path = output_dir / "narrators_canonical.parquet"
     if not canonical_path.exists():
         logger.warning("reconcile_dates_no_canonical", path=str(canonical_path))

--- a/src/resolve/dedup.py
+++ b/src/resolve/dedup.py
@@ -31,6 +31,7 @@ from src.resolve._checkpoint import (
     save_checkpoint,
 )
 from src.resolve._deps import MissingDependencyError, missing_dependencies
+from src.resolve._inputs import require_input
 from src.resolve._provenance import (
     DetectorProvenance,
     DetectorStatus,
@@ -728,17 +729,28 @@ def run_dedup(
     hadith_files = _hadith_files(staging_dir)
     if not hadith_files:
         # Case A: no input files at all. This is an upstream defect (parse never
-        # ran / wrong staging_dir), NOT a true negative -- but `run_dedup` is also
-        # called directly on empty tmp dirs by unit tests, so making it fatal is a
-        # behaviour change tracked separately. Kept distinct from Case B below so
-        # the two are no longer structurally indistinguishable.
+        # ran / wrong staging_dir), NOT a true negative. da#309 split this from
+        # Case B and stamped it ``NO_INPUT`` but left it non-fatal, noting the fatal
+        # turn was "tracked separately" -- that follow-up is da#361, now landable
+        # because da#360 makes ``run_all`` surface a raise instead of swallowing it.
+        # ``require_input`` raises ``MissingInputError`` (an ``Exception``), which
+        # ``run_all`` records as a ``StageErrored`` -> ``ResolveStageError`` -> exit
+        # ``EXIT_STAGE_FAILED``. Case B below (files present, no English matn) stays
+        # an honest empty success, so the two remain distinguishable.
         logger.warning("dedup_no_hadith_files", staging_dir=str(staging_dir))
-        return _write_empty_output(staging_dir, DetectorStatus.NO_INPUT)
+        require_input(
+            stage="dedup",
+            present=False,
+            input_desc=f"{_HADITH_GLOB} under {staging_dir}",
+            produced_by="parse (hadith adapters)",
+            remediation="re-run `parse`; an absent hadith staging set is an upstream defect",
+        )
 
     hadith_ids, texts, sects = _load_hadith_texts(staging_dir)
     if not texts:
         # Case B: input files exist, but no row carries a non-empty English matn.
-        # A genuinely empty input for an English-matn semantic detector.
+        # A genuinely empty input for an English-matn semantic detector -- an honest
+        # empty success, NOT a missing input, so it is written, not raised (da#361).
         logger.warning("dedup_no_texts", files=len(hadith_files))
         return _write_empty_output(staging_dir, DetectorStatus.NO_TEXTS)
 

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -36,6 +36,7 @@ from src.resolve._checkpoint import (
     resolve_cadence,
     save_checkpoint,
 )
+from src.resolve._inputs import require_input
 from src.resolve.geography import regions_plausible, resolve_region
 from src.resolve.mononym_split import refine_mononym_name
 from src.resolve.schemas import (
@@ -554,11 +555,23 @@ def _count_mentions(mentions_dir: Path) -> int:
 def _load_mentions(
     staging_dir: Path,
 ) -> list[dict[str, str | int | float | None]]:
-    """Load narrator_mentions_resolved.parquet from NER stage."""
+    """Load narrator_mentions_resolved.parquet from NER stage.
+
+    da#361: an absent mentions file is a missing required input (NER did not run
+    or wrote elsewhere), not an empty result, so this raises rather than returning
+    ``[]``. NOTE: this helper is currently uncalled — ``run`` uses
+    :func:`_count_mentions` for the presence/size check — but it is kept honest so
+    a future re-wiring inherits the fail-loud contract rather than the old silent
+    empty. (Tracked for wire-up-or-remove; see da#361 discussion.)
+    """
     path = staging_dir / "narrator_mentions_resolved.parquet"
-    if not path.exists():
-        logger.warning("mentions_file_missing", path=str(path))
-        return []
+    require_input(
+        stage="disambiguate",
+        present=path.exists(),
+        input_desc=f"{path.name} (NER mention output)",
+        produced_by="resolve NER stage",
+        remediation="re-run resolve from the `ner` step; the mention output is absent",
+    )
 
     table = pq.read_table(path)
     rows: list[dict[str, str | int | float | None]] = []
@@ -1158,16 +1171,37 @@ def run(
         output_dir=str(output_dir),
     )
 
+    # Required input: candidate bio files (produced by parse). da#361 distinguishes
+    # an ABSENT input (no bio shards at all — an upstream defect) from a PRESENT one
+    # that is genuinely empty (shards exist, zero candidate rows). Absent → raise;
+    # present-but-empty → the honest ``disambiguate_no_candidates`` empty return.
+    bio_files = sorted(staging_dir.glob("narrators_bio_*.parquet"))
+    require_input(
+        stage="disambiguate",
+        present=bool(bio_files),
+        input_desc=f"narrators_bio_*.parquet under {staging_dir} (candidate narrator profiles)",
+        produced_by="parse (bio adapters)",
+        remediation="re-run `parse`; disambiguation has no candidate profiles to match against",
+    )
+
     # Load candidates and build blocking index.
     candidates = _load_candidates(staging_dir)
 
     if not candidates:
+        # Bio shards present but zero candidate rows — an honest empty, NOT a
+        # missing input (distinct from the raise above), so it stays a warning.
         logger.warning("disambiguate_no_candidates")
         return []
 
     index = _build_blocking_index(candidates)
 
-    # Check mention count without loading data.
+    # Check mention count without loading data. da#361: an absent/zero mentions file
+    # is NOT a missing input here — NER legitimately produces zero mentions for a
+    # bio-only corpus (e.g. muhaddithat, which NER skips) or an all-null-isnad
+    # subset. That is "an input that ran and legitimately produced nothing", which
+    # the da#361 defect definition explicitly excludes, so this stays an honest
+    # empty return, NOT a ``require_input`` raise. (The bio candidates above ARE
+    # required and DO raise when absent.)
     total_mentions = _count_mentions(output_dir)
     if total_mentions == 0:
         logger.warning("disambiguate_no_mentions")

--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -128,6 +128,7 @@ import pyarrow.parquet as pq
 from src.models.enums import DatePrecision, NarratorGeneration
 from src.parse.base import safe_str, write_parquet
 from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
+from src.resolve._inputs import require_input
 from src.resolve.generic_name import is_generic_name
 from src.resolve.mononym_split import _MAX_GAP, _MIN_GAP, is_registered_mononym
 from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
@@ -600,17 +601,31 @@ def split_generic_narrators(output_dir: Path, *, staging_dir: Path | None = None
     is accepted for run_all call-shape parity; this stage keeps no checkpoint (it is a
     single idempotent pass, like reconcile/tabaqa_dates).
     """
+    # Required input (da#361): the canonical table, produced by disambiguate/bio_promote
+    # earlier THIS run. By the time narrator_split runs (step 3.55) at least one of
+    # those has run in any non-empty resolve, so an absent canonical table is an
+    # upstream defect — raise, not a success-shaped ``None``. A canonical table that
+    # EXISTS but is empty (zero records) is the honest no-op below.
     canonical_path = output_dir / "narrators_canonical.parquet"
     mentions_path = output_dir / "narrator_mentions_resolved.parquet"
-    if not canonical_path.exists():
-        logger.warning("narrator_split_no_canonical", path=str(canonical_path))
-        return None
+    require_input(
+        stage="narrator_split",
+        present=canonical_path.exists(),
+        input_desc=f"{canonical_path.name} (canonical narrators)",
+        produced_by="resolve disambiguate/bio_promote stages",
+        remediation="re-run resolve from `disambiguate`; the canonical table is absent",
+    )
     if not mentions_path.exists():
+        # da#361: an absent mentions file is NOT a missing input here — NER
+        # legitimately produces zero mentions for a bio-only corpus (bio_promote
+        # still writes a canonical table with no chain mentions to split). A genuine
+        # no-op, not a defect, so it returns ``None`` rather than raising.
         logger.warning("narrator_split_no_mentions", path=str(mentions_path))
         return None
 
     records = pq.read_table(canonical_path).to_pylist()
     if not records:
+        # Canonical table present but empty — an honest no-op, not a missing input.
         return None
 
     name_by_id: dict[str, str] = {}

--- a/src/resolve/ner.py
+++ b/src/resolve/ner.py
@@ -23,6 +23,7 @@ from src.exit_codes import EXIT_UNROUTED_CORPUS
 from src.parse.base import safe_str, write_parquet
 from src.parse.name_quality import clean_narrator_name, strip_markup
 from src.parse.narrator_extraction import IsnadSegmentationError, extract_narrator_mentions
+from src.resolve._inputs import require_input
 from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA
 from src.utils.arabic import is_arabic, normalize_arabic
 from src.utils.logging import get_logger
@@ -166,11 +167,35 @@ def _load_phase1_mentions(
     staging_dir: Path,
     corpus: str,
     filename: str,
+    *,
+    required: bool = False,
 ) -> list[dict[str, str | int | None]]:
-    """Load pre-extracted Phase 1 narrator mentions and map to resolved schema."""
+    """Load pre-extracted Phase 1 narrator mentions and map to resolved schema.
+
+    ``required`` (da#361): when the corpus is actually staged (present in
+    ``_discover_staged_corpora``) its Phase-1 mentions file MUST exist — its
+    absence is an upstream defect (parse mis-wrote or never ran), not an empty
+    result, so :func:`require_input` raises. When the corpus is merely a
+    *configured* Phase-1 source that is not part of this (partial) staging subset,
+    ``required`` is ``False`` and the absent file is a legitimate skip: ``run``
+    loops over every configured source, and resolving a subset of corpora is a
+    supported mode (this is why ``run`` on an empty staging dir must NOT raise).
+    """
     path = staging_dir / filename
     if not path.exists():
-        logger.warning("phase1_mentions_missing", corpus=corpus, path=str(path))
+        require_input(
+            stage="ner",
+            present=not required,
+            input_desc=f"{filename} (Phase-1 mentions for staged corpus {corpus!r})",
+            produced_by="parse (Phase-1 mention extractor)",
+            remediation=(
+                f"corpus {corpus!r} is staged but its Phase-1 mentions file is absent; "
+                "re-run `parse` for it"
+            ),
+        )
+        # required is False: a configured Phase-1 source simply absent from this
+        # (partial) staging subset — a legitimate skip, not a defect.
+        logger.info("phase1_mentions_absent_unstaged", corpus=corpus, path=str(path))
         return []
 
     table = pq.read_table(path)
@@ -226,12 +251,31 @@ def _extract_from_hadiths(
     staging_dir: Path,
     corpus: str,
     language: str,
+    *,
+    required: bool = False,
 ) -> list[dict[str, str | int | None]]:
-    """Extract narrator mentions from hadith Parquet files for a given corpus."""
+    """Extract narrator mentions from hadith Parquet files for a given corpus.
+
+    ``required`` (da#361): same discrimination as :func:`_load_phase1_mentions`. A
+    staged corpus (present in ``_discover_staged_corpora``) routed here MUST have
+    its ``hadiths_{corpus}*.parquet`` — its absence is an upstream defect and
+    :func:`require_input` raises. A configured Arabic/English source that is not in
+    this staging subset (``required=False``) is a legitimate skip.
+    """
     pattern = f"hadiths_{corpus}*.parquet"
     hadith_files = sorted(staging_dir.glob(pattern))
     if not hadith_files:
-        logger.warning("no_hadith_files", corpus=corpus, pattern=pattern)
+        require_input(
+            stage="ner",
+            present=not required,
+            input_desc=f"{pattern} (isnad text for staged corpus {corpus!r})",
+            produced_by="parse (hadith adapters)",
+            remediation=(
+                f"corpus {corpus!r} is staged but has no {pattern}; re-run `parse` for it"
+            ),
+        )
+        # required is False: configured source absent from this staging subset.
+        logger.info("hadiths_absent_unstaged", corpus=corpus, pattern=pattern)
         return []
 
     rows: list[dict[str, str | int | None]] = []
@@ -384,19 +428,26 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
 
     all_rows: list[dict[str, str | int | None]] = []
 
+    # da#361: a configured source is *required* only when it is actually staged.
+    # ``run`` loops over every configured source, but resolving a partial staging
+    # subset is supported, so an absent file for a non-staged source is a legitimate
+    # skip while an absent file for a STAGED corpus is an upstream defect that must
+    # fail loud (``require_input`` inside each helper). ``staged`` is already
+    # computed above for the da#369 routing guard.
+
     # Step 1: Load Phase 1 pre-extracted mentions (sanadset, lk).
     for corpus, filename in _PHASE1_MENTION_SOURCES.items():
-        rows = _load_phase1_mentions(staging_dir, corpus, filename)
+        rows = _load_phase1_mentions(staging_dir, corpus, filename, required=corpus in staged)
         all_rows.extend(rows)
 
     # Step 2: Extract from Arabic-text sources.
     for corpus in sorted(_ARABIC_SOURCES):
-        rows = _extract_from_hadiths(staging_dir, corpus, language="ar")
+        rows = _extract_from_hadiths(staging_dir, corpus, language="ar", required=corpus in staged)
         all_rows.extend(rows)
 
     # Step 3: Extract from English-only sources.
     for corpus in sorted(_ENGLISH_SOURCES):
-        rows = _extract_from_hadiths(staging_dir, corpus, language="en")
+        rows = _extract_from_hadiths(staging_dir, corpus, language="en", required=corpus in staged)
         all_rows.extend(rows)
 
     # Step 4: Log deferred sources -- isnad-in-matn corpora explicitly held until

--- a/src/resolve/tabaqa_dates.py
+++ b/src/resolve/tabaqa_dates.py
@@ -195,6 +195,11 @@ def apply_tabaqa_fallback(output_dir: Path) -> Path | None:
     Returns the canonical path, or ``None`` when it does not yet exist (the stage
     is a no-op until the prior resolve stages have produced the table).
     """
+    # OPTIONAL input (da#361): like date_reconcile, this is a pure date-enricher —
+    # with no canonical table there are no narrators to estimate ṭabaqa windows for,
+    # so an absent table is an honest no-op, not an upstream defect. Confirmed as
+    # intended (da#361 carved date_reconcile + tabaqa_dates out of the fail-loud
+    # set): it does NOT call ``require_input`` and returns ``None`` by design.
     canonical_path = output_dir / "narrators_canonical.parquet"
     if not canonical_path.exists():
         logger.warning("tabaqa_fallback_no_canonical", path=str(canonical_path))

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -17,6 +17,7 @@ from src.parse.name_quality import (
     cleaner_removed_content,
 )
 from src.parse.schemas import NARRATOR_ALIAS_SCHEMA, NARRATOR_BIO_SCHEMA
+from src.resolve import MissingInputError
 from src.resolve.bio_promote import promote_bios_to_canonical
 from src.utils.arabic import normalize_arabic
 
@@ -214,12 +215,37 @@ def test_merges_into_existing_canonical(tmp_path: Path) -> None:
     assert len(ids) == 2  # plus the new itqan-derived narrator
 
 
-def test_no_bio_files_returns_none(tmp_path: Path) -> None:
+def test_no_bio_files_raises_missing_input(tmp_path: Path) -> None:
+    """da#361: absent bio shards = an upstream defect, not an empty result.
+
+    RED before da#361: this returned a success-shaped ``None`` indistinguishable
+    from a genuine empty (see the present-but-empty case below).
+    """
     staging = tmp_path / "staging"
     staging.mkdir()
     out_dir = tmp_path / "curated"
     out_dir.mkdir()
-    assert promote_bios_to_canonical(staging, out_dir) is None
+    with pytest.raises(MissingInputError) as excinfo:
+        promote_bios_to_canonical(staging, out_dir)
+    assert excinfo.value.stage == "bio_promote"
+    assert "narrators_bio_*.parquet" in str(excinfo.value)
+
+
+def test_present_but_empty_bio_shard_still_succeeds(tmp_path: Path) -> None:
+    """da#361 distinction: a bio shard that EXISTS but is source-filtered to zero
+    promotable rows is a genuine empty — it must NOT raise. The input is present, so
+    the stage completes honestly (writing its canonical table), unlike the absent
+    case above which raises."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    # A real (schema-valid) bio shard whose only row is filtered out by ``sources``.
+    _write_bios(staging, "itqan", [{"bio_id": "b1", "name_ar": "محمد", "source": "itqan"}])
+    # Restrict to a source the shard does not carry: input present, zero promoted —
+    # an honest success (a written canonical path), never a raise.
+    result = promote_bios_to_canonical(staging, out_dir, sources={"not_a_real_source"})
+    assert result is not None
 
 
 def test_aliases_attach_to_matching_canonical(tmp_path: Path) -> None:

--- a/tests/test_resolve/test_dedup.py
+++ b/tests/test_resolve/test_dedup.py
@@ -12,6 +12,7 @@ import pyarrow.parquet as pq
 import pytest
 
 from src.models.enums import VariantType
+from src.resolve import MissingInputError
 from src.resolve._provenance import DetectorStatus, read_provenance
 from src.resolve.dedup import (
     _classify_pair,
@@ -281,16 +282,22 @@ class TestEmbeddingPipeline:
 # ---------------------------------------------------------------------------
 @ml
 class TestEmptyInput:
-    def test_empty_output_on_no_hadith_files(self, tmp_path: Path) -> None:
-        """Case A. Still non-fatal, but no longer conflated with Case B.
+    def test_no_hadith_files_raises_missing_input(self, tmp_path: Path) -> None:
+        """Case A (da#361): zero input files = an upstream defect (parse produced
+        nothing / wrong staging_dir), not a true negative — so it now RAISES rather
+        than writing a success-shaped empty output.
 
-        Zero input files means the upstream parse stage produced nothing — an
-        upstream defect rather than a true negative. Making it fatal is a
-        behaviour change tracked as a follow-up, not folded into da#309.
+        RED before da#361: da#309 stamped this ``NO_INPUT`` but left it non-fatal
+        (``return _write_empty_output(...)``), explicitly deferring the fatal turn
+        as "tracked separately" — this is that follow-up, landable now that da#360
+        makes ``run_all`` surface the raise instead of swallowing it. Case B below
+        (files present, no English matn) is still an honest empty success, so the
+        two remain distinguishable.
         """
-        path = run_dedup(tmp_path)
-        assert path.exists()
-        assert pq.read_table(path).num_rows == 0
+        with pytest.raises(MissingInputError) as excinfo:
+            run_dedup(tmp_path)
+        assert excinfo.value.stage == "dedup"
+        assert not (tmp_path / "parallel_links.parquet").exists()
 
     def test_empty_output_when_no_row_has_english_matn(self, tmp_path: Path) -> None:
         """Case B: a legitimate empty input for an English-matn semantic detector."""

--- a/tests/test_resolve/test_discriminated_stage_result.py
+++ b/tests/test_resolve/test_discriminated_stage_result.py
@@ -40,6 +40,7 @@ from src.resolve import (
     disambiguate,
     fuzzy_cluster,
     muhaddithat_links,
+    narrator_split,
     ner,
     parallels,
     run_all,
@@ -71,6 +72,7 @@ def _install_benign_spies(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(bio_promote, "promote_bios_to_canonical", lambda *_a, **_k: None)
     metrics = type("M", (), {"merged_records": 0, "multi_member_clusters": 0})()
     monkeypatch.setattr(fuzzy_cluster, "cluster_canonical_narrators", lambda *_a, **_k: metrics)
+    monkeypatch.setattr(narrator_split, "split_generic_narrators", lambda *_a, **_k: None)
     monkeypatch.setattr(date_reconcile, "reconcile_canonical_dates", lambda *_a, **_k: None)
     monkeypatch.setattr(tabaqa_dates, "apply_tabaqa_fallback", lambda *_a, **_k: None)
     monkeypatch.setattr(

--- a/tests/test_resolve/test_missing_input_fail_loud.py
+++ b/tests/test_resolve/test_missing_input_fail_loud.py
@@ -1,0 +1,287 @@
+"""Missing-required-input fail-loud guards for resolve stages (da#361).
+
+Before da#361 several ``src/resolve`` stages returned a success-shaped empty
+result — ``[]`` / ``None`` / a zero-row parquet — when a **required** input
+artifact was absent (an upstream defect: parse never ran, or ran against the
+wrong dir). That empty was indistinguishable to every caller, and to the process
+exit status, from an input that ran and legitimately produced nothing. This is
+the #309 defect class (a missing *dependency*) one layer up (a missing *input*),
+and it is landable now that #360 makes ``run_all`` surface a raise instead of
+swallowing it.
+
+Each test below is RED on origin: the stage returned an empty success. The
+paired "present-but-empty" test pins the *other* side of the distinction — a
+genuine empty must still succeed honestly — so the fix cannot be a blanket
+"empty == error".
+
+The dedup / bio_promote / narrator_split sites are covered in their own suites
+(``test_dedup.py``, ``test_bio_promote.py``, ``test_narrator_split.py``); this
+file covers the ner + disambiguate sites, the ``MissingInputError`` contract, and
+the ``run_all`` → exit-code integration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.parse.schemas import NARRATOR_BIO_SCHEMA
+from src.resolve import (
+    MissingDependencyError,
+    MissingInputError,
+    ResolveStageError,
+    bio_promote,
+    date_reconcile,
+    dedup,
+    disambiguate,
+    fuzzy_cluster,
+    muhaddithat_links,
+    narrator_split,
+    parallels,
+    run_all,
+    tabaqa_dates,
+)
+from src.resolve import ner as ner_mod
+from src.resolve._inputs import require_input
+from src.resolve.disambiguate import _load_mentions
+from src.resolve.disambiguate import run as disambiguate_run
+from src.resolve.ner import _extract_from_hadiths, _load_phase1_mentions
+from src.resolve.ner import run as ner_run
+from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA
+from tests.factories import build_hadith_table
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / writers
+# --------------------------------------------------------------------------- #
+def _write_bios(staging: Path, rows: list[dict[str, object]]) -> Path:
+    """Write a schema-valid narrators_bio_test.parquet from partial rows."""
+    full = [{**{f.name: None for f in NARRATOR_BIO_SCHEMA}, **r} for r in rows]
+    arrays = {f.name: [r[f.name] for r in full] for f in NARRATOR_BIO_SCHEMA}
+    path = staging / "narrators_bio_test.parquet"
+    pq.write_table(pa.table(arrays, schema=NARRATOR_BIO_SCHEMA), path)
+    return path
+
+
+def _write_mentions(output: Path, rows: list[dict[str, object]]) -> Path:
+    """Write a schema-valid narrator_mentions_resolved.parquet from partial rows."""
+    full = [{**{f.name: None for f in NARRATOR_MENTIONS_RESOLVED_SCHEMA}, **r} for r in rows]
+    arrays = {f.name: [r[f.name] for r in full] for f in NARRATOR_MENTIONS_RESOLVED_SCHEMA}
+    path = output / "narrator_mentions_resolved.parquet"
+    pq.write_table(pa.table(arrays, schema=NARRATOR_MENTIONS_RESOLVED_SCHEMA), path)
+    return path
+
+
+def _staging_output(tmp_path: Path) -> tuple[Path, Path]:
+    staging = tmp_path / "staging"
+    output = tmp_path / "output"
+    staging.mkdir()
+    output.mkdir()
+    return staging, output
+
+
+# --------------------------------------------------------------------------- #
+# MissingInputError contract
+# --------------------------------------------------------------------------- #
+class TestMissingInputErrorContract:
+    def test_is_an_exception_not_a_baseexception(self) -> None:
+        """Unlike ``MissingDependencyError`` (which sails PAST ``run_all``'s
+        ``except Exception`` to its own exit code), ``MissingInputError`` is a
+        plain ``Exception`` ON PURPOSE, so ``run_all`` CATCHES it as a
+        ``StageErrored`` and reuses the da#360 fail-loud machinery."""
+        assert issubclass(MissingInputError, Exception)
+        assert not issubclass(MissingDependencyError, Exception)  # BaseException-only
+
+    def test_require_input_raises_on_absent_and_passes_on_present(self) -> None:
+        # present=True → no raise.
+        require_input(stage="s", present=True, input_desc="x", produced_by="p", remediation="r")
+        # present=False → raise, message naming stage + input + remediation.
+        with pytest.raises(MissingInputError) as excinfo:
+            require_input(
+                stage="ner",
+                present=False,
+                input_desc="foo.parquet",
+                produced_by="parse",
+                remediation="re-run parse",
+            )
+        msg = str(excinfo.value)
+        assert "ner" in msg and "foo.parquet" in msg and "re-run parse" in msg
+
+
+# --------------------------------------------------------------------------- #
+# NER — a STAGED corpus missing its expected input is a defect; an UNSTAGED
+# configured source simply absent from a partial staging subset is legitimate.
+# --------------------------------------------------------------------------- #
+class TestNerMissingInput:
+    def test_staged_phase1_corpus_missing_mentions_raises(self, tmp_path: Path) -> None:
+        """RED on origin: sanadset's hadiths are staged (so it is a real corpus in
+        this run) but its Phase-1 mentions file is absent — NER returned ``[]`` and
+        the pipeline marched on. Now it fails loud."""
+        staging, output = _staging_output(tmp_path)
+        # sanadset staged (via a hadiths shard carrying source_corpus=sanadset) but
+        # its required narrator_mentions_sanadset.parquet is NOT written.
+        table = build_hadith_table([{"source_id": "s-1", "source_corpus": "sanadset"}])
+        pq.write_table(table, staging / "hadiths_sanadset.parquet")
+
+        with pytest.raises(MissingInputError) as excinfo:
+            ner_run(staging, output)
+        assert excinfo.value.stage == "ner"
+        assert "narrator_mentions_sanadset.parquet" in str(excinfo.value)
+
+    def test_empty_staging_does_not_raise(self, tmp_path: Path) -> None:
+        """Distinction: an EMPTY staging tree stages no corpus, so every configured
+        source is unstaged (required=False) — a legitimate skip, not a defect. This
+        is why partial-staging / standalone runs keep working."""
+        staging, output = _staging_output(tmp_path)
+        assert ner_run(staging, output) == []
+
+    def test_unstaged_configured_source_absent_is_legitimate(self, tmp_path: Path) -> None:
+        """Only ONE corpus staged (thaqalayn, Arabic-routed); sanadset/lk/sunnah are
+        configured but unstaged, so their absent files do NOT raise."""
+        staging, output = _staging_output(tmp_path)
+        # thaqalayn present with a real isnad so it extracts; no other corpus staged.
+        table = build_hadith_table(
+            [{"source_id": "t-1", "source_corpus": "thaqalayn", "isnad_raw_ar": "حدثنا محمد"}]
+        )
+        pq.write_table(table, staging / "hadiths_thaqalayn.parquet")
+        # Must not raise (sanadset/lk phase1 + sunnah english are unstaged).
+        result = ner_run(staging, output)
+        assert isinstance(result, list)
+
+    def test_extract_helper_required_absent_raises(self, tmp_path: Path) -> None:
+        """Helper-level: ``required=True`` + no hadith files → raise."""
+        staging, _ = _staging_output(tmp_path)
+        with pytest.raises(MissingInputError):
+            _extract_from_hadiths(staging, "thaqalayn", language="ar", required=True)
+
+    def test_extract_helper_not_required_absent_returns_empty(self, tmp_path: Path) -> None:
+        """Helper-level: ``required=False`` (default) + no hadith files → honest []."""
+        staging, _ = _staging_output(tmp_path)
+        assert _extract_from_hadiths(staging, "thaqalayn", language="ar") == []
+
+    def test_phase1_helper_required_absent_raises(self, tmp_path: Path) -> None:
+        staging, _ = _staging_output(tmp_path)
+        with pytest.raises(MissingInputError):
+            _load_phase1_mentions(staging, "sanadset", "missing.parquet", required=True)
+
+    def test_phase1_helper_not_required_absent_returns_empty(self, tmp_path: Path) -> None:
+        staging, _ = _staging_output(tmp_path)
+        assert _load_phase1_mentions(staging, "sanadset", "missing.parquet") == []
+
+
+# --------------------------------------------------------------------------- #
+# Disambiguate — candidate bios (staging) + NER mention output (output_dir).
+# --------------------------------------------------------------------------- #
+class TestDisambiguateMissingInput:
+    def test_no_bio_files_raises(self, tmp_path: Path) -> None:
+        """RED on origin: no candidate bio shards → ``[]`` (silent). Now raises."""
+        staging, output = _staging_output(tmp_path)
+        with pytest.raises(MissingInputError) as excinfo:
+            disambiguate_run(staging, output)
+        assert excinfo.value.stage == "disambiguate"
+        assert "narrators_bio_*.parquet" in str(excinfo.value)
+
+    def test_present_but_empty_bio_shard_is_honest_empty(self, tmp_path: Path) -> None:
+        """Distinction: a bio shard that EXISTS but has zero rows is a genuine empty
+        (no candidates) — an honest ``[]``, NOT a raise."""
+        staging, output = _staging_output(tmp_path)
+        _write_bios(staging, [])  # present, zero candidate rows
+        assert disambiguate_run(staging, output) == []
+
+    def test_bios_present_mentions_absent_is_honest_empty(self, tmp_path: Path) -> None:
+        """da#361 carve-out: candidates present but the NER mention output ABSENT is
+        NOT a missing input — NER legitimately produces zero mentions for a bio-only
+        corpus (e.g. muhaddithat), so disambiguate no-ops honestly (``[]``), never
+        raises. (The bio candidates ARE required and DO raise when absent.)"""
+        staging, output = _staging_output(tmp_path)
+        _write_bios(
+            staging,
+            [{"bio_id": "b1", "source": "itqan", "name_ar": "محمد", "name_ar_normalized": "محمد"}],
+        )
+        # No narrator_mentions_resolved.parquet in output_dir — legitimate empty.
+        assert disambiguate_run(staging, output) == []
+
+    def test_bios_present_mentions_present_but_empty_is_honest_empty(self, tmp_path: Path) -> None:
+        """Same carve-out with the mentions file present but zero rows — honest []."""
+        staging, output = _staging_output(tmp_path)
+        _write_bios(
+            staging,
+            [{"bio_id": "b1", "source": "itqan", "name_ar": "محمد", "name_ar_normalized": "محمد"}],
+        )
+        _write_mentions(output, [])  # present, zero mention rows
+        assert disambiguate_run(staging, output) == []
+
+    def test_dead_code_load_mentions_helper_raises_on_absent(self, tmp_path: Path) -> None:
+        """``_load_mentions`` is currently uncalled (``run`` uses ``_count_mentions``)
+        but is kept honest so a future re-wiring inherits the fail-loud contract."""
+        staging, _ = _staging_output(tmp_path)
+        with pytest.raises(MissingInputError):
+            _load_mentions(staging)
+
+
+# --------------------------------------------------------------------------- #
+# Optional inputs — date_reconcile + tabaqa_dates are carved OUT of fail-loud.
+# --------------------------------------------------------------------------- #
+class TestOptionalInputsDoNotRaise:
+    def test_date_reconcile_no_canonical_is_noop(self, tmp_path: Path) -> None:
+        from src.resolve.date_reconcile import reconcile_canonical_dates
+
+        staging, output = _staging_output(tmp_path)
+        assert reconcile_canonical_dates(staging, output) is None
+
+    def test_tabaqa_dates_no_canonical_is_noop(self, tmp_path: Path) -> None:
+        from src.resolve.tabaqa_dates import apply_tabaqa_fallback
+
+        _, output = _staging_output(tmp_path)
+        assert apply_tabaqa_fallback(output) is None
+
+
+# --------------------------------------------------------------------------- #
+# run_all integration — a MissingInputError from a real stage is caught as a
+# StageErrored (da#360) and surfaces as ResolveStageError, never a silent exit 0.
+# --------------------------------------------------------------------------- #
+def test_run_all_surfaces_missing_input_as_stage_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stage that raises ``MissingInputError`` inside ``run_all`` must be recorded
+    as a ``StageErrored`` and re-raised as ``ResolveStageError`` — i.e. da#360's
+    machinery catches it (proving the ``Exception``-not-``BaseException`` choice)."""
+    staging = tmp_path / "staging"
+    output = tmp_path / "output"
+    staging.mkdir()
+    output.mkdir()
+    # Pre-flight needs a staging parquet.
+    pq.write_table(pa.table({"x": [1]}), staging / "hadiths_test.parquet")
+
+    # Neutralise every other stage (dedup would raise MissingDependencyError without
+    # ml; narrator_split would raise its own MissingInputError) so exactly
+    # bio_promote raises MissingInputError.
+    monkeypatch.setattr(ner_mod, "run", lambda *_a, **_k: [])
+    monkeypatch.setattr(disambiguate, "run", lambda *_a, **_k: [])
+    _metrics = type("M", (), {"merged_records": 0, "multi_member_clusters": 0})()
+    monkeypatch.setattr(fuzzy_cluster, "cluster_canonical_narrators", lambda *_a, **_k: _metrics)
+    monkeypatch.setattr(narrator_split, "split_generic_narrators", lambda *_a, **_k: None)
+    monkeypatch.setattr(date_reconcile, "reconcile_canonical_dates", lambda *_a, **_k: None)
+    monkeypatch.setattr(tabaqa_dates, "apply_tabaqa_fallback", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        muhaddithat_links, "build_muhaddithat_mention_links", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(dedup, "run", lambda *_a, **_k: [])
+    monkeypatch.setattr(parallels, "run", lambda *_a, **_k: [])
+
+    def _boom(*_a: object, **_k: object) -> object:
+        raise MissingInputError(
+            stage="bio_promote",
+            input_desc="narrators_bio_*.parquet",
+            produced_by="parse",
+            remediation="re-run parse",
+        )
+
+    monkeypatch.setattr(bio_promote, "promote_bios_to_canonical", _boom)
+
+    with pytest.raises(ResolveStageError) as excinfo:
+        run_all(tmp_path / "raw", staging, output)
+    assert "bio_promote" in [e.step for e in excinfo.value.errored]

--- a/tests/test_resolve/test_narrator_split.py
+++ b/tests/test_resolve/test_narrator_split.py
@@ -20,9 +20,11 @@ from typing import Any
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 
 from src.models.enums import DatePrecision
 from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
+from src.resolve import MissingInputError
 from src.resolve.generic_name import is_generic_name
 from src.resolve.narrator_split import (
     MID_GAP,
@@ -231,8 +233,38 @@ def _read_canonical(out: Path) -> dict[str, dict[str, Any]]:
     }
 
 
-def test_stage_no_canonical_is_noop(tmp_path: Path) -> None:
-    assert split_generic_narrators(tmp_path) is None
+def test_stage_no_canonical_raises_missing_input(tmp_path: Path) -> None:
+    """da#361: an absent canonical table = an upstream defect (disambiguate/bio_promote
+    did not run this pass), not a no-op. RED before da#361: returned ``None``."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(MissingInputError) as excinfo:
+        split_generic_narrators(tmp_path)
+    assert excinfo.value.stage == "narrator_split"
+    assert "narrators_canonical.parquet" in str(excinfo.value)
+
+
+def test_stage_canonical_present_no_mentions_is_honest_noop(tmp_path: Path) -> None:
+    """da#361 carve-out: canonical present but the NER mention output ABSENT is NOT a
+    missing input — a bio-only corpus has a canonical table (from bio_promote) and no
+    chain mentions to split, so the stage no-ops honestly (``None``), never raises."""
+    out = tmp_path / "out"
+    out.mkdir(parents=True, exist_ok=True)
+    # Write only the canonical table; leave narrator_mentions_resolved.parquet absent.
+    c = [_canonical_row("nar:x", normalize_arabic("محمد"), 3)]
+    c_arrays = {f.name: [r[f.name] for r in c] for f in NARRATORS_CANONICAL_SCHEMA}
+    pq.write_table(
+        pa.table(c_arrays, schema=NARRATORS_CANONICAL_SCHEMA),
+        out / "narrators_canonical.parquet",
+    )
+    assert split_generic_narrators(out) is None
+
+
+def test_stage_empty_canonical_is_honest_noop(tmp_path: Path) -> None:
+    """da#361 distinction: both inputs PRESENT but the canonical table is genuinely
+    empty (zero records) — an honest no-op ``None``, NOT a raise."""
+    out = tmp_path / "out"
+    _write(out, canonical=[], mentions=[])
+    assert split_generic_narrators(out) is None
 
 
 def test_stage_splits_two_bands_and_peels(tmp_path: Path) -> None:

--- a/tests/test_resolve/test_resolve_from_step.py
+++ b/tests/test_resolve/test_resolve_from_step.py
@@ -26,6 +26,7 @@ from src.resolve import (
     disambiguate,
     fuzzy_cluster,
     muhaddithat_links,
+    narrator_split,
     ner,
     parallels,
     run_all,
@@ -64,6 +65,7 @@ def _install_spies(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     monkeypatch.setattr(
         fuzzy_cluster, "cluster_canonical_narrators", spy("cluster", cluster_metrics)
     )
+    monkeypatch.setattr(narrator_split, "split_generic_narrators", spy("narrator_split", None))
     monkeypatch.setattr(date_reconcile, "reconcile_canonical_dates", spy("reconcile", None))
     monkeypatch.setattr(tabaqa_dates, "apply_tabaqa_fallback", spy("tabaqa_dates", None))
     monkeypatch.setattr(

--- a/tests/test_resolve/test_run_all.py
+++ b/tests/test_resolve/test_run_all.py
@@ -20,7 +20,7 @@ import pyarrow.parquet as pq
 
 from src.parse.identity import make_canonical_id
 from src.parse.schemas import NARRATOR_BIO_SCHEMA
-from src.resolve import bio_promote, dedup, disambiguate, ner, parallels, run_all
+from src.resolve import bio_promote, dedup, disambiguate, narrator_split, ner, parallels, run_all
 from src.utils.arabic import normalize_arabic
 from tests.test_graph.conftest import write_hadiths, write_narrator_mentions_resolved
 
@@ -61,6 +61,9 @@ def test_run_all_invokes_bio_promote_and_parallels_disambiguate_first(
     monkeypatch.setattr(ner, "run", _rec("ner", [staging / "mentions"]))
     monkeypatch.setattr(disambiguate, "run", _rec("disambiguate", []))
     monkeypatch.setattr(bio_promote, "promote_bios_to_canonical", _rec("bio_promote", None))
+    # narrator_split now fails loud on an absent canonical table (da#361); this
+    # disambiguate spy writes no canonical, so spy it too or run_all raises.
+    monkeypatch.setattr(narrator_split, "split_generic_narrators", _rec("narrator_split", None))
     monkeypatch.setattr(dedup, "run", _rec("dedup", []))
     monkeypatch.setattr(parallels, "run", _rec("parallels", []))
 


### PR DESCRIPTION
## What & why

`resolve` returned a **success-shaped empty** (`[]` / `None` / a zero-row parquet) when a **required input artifact was absent** — the same defect class as #309 (a missing *dependency*) one layer up (a missing *input*), and as #360 (a swallowed raise). A missing input means an upstream stage did not run (or ran against the wrong dir): an upstream defect, indistinguishable to every caller and to the exit status from an input that ran and legitimately produced nothing.

Landable now because **#360** makes `run_all` surface a raise instead of swallowing it.

## Mechanism

New shared guard `src/resolve/_inputs.py` mirroring `_deps.py`:

- `require_input(present=...)` raises `MissingInputError` on an absent required input.
- `MissingInputError` subclasses **`Exception`** (not `BaseException` like `MissingDependencyError`) **on purpose** — so `run_all` **catches** it as a `StageErrored` and reuses #360's machinery → exit `EXIT_STAGE_FAILED` (11). No new exit code, no CLI change.
- Fires **only on absence** — each site keeps its honest empty return for the present-but-zero-rows true negative. The two stay distinguishable (not a blanket "empty == error").

## Site enumeration (all 11 from the issue, measured at HEAD)

**Made fatal (absent required input → raise):**
| Site | Input | Notes |
|---|---|---|
| dedup `run_dedup` | `hadiths_*.parquet` | the `NO_INPUT` case #309 stamped and explicitly deferred as "tracked separately" — this is that follow-up. `NO_TEXTS` stays an honest empty. |
| ner `_load_phase1_mentions` | phase1 mentions of a **staged** corpus | staged-aware |
| ner `_extract_from_hadiths` | hadiths of a **staged** corpus | staged-aware |
| disambiguate `run` | `narrators_bio_*.parquet` (candidates) | present-but-0-rows → honest `[]` |
| bio_promote | `narrators_bio_*.parquet` | present-but-all-filtered → honest success |
| narrator_split | `narrators_canonical.parquet` | empty canonical → honest no-op |
| disambiguate `_load_mentions` | mentions | currently uncalled; kept honest for future wire-up |

**Left honest (NOT this defect class — a measurement finding):** NER legitimately produces zero mentions for a bio-only corpus (e.g. `muhaddithat`, which NER skips) — "an input that ran and produced nothing", which #361 explicitly excludes. So these stay honest no-ops:
- disambiguate `_count_mentions()==0`
- narrator_split absent `narrator_mentions_resolved.parquet`

The **`muhaddithat` live integration test** is the oracle that proved raising on these two was a false positive on a legitimate bio-only resolve.

**Optional, confirmed & declared (no raise):** `date_reconcile`, `tabaqa_dates` — pure date-enrichers with no narrators to date when the canonical table is absent.

**Staged-aware ner:** `run` loops over *configured* sources; a source merely absent from a partial staging subset is a legitimate skip. Only a corpus that IS staged but missing its expected file raises — so empty/partial-staging runs (and `test_empty_staging_dir`) keep working.

## Red-first evidence

- `test_missing_input_fail_loud.py` (new, 17 tests): ner + disambiguate raises, the `MissingInputError` contract (`Exception` not `BaseException`), each raise paired with a present-but-empty honest-success test, `run_all` → `ResolveStageError` integration, and the two optional/carve-out no-ops.
- Flipped in place (were asserting the old empty success): `test_dedup.py::TestEmptyInput` (`@ml`), `test_bio_promote.py::test_no_bio_files_*`, `test_narrator_split.py::test_stage_no_canonical_*`.
- Three `run_all` spy harnesses now also stub `narrator_split` (their "replace every stage" contract previously omitted it — harmless only while it silently no-op'd).

Full suite green under `uv run` (`2047 passed`, integration deselected); the `muhaddithat` live suite passes (`3 passed`) with Docker; ruff-format/lint + mypy-strict clean; pre-commit + pre-push hooks passed.

Closes #361
