### PR TITLE
feat(graph): prune-narrators subcommand — canonical-set SHRINK (da#413)

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -525,7 +525,12 @@ def _cmd_migrate_transmitted_hadith_ids(*, batch_size: int = 1000) -> None:
         print("\nMigration complete.")
 
 
-def _cmd_prune_narrators(*, canonical: str, dry_run: bool = False) -> None:
+def _cmd_prune_narrators(
+    *,
+    canonical: str,
+    dry_run: bool = False,
+    max_missing_fraction: float | None = None,
+) -> None:
     """DETACH DELETE Narrator nodes whose id is not in narrators_canonical.parquet (da#413).
 
     The canonical-set SHRINK: after a re-resolve collapses ids, the graph still holds
@@ -536,13 +541,28 @@ def _cmd_prune_narrators(*, canonical: str, dry_run: bool = False) -> None:
     nothing.
 
     Refuses — non-zero exit :attr:`ExitCode.EMPTY_CANONICAL_SET`, ZERO deletion — when
-    the canonical set is empty or its parquet is unreadable/missing. A bad read must
-    never wipe the graph.
+    the keep-set cannot be trusted: it is empty / unreadable / missing
+    (:class:`EmptyCanonicalSetError`), or it is well-formed but is not **this graph's**
+    (:class:`ForeignCanonicalSetError` — a stale ``--canonical``, caught by the
+    ``missing`` provenance signal). A bad read must never wipe the graph, and neither
+    must the wrong parquet.
     """
     from pathlib import Path
 
-    from src.graph.prune import EmptyCanonicalSetError, prune_narrators, summary_line
+    from src.graph.prune import (
+        DEFAULT_MAX_MISSING_FRACTION,
+        UnusableCanonicalSetError,
+        prune_narrators,
+        summary_line,
+    )
     from src.utils.neo4j_client import Neo4jClient
+
+    # `None` (not the literal) is the CLI default, so the ceiling has exactly one home:
+    # src.graph.prune. A hardcoded default here — the shape of migrate's `--batch-size`
+    # — is a second copy of a number that must not drift, and cli.py lazy-imports the
+    # module precisely so `--help` need not pay for pyarrow + the neo4j driver.
+    if max_missing_fraction is None:
+        max_missing_fraction = DEFAULT_MAX_MISSING_FRACTION
 
     # This command reads the canonical parquet and writes ONLY to the graph and
     # stdout. It never writes back into the parquet's directory (no manifest, no audit
@@ -551,21 +571,30 @@ def _cmd_prune_narrators(*, canonical: str, dry_run: bool = False) -> None:
 
     canonical_path = Path(canonical)
 
-    # The guard runs inside prune_narrators, BEFORE the graph is touched. Catch it
-    # here to exit the named code rather than crash — nothing was deleted.
+    # Both guards run inside prune_narrators, BEFORE any graph WRITE. Catch their common
+    # supertype here to exit the named code rather than crash — nothing was deleted.
     try:
-        # The guard reads the parquet, not the DB. Check connectivity first (like
+        # The first guard reads the parquet, not the DB. Check connectivity first (like
         # load/migrate) so an unreachable DB is DB_UNREACHABLE, not a later crash.
         _check_neo4j()
         with Neo4jClient() as client:
-            result = prune_narrators(client, canonical_path, dry_run=dry_run)
-    except EmptyCanonicalSetError as guard:
+            result = prune_narrators(
+                client,
+                canonical_path,
+                dry_run=dry_run,
+                max_missing_fraction=max_missing_fraction,
+            )
+    except UnusableCanonicalSetError as guard:
         print(f"\nERROR: {guard}", file=sys.stderr)
         sys.exit(ExitCode.EMPTY_CANONICAL_SET)
 
     print("=== prune-narrators (canonical-set shrink, da#413) ===")
     print(f"  Canonical ids (keep-set)   : {result.canonical_ids_seen}")
     print(f"  Orphans (id ∉ canonical)   : {result.orphans_identified}")
+    # The keep-set provenance reading. ~0 says the parquet is this graph's; a large value
+    # says it is a stale/foreign one — the one thing no post-op gate can check, because
+    # every one of them is derived from this same keep-set.
+    print(f"  Missing (canonical ∉ graph): {result.missing}")
     if result.sample:
         shown = ", ".join(result.sample)
         more = result.orphans_identified - len(result.sample)
@@ -772,6 +801,22 @@ def _cmd_pipeline() -> None:
     print("=== Full Pipeline Complete ===")
 
 
+def _unit_fraction(raw: str) -> float:
+    """argparse type for a fraction in [0.0, 1.0].
+
+    An out-of-range ceiling is operator error, so it must be argparse's usage exit (2),
+    not a traceback and not a silently clamped value that would quietly weaken a
+    destructive-op guard.
+    """
+    try:
+        value = float(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{raw!r} is not a number") from None
+    if not 0.0 <= value <= 1.0:
+        raise argparse.ArgumentTypeError(f"must be in [0.0, 1.0], got {value}")
+    return value
+
+
 def main() -> None:
     """Run the isnad-ingest CLI."""
     from src.graph.validate import _DEFAULT_VALIDATION_TIMEOUT_SECONDS
@@ -939,13 +984,29 @@ def main() -> None:
         help=(
             "Path to narrators_canonical.parquet. Its canonical_id set is the "
             "authoritative keep-set: every Narrator whose id is absent from it is "
-            "DETACH DELETEd. Refuses (exit 12, zero deletion) if empty/unreadable."
+            "DETACH DELETEd. Refuses (exit 12, zero deletion) if it is empty, missing "
+            "or unreadable — or if it is not THIS graph's keep-set (see "
+            "--max-missing-fraction). Point it at the parquet the live graph was "
+            "loaded from: a stale one deletes the narrators it fails to mention."
         ),
     )
     prune_parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Report the count that would be deleted (and a sample); delete nothing.",
+    )
+    prune_parser.add_argument(
+        "--max-missing-fraction",
+        type=_unit_fraction,
+        default=None,
+        metavar="FRACTION",
+        help=(
+            "Ceiling on 'missing' (canonical ids the graph has never seen), as a "
+            "fraction of the keep-set. Above it the keep-set is refused as belonging to "
+            "a DIFFERENT graph (exit 12, zero deletion) — the stale --canonical guard. "
+            "Default: half the keep-set. Raise it (up to 1.0, which disables the "
+            "ceiling) only when a genuinely large partial load is intended."
+        ),
     )
 
     audit_parser = subparsers.add_parser("audit", help="View recent pipeline audit entries")
@@ -1028,7 +1089,11 @@ def main() -> None:
     elif args.command == "migrate-transmitted-hadith-ids":
         _cmd_migrate_transmitted_hadith_ids(batch_size=args.batch_size)
     elif args.command == "prune-narrators":
-        _cmd_prune_narrators(canonical=args.canonical, dry_run=args.dry_run)
+        _cmd_prune_narrators(
+            canonical=args.canonical,
+            dry_run=args.dry_run,
+            max_missing_fraction=args.max_missing_fraction,
+        )
     elif args.command == "audit":
         _cmd_audit(last_n=args.last)
     elif args.command == "pipeline":

--- a/src/cli.py
+++ b/src/cli.py
@@ -525,6 +525,62 @@ def _cmd_migrate_transmitted_hadith_ids(*, batch_size: int = 1000) -> None:
         print("\nMigration complete.")
 
 
+def _cmd_prune_narrators(*, canonical: str, dry_run: bool = False) -> None:
+    """DETACH DELETE Narrator nodes whose id is not in narrators_canonical.parquet (da#413).
+
+    The canonical-set SHRINK: after a re-resolve collapses ids, the graph still holds
+    the orphaned ``Narrator`` nodes (many WITH edges — a zero-degree predicate misses
+    them). The only correct orphan predicate is canonical-set membership, which lives
+    in the parquet, so this is a da-side subcommand rather than a cypher-only job
+    (deploy#557). ``--dry-run`` reports the count that would be deleted and deletes
+    nothing.
+
+    Refuses — non-zero exit :attr:`ExitCode.EMPTY_CANONICAL_SET`, ZERO deletion — when
+    the canonical set is empty or its parquet is unreadable/missing. A bad read must
+    never wipe the graph.
+    """
+    from pathlib import Path
+
+    from src.graph.prune import EmptyCanonicalSetError, prune_narrators
+    from src.utils.neo4j_client import Neo4jClient
+
+    canonical_path = Path(canonical)
+
+    # The guard runs inside prune_narrators, BEFORE the graph is touched. Catch it
+    # here to exit the named code rather than crash — nothing was deleted.
+    try:
+        # _check_neo4j only after the guard would have a chance to fire? No: the guard
+        # reads the parquet, not the DB, and reads nothing destructive. Check
+        # connectivity first (like load/migrate) so an unreachable DB is DB_UNREACHABLE.
+        _check_neo4j()
+        with Neo4jClient() as client:
+            result = prune_narrators(client, canonical_path, dry_run=dry_run)
+    except EmptyCanonicalSetError as guard:
+        print(f"\nERROR: {guard}", file=sys.stderr)
+        sys.exit(ExitCode.EMPTY_CANONICAL_SET)
+
+    print("=== prune-narrators (canonical-set shrink, da#413) ===")
+    print(f"  Canonical ids (keep-set)   : {result.canonical_ids_seen}")
+    print(f"  Narrator nodes in graph    : {result.graph_narrators_seen}")
+    print(f"  Orphans (id ∉ canonical)   : {result.orphans_identified}")
+    if result.sample:
+        shown = ", ".join(result.sample)
+        more = result.orphans_identified - len(result.sample)
+        suffix = f" (+{more} more)" if more > 0 else ""
+        print(f"  Sample orphan ids          : {shown}{suffix}")
+    if dry_run:
+        print(
+            f"\nDRY RUN: {result.orphans_identified} Narrator node(s) WOULD be "
+            "DETACH DELETEd. Nothing was deleted."
+        )
+    else:
+        print(f"  Narrator nodes deleted     : {result.deleted}")
+        if result.orphans_identified == 0:
+            print("\nNo orphans — every Narrator in the graph is in the canonical set.")
+        else:
+            print("\nPrune complete.")
+
+
 def _cmd_enrich(
     *,
     only: list[str] | None = None,
@@ -858,6 +914,30 @@ def main() -> None:
         help="Edges rewritten per write batch (default: 1000)",
     )
 
+    prune_parser = subparsers.add_parser(
+        "prune-narrators",
+        help=(
+            "DETACH DELETE Narrator nodes whose id is not in narrators_canonical.parquet "
+            "(canonical-set shrink; da#413)"
+        ),
+    )
+    prune_parser.add_argument(
+        "--canonical",
+        type=str,
+        required=True,
+        metavar="PARQUET",
+        help=(
+            "Path to narrators_canonical.parquet. Its canonical_id set is the "
+            "authoritative keep-set: every Narrator whose id is absent from it is "
+            "DETACH DELETEd. Refuses (exit 12, zero deletion) if empty/unreadable."
+        ),
+    )
+    prune_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report the count that would be deleted (and a sample); delete nothing.",
+    )
+
     audit_parser = subparsers.add_parser("audit", help="View recent pipeline audit entries")
     audit_parser.add_argument(
         "--last",
@@ -937,6 +1017,8 @@ def main() -> None:
             sys.exit(ExitCode.VALIDATION_FINDINGS)
     elif args.command == "migrate-transmitted-hadith-ids":
         _cmd_migrate_transmitted_hadith_ids(batch_size=args.batch_size)
+    elif args.command == "prune-narrators":
+        _cmd_prune_narrators(canonical=args.canonical, dry_run=args.dry_run)
     elif args.command == "audit":
         _cmd_audit(last_n=args.last)
     elif args.command == "pipeline":

--- a/src/cli.py
+++ b/src/cli.py
@@ -541,17 +541,21 @@ def _cmd_prune_narrators(*, canonical: str, dry_run: bool = False) -> None:
     """
     from pathlib import Path
 
-    from src.graph.prune import EmptyCanonicalSetError, prune_narrators
+    from src.graph.prune import EmptyCanonicalSetError, prune_narrators, summary_line
     from src.utils.neo4j_client import Neo4jClient
+
+    # This command reads the canonical parquet and writes ONLY to the graph and
+    # stdout. It never writes back into the parquet's directory (no manifest, no audit
+    # entry, unlike `load`) — deploy#557 mounts that dir read-only, so a stray write
+    # would trip the :ro mount (da#348).
 
     canonical_path = Path(canonical)
 
     # The guard runs inside prune_narrators, BEFORE the graph is touched. Catch it
     # here to exit the named code rather than crash — nothing was deleted.
     try:
-        # _check_neo4j only after the guard would have a chance to fire? No: the guard
-        # reads the parquet, not the DB, and reads nothing destructive. Check
-        # connectivity first (like load/migrate) so an unreachable DB is DB_UNREACHABLE.
+        # The guard reads the parquet, not the DB. Check connectivity first (like
+        # load/migrate) so an unreachable DB is DB_UNREACHABLE, not a later crash.
         _check_neo4j()
         with Neo4jClient() as client:
             result = prune_narrators(client, canonical_path, dry_run=dry_run)
@@ -561,7 +565,6 @@ def _cmd_prune_narrators(*, canonical: str, dry_run: bool = False) -> None:
 
     print("=== prune-narrators (canonical-set shrink, da#413) ===")
     print(f"  Canonical ids (keep-set)   : {result.canonical_ids_seen}")
-    print(f"  Narrator nodes in graph    : {result.graph_narrators_seen}")
     print(f"  Orphans (id ∉ canonical)   : {result.orphans_identified}")
     if result.sample:
         shown = ", ".join(result.sample)
@@ -569,16 +572,23 @@ def _cmd_prune_narrators(*, canonical: str, dry_run: bool = False) -> None:
         suffix = f" (+{more} more)" if more > 0 else ""
         print(f"  Sample orphan ids          : {shown}{suffix}")
     if dry_run:
+        print(f"  Narrator nodes in graph    : {result.graph_total}")
         print(
             f"\nDRY RUN: {result.orphans_identified} Narrator node(s) WOULD be "
             "DETACH DELETEd. Nothing was deleted."
         )
     else:
         print(f"  Narrator nodes deleted     : {result.deleted}")
+        print(f"  Narrator nodes remaining   : {result.graph_total}")
+        print(f"  Orphans remaining (post)   : {result.orphans}")
         if result.orphans_identified == 0:
             print("\nNo orphans — every Narrator in the graph is in the canonical set.")
         else:
             print("\nPrune complete.")
+
+    # The load-bearing machine-readable line deploy#557's verify greps. Emitted on
+    # BOTH modes and last, so it is unmissable on stdout.
+    print(summary_line(result))
 
 
 def _cmd_enrich(

--- a/src/cli.py
+++ b/src/cli.py
@@ -530,6 +530,7 @@ def _cmd_prune_narrators(
     canonical: str,
     dry_run: bool = False,
     max_missing_fraction: float | None = None,
+    max_orphan_fraction: float | None = None,
 ) -> None:
     """DETACH DELETE Narrator nodes whose id is not in narrators_canonical.parquet (da#413).
 
@@ -540,29 +541,38 @@ def _cmd_prune_narrators(
     (deploy#557). ``--dry-run`` reports the count that would be deleted and deletes
     nothing.
 
-    Refuses — non-zero exit :attr:`ExitCode.EMPTY_CANONICAL_SET`, ZERO deletion — when
-    the keep-set cannot be trusted: it is empty / unreadable / missing
-    (:class:`EmptyCanonicalSetError`), or it is well-formed but is not **this graph's**
-    (:class:`ForeignCanonicalSetError` — a stale ``--canonical``, caught by the
-    ``missing`` provenance signal). A bad read must never wipe the graph, and neither
-    must the wrong parquet.
+    Refuses — non-zero exit :attr:`ExitCode.UNUSABLE_CANONICAL_SET`, ZERO deletion — when
+    the keep-set cannot be trusted, on any of three axes:
+
+    * it is empty / unreadable / missing (:class:`EmptyCanonicalSetError`);
+    * it is well-formed but is not **this graph's** — a stale ``--canonical``, caught by
+      the ``missing`` provenance signal (:class:`ForeignCanonicalSetError`);
+    * it *is* this graph's but keeps so little of it that the prune is a wipe — a
+      TRUNCATED parquet, caught by the delete magnitude (:class:`ExcessiveDeletionError`).
+      Note this one has ``missing == 0``: every id-provenance check passes on it.
+
+    A bad read must never wipe the graph — and neither must the wrong parquet, nor half
+    of the right one.
     """
     from pathlib import Path
 
     from src.graph.prune import (
         DEFAULT_MAX_MISSING_FRACTION,
+        DEFAULT_MAX_ORPHAN_FRACTION,
         UnusableCanonicalSetError,
         prune_narrators,
         summary_line,
     )
     from src.utils.neo4j_client import Neo4jClient
 
-    # `None` (not the literal) is the CLI default, so the ceiling has exactly one home:
+    # `None` (not the literal) is the CLI default, so each ceiling has exactly one home:
     # src.graph.prune. A hardcoded default here — the shape of migrate's `--batch-size`
     # — is a second copy of a number that must not drift, and cli.py lazy-imports the
     # module precisely so `--help` need not pay for pyarrow + the neo4j driver.
     if max_missing_fraction is None:
         max_missing_fraction = DEFAULT_MAX_MISSING_FRACTION
+    if max_orphan_fraction is None:
+        max_orphan_fraction = DEFAULT_MAX_ORPHAN_FRACTION
 
     # This command reads the canonical parquet and writes ONLY to the graph and
     # stdout. It never writes back into the parquet's directory (no manifest, no audit
@@ -583,10 +593,11 @@ def _cmd_prune_narrators(
                 canonical_path,
                 dry_run=dry_run,
                 max_missing_fraction=max_missing_fraction,
+                max_orphan_fraction=max_orphan_fraction,
             )
     except UnusableCanonicalSetError as guard:
         print(f"\nERROR: {guard}", file=sys.stderr)
-        sys.exit(ExitCode.EMPTY_CANONICAL_SET)
+        sys.exit(ExitCode.UNUSABLE_CANONICAL_SET)
 
     print("=== prune-narrators (canonical-set shrink, da#413) ===")
     print(f"  Canonical ids (keep-set)   : {result.canonical_ids_seen}")
@@ -1008,6 +1019,21 @@ def main() -> None:
             "ceiling) only when a genuinely large partial load is intended."
         ),
     )
+    prune_parser.add_argument(
+        "--max-orphan-fraction",
+        type=_unit_fraction,
+        default=None,
+        metavar="FRACTION",
+        help=(
+            "Ceiling on the share of the Narrator graph this prune may DELETE. Above it "
+            "the prune is refused (exit 12, zero deletion) — the TRUNCATED --canonical "
+            "guard, which --max-missing-fraction cannot catch because a truncated "
+            "keep-set's ids are all genuinely this graph's ('missing' is 0). Default: "
+            "0.9 — a legitimate post-re-mint cleanup can orphan ~55%% of an accumulated "
+            "graph, so a tighter ceiling would refuse real work; a truncated keep-set "
+            "deletes 97%%+. Raise it (1.0 disables) only when a wipe is genuinely meant."
+        ),
+    )
 
     audit_parser = subparsers.add_parser("audit", help="View recent pipeline audit entries")
     audit_parser.add_argument(
@@ -1093,6 +1119,7 @@ def main() -> None:
             canonical=args.canonical,
             dry_run=args.dry_run,
             max_missing_fraction=args.max_missing_fraction,
+            max_orphan_fraction=args.max_orphan_fraction,
         )
     elif args.command == "audit":
         _cmd_audit(last_n=args.last)

--- a/src/exit_codes.py
+++ b/src/exit_codes.py
@@ -47,6 +47,7 @@ code    name                   what is on disk when it fires
 ``9``   ``UNROUTED_CORPUS``    nothing resolve would have written (NER Step-1 abort)
 ``10``  ``PARSE_PRODUCER_DEFECT`` the clean sources' staging; the defective source's is absent
 ``11``  ``RESOLVE_STAGE_FAILED`` prior stages' artifacts; a stage raised (da#360)
+``12``  ``EMPTY_CANONICAL_SET`` the graph, untouched; ``prune-narrators`` refused (da#413)
 ======  =====================  ===================================================
 
 da#360, da#369 and da#386 all branched from a main whose next free code was ``9``
@@ -161,6 +162,7 @@ import enum
 
 __all__ = [
     "EXIT_DB_UNREACHABLE",
+    "EXIT_EMPTY_CANONICAL_SET",
     "EXIT_ENRICH_FAILED",
     "EXIT_LOAD_FAILED",
     "EXIT_MISSING_DEPENDENCY",
@@ -333,6 +335,32 @@ class ExitCode(enum.IntEnum):
     fails the whole invocation rather than being logged and skipped.
     """
 
+    EMPTY_CANONICAL_SET = 12
+    """``prune-narrators`` refused: its authoritative keep-set was unusable (da#413).
+
+    What is on disk when it fires: **the graph, exactly as it was** — zero nodes
+    deleted, zero edges touched. This is the load-bearing guarantee of a destructive
+    op: a bad read must never wipe the graph.
+
+    ``prune-narrators`` DETACH-DELETEs every ``Narrator`` whose ``id`` is not in
+    ``narrators_canonical.parquet``. That keep-set is the ONLY thing standing between
+    the command and deleting a node, so the command refuses — before it reads or
+    writes the graph at all — if the keep-set cannot be trusted to name the survivors.
+
+    Named for the worst of the three doors, not for one instance. The guard raises on
+    an **empty** keep-set (which would delete every narrator), a **missing** parquet,
+    and an **unreadable/malformed** parquet alike: each yields no usable set, and the
+    exception message names which door fired. Naming the member after only the empty
+    case would re-arm the trap for the missing/unreadable cases, the same mistake
+    :attr:`REFUSED_ROWS` documents for the malformed-id-vs-blank-id classes.
+
+    This is the da#309 / da#361 fail-loud-on-missing-input discipline applied to a
+    *destructive* op. It gets its own code — not :attr:`LOAD_FAILED` — because a
+    prune is not a load, and because the safe "deleted nothing" state must be
+    unambiguous: a distinct code lets deploy#557's workflow tell "refused, graph
+    safe, fix the parquet and retry" apart from any partial-deletion failure.
+    """
+
 
 # Module-level aliases. Consumers may import either the enum or these names; the
 # alias form keeps a migrating call site to an *import-site* change rather than a
@@ -348,3 +376,4 @@ EXIT_REFUSED_ROWS = ExitCode.REFUSED_ROWS
 EXIT_UNROUTED_CORPUS = ExitCode.UNROUTED_CORPUS
 EXIT_PARSE_PRODUCER_DEFECT = ExitCode.PARSE_PRODUCER_DEFECT
 EXIT_STAGE_FAILED = ExitCode.RESOLVE_STAGE_FAILED
+EXIT_EMPTY_CANONICAL_SET = ExitCode.EMPTY_CANONICAL_SET

--- a/src/exit_codes.py
+++ b/src/exit_codes.py
@@ -47,7 +47,7 @@ code    name                   what is on disk when it fires
 ``9``   ``UNROUTED_CORPUS``    nothing resolve would have written (NER Step-1 abort)
 ``10``  ``PARSE_PRODUCER_DEFECT`` the clean sources' staging; the defective source's is absent
 ``11``  ``RESOLVE_STAGE_FAILED`` prior stages' artifacts; a stage raised (da#360)
-``12``  ``EMPTY_CANONICAL_SET`` the graph, untouched; ``prune-narrators`` refused (da#413)
+``12``  ``UNUSABLE_CANONICAL_SET`` the graph, untouched; ``prune-narrators`` refused (da#413)
 ======  =====================  ===================================================
 
 da#360, da#369 and da#386 all branched from a main whose next free code was ``9``
@@ -162,7 +162,7 @@ import enum
 
 __all__ = [
     "EXIT_DB_UNREACHABLE",
-    "EXIT_EMPTY_CANONICAL_SET",
+    "EXIT_UNUSABLE_CANONICAL_SET",
     "EXIT_ENRICH_FAILED",
     "EXIT_LOAD_FAILED",
     "EXIT_MISSING_DEPENDENCY",
@@ -335,7 +335,7 @@ class ExitCode(enum.IntEnum):
     fails the whole invocation rather than being logged and skipped.
     """
 
-    EMPTY_CANONICAL_SET = 12
+    UNUSABLE_CANONICAL_SET = 12
     """``prune-narrators`` refused: its authoritative keep-set was untrustworthy (da#413).
 
     What is on disk when it fires: **the graph, exactly as it was** — zero nodes
@@ -347,29 +347,38 @@ class ExitCode(enum.IntEnum):
     the command and deleting a node, so the command refuses — before it writes to the
     graph at all — if the keep-set cannot be trusted to name the survivors.
 
-    Named for the worst of the **four** doors, not for one instance. Three of them ask
-    whether the parquet is usable *on its face* and fire before the graph is even read:
-    an **empty** keep-set (which would delete every narrator), a **missing** parquet,
-    an **unreadable/malformed** one. The fourth asks the question those three cannot,
-    because it is a relation between the parquet and the graph rather than a property
-    of the parquet: a keep-set that is well-formed but is **not this graph's** — a
-    stale ``--canonical`` from a previous resolve run, readable and non-empty and
-    catastrophic, detected by the ``missing`` (= ``|canonical - graph|``) signal and
-    raised as ``ForeignCanonicalSetError`` (da#413 review, Jean-Claude Habimana). It
-    fires after the graph is *read* and before any *write*, so its on-disk state is
-    identical to the other three, which is exactly why it shares this code.
+    Named for the CONCEPT — an untrustworthy keep-set — not for any one door, and there
+    are **five**. Three ask whether the parquet is usable *on its face* and fire before
+    the graph is even read: an **empty** keep-set (which would delete every narrator), a
+    **missing** parquet, an **unreadable/malformed** one. The last two ask questions those
+    three structurally cannot, because they are *relations between the parquet and the
+    graph* rather than properties of the parquet, and so they fire after the graph is
+    **read** and before any **write**:
 
-    That sharing is the deliberate reading of this registry's own rule — a code is
-    defined by **what is on disk when it fires**, and all four doors leave the graph
-    untouched, name the same remedy (fix the input, re-run), and are propagated
-    verbatim by a consumer that only asks whether the rc is zero. A fifth member would
-    encode a distinction nothing acts on, while re-opening the three-way collision
-    hazard this module was written to record. The exception subclass carries the
-    distinction where it is actually consumed: in-process, and on stderr.
+    * **not this graph's** — a stale ``--canonical`` from a previous resolve run,
+      readable and non-empty and catastrophic. Detected by ``missing``
+      (= ``|canonical - graph|``); raised as ``ForeignCanonicalSetError``.
+    * **this graph's, but a remnant of it** — a *truncated* keep-set (a resolve stopped
+      early, a half-written or partially uploaded parquet, a null-heavy ``canonical_id``
+      column). Every id in it is real and current, so ``missing`` is **0** and every
+      id-provenance instrument reports it healthy, while the prune deletes all but the
+      remnant. Detected by the delete magnitude ``|orphans| / |graph|``; raised as
+      ``ExcessiveDeletionError``.
 
-    Naming the member after only the empty case would re-arm the trap for the other
-    three, the same mistake :attr:`REFUSED_ROWS` documents for the
-    malformed-id-vs-blank-id classes.
+    The fifth door is the one worth dwelling on, because it is what the *name* of this
+    member used to hide. It was called ``EMPTY_CANONICAL_SET`` — and its own docstring
+    argued that "naming the member after only the empty case would re-arm the trap for
+    the other doors" while doing precisely that. The value stays ``12``; the name now
+    says what it has always meant. (Renamed on Jean-Claude Habimana's read of da#413,
+    which caught the contradiction.)
+
+    All five leave the graph untouched, name the same remedy (fix the input, re-run) and
+    are propagated verbatim by a consumer that only asks whether the rc is zero. Sharing
+    one code is therefore the deliberate reading of this registry's own rule — a code is
+    defined by **what is on disk when it fires**. A second member would encode a
+    distinction nothing acts on, while re-opening the three-way collision hazard this
+    module was written to record. The exception subclasses carry the distinction where it
+    is actually consumed: in-process, and on stderr.
 
     This is the da#309 / da#361 fail-loud-on-missing-input discipline applied to a
     *destructive* op. It gets its own code — not :attr:`LOAD_FAILED` — because a
@@ -393,4 +402,4 @@ EXIT_REFUSED_ROWS = ExitCode.REFUSED_ROWS
 EXIT_UNROUTED_CORPUS = ExitCode.UNROUTED_CORPUS
 EXIT_PARSE_PRODUCER_DEFECT = ExitCode.PARSE_PRODUCER_DEFECT
 EXIT_STAGE_FAILED = ExitCode.RESOLVE_STAGE_FAILED
-EXIT_EMPTY_CANONICAL_SET = ExitCode.EMPTY_CANONICAL_SET
+EXIT_UNUSABLE_CANONICAL_SET = ExitCode.UNUSABLE_CANONICAL_SET

--- a/src/exit_codes.py
+++ b/src/exit_codes.py
@@ -336,7 +336,7 @@ class ExitCode(enum.IntEnum):
     """
 
     EMPTY_CANONICAL_SET = 12
-    """``prune-narrators`` refused: its authoritative keep-set was unusable (da#413).
+    """``prune-narrators`` refused: its authoritative keep-set was untrustworthy (da#413).
 
     What is on disk when it fires: **the graph, exactly as it was** — zero nodes
     deleted, zero edges touched. This is the load-bearing guarantee of a destructive
@@ -344,15 +344,32 @@ class ExitCode(enum.IntEnum):
 
     ``prune-narrators`` DETACH-DELETEs every ``Narrator`` whose ``id`` is not in
     ``narrators_canonical.parquet``. That keep-set is the ONLY thing standing between
-    the command and deleting a node, so the command refuses — before it reads or
-    writes the graph at all — if the keep-set cannot be trusted to name the survivors.
+    the command and deleting a node, so the command refuses — before it writes to the
+    graph at all — if the keep-set cannot be trusted to name the survivors.
 
-    Named for the worst of the three doors, not for one instance. The guard raises on
+    Named for the worst of the **four** doors, not for one instance. Three of them ask
+    whether the parquet is usable *on its face* and fire before the graph is even read:
     an **empty** keep-set (which would delete every narrator), a **missing** parquet,
-    and an **unreadable/malformed** parquet alike: each yields no usable set, and the
-    exception message names which door fired. Naming the member after only the empty
-    case would re-arm the trap for the missing/unreadable cases, the same mistake
-    :attr:`REFUSED_ROWS` documents for the malformed-id-vs-blank-id classes.
+    an **unreadable/malformed** one. The fourth asks the question those three cannot,
+    because it is a relation between the parquet and the graph rather than a property
+    of the parquet: a keep-set that is well-formed but is **not this graph's** — a
+    stale ``--canonical`` from a previous resolve run, readable and non-empty and
+    catastrophic, detected by the ``missing`` (= ``|canonical - graph|``) signal and
+    raised as ``ForeignCanonicalSetError`` (da#413 review, Jean-Claude Habimana). It
+    fires after the graph is *read* and before any *write*, so its on-disk state is
+    identical to the other three, which is exactly why it shares this code.
+
+    That sharing is the deliberate reading of this registry's own rule — a code is
+    defined by **what is on disk when it fires**, and all four doors leave the graph
+    untouched, name the same remedy (fix the input, re-run), and are propagated
+    verbatim by a consumer that only asks whether the rc is zero. A fifth member would
+    encode a distinction nothing acts on, while re-opening the three-way collision
+    hazard this module was written to record. The exception subclass carries the
+    distinction where it is actually consumed: in-process, and on stderr.
+
+    Naming the member after only the empty case would re-arm the trap for the other
+    three, the same mistake :attr:`REFUSED_ROWS` documents for the
+    malformed-id-vs-blank-id classes.
 
     This is the da#309 / da#361 fail-loud-on-missing-input discipline applied to a
     *destructive* op. It gets its own code — not :attr:`LOAD_FAILED` — because a

--- a/src/graph/prune.py
+++ b/src/graph/prune.py
@@ -129,6 +129,53 @@ truncated 500-id keep-set                    99.7%                REFUSE
 "no legitimate prune looks like this" line, not a tuned parameter — and, like the
 ``missing`` ceiling, it is a **backstop**, not a policy. Surviving fewer than one node in
 ten is not a prune; it is a wipe wearing a prune's clothes.
+
+What NEITHER ceiling catches — read this before trusting them
+-------------------------------------------------------------
+Both ceilings are magnitude backstops on the catastrophic tail. Neither is a completeness
+check, and the difference matters, because the band they rely on **closes from both ends**:
+
+*From below — skipping the prune.* Each unpruned re-mint leaves another stale generation
+resident, so the legitimate orphan fraction is ``k/(k+1)`` for ``k`` stale generations:
+50% at ``k=1``, 75% at ``k=3``, and it *reaches 0.9 at k=9*. The 0.9 ceiling is therefore
+sound only while the prune runs regularly. deploy#557/#574 runs it per load (``k=1``); a
+graph left unpruned for many load cycles would start false-refusing its own cleanup.
+
+*From above — a MILD truncation. This is the real hole, and it does not close.* The
+delete-side ceiling catches a keep-set truncated to a *remnant*. It cannot catch one
+truncated to a *fraction*. With the keep-set retaining share ``f`` of the canonical set,
+the prune deletes ``1 - f * 129,234/160,614`` of the graph:
+
+======  ==================  =========================================
+``f``   deletes             verdict
+======  ==================  =========================================
+0.05    96.0%               REFUSED
+0.10    92.0%               REFUSED
+0.124   90.0%               REFUSED (the ceiling)
+0.20    **83.9%**           **PASSES** — 134,768 legitimate narrators gone
+0.40    **67.8%**           **PASSES**
+0.60    **51.7%**           **PASSES**
+0.80    **35.6%**           **PASSES**
+======  ==================  =========================================
+
+A parquet that lost a fifth of its rows deletes 84% of the narrator graph and is refused
+by nothing here — and **no choice of ceiling fixes it**, because 83.9% (truncated) and
+55.4% (the legitimate full re-mint, A2 above) are the same *kind* of number. The bands
+overlap. A fraction cannot separate them; only a *completeness* signal can, and there
+isn't one in this command's inputs.
+
+The principled cure is to bind the keep-set to the run that produced it — an expected row
+count, or the ``src/pipeline/manifest.py`` md5 of the resolve output — so a short parquet
+is caught by being *short*, not by being *drastic*. That is a different axis from any
+magnitude ceiling, and it is not plumbed to where the prune runs today (deploy#557 pulls
+the one parquet into a scratch dir; the load's manifest is not there). Until it is, the
+honest statement of what this module guarantees is:
+
+    A wrong keep-set (foreign) is refused. A remnant keep-set is refused. A **short**
+    keep-set is NOT — it is merely reported, via ``missing`` and the orphan count, and
+    the operator's dry run is the only thing standing in front of it.
+
+Do not let the two ceilings read as more than they are.
 """
 
 from __future__ import annotations

--- a/src/graph/prune.py
+++ b/src/graph/prune.py
@@ -1,0 +1,212 @@
+"""Canonical-set SHRINK: DETACH DELETE Narrator nodes not in the canonical master (da#413).
+
+Why this cannot be pure cypher (deploy#557, Aisha Idrissi's measure-first)
+--------------------------------------------------------------------------
+The graph accumulates ``Narrator`` nodes across loads, but a re-resolve can collapse
+two ids into one (over-merge fixes, de-keying, fuzzy folds). The nodes left behind —
+present in the graph, absent from the freshly written ``narrators_canonical.parquet``
+— are orphans that must go, edges and all.
+
+**The only correct orphan predicate is canonical-set membership**, and the canonical
+set lives in the parquet, unreadable by a cypher-only graph job. A graph-side proxy
+gets it wrong in both directions, measured on the real data:
+
+* A zero-degree / "unreferenced" predicate MISSES 18,518 of the 31,380 orphans, which
+  still have edges (a collapsed id keeps its ``TRANSMITTED_TO`` / ``NARRATED`` edges).
+* It also WRONGLY DELETES 57,993 zero-degree canonical narrators, which are
+  legitimate (owner da#352: a narrator attested only in a deduped edition is a real
+  narrator, edge-count zero yet canonical). A degree prune wipes exactly these.
+
+No in-graph stamp separates orphan from legit — only canonical-set membership does.
+So this reads the authoritative id set from the parquet in Python (like
+:mod:`src.graph.migrate` reads its distinct ids), computes the complement against the
+graph's ``Narrator`` ids, and DETACH-DELETEs that complement in batches.
+
+The guard is the point
+----------------------
+``DETACH DELETE`` is irreversible against a live box. The keep-set — the canonical id
+set — is the ONLY thing standing between this command and deleting a node, so
+:func:`read_canonical_ids` refuses (raises :class:`EmptyCanonicalSetError`, exit
+:attr:`~src.exit_codes.ExitCode.EMPTY_CANONICAL_SET`) BEFORE the graph is read or
+written if that set cannot be trusted — an **empty** set (which would delete every
+narrator), a **missing** parquet, or an **unreadable/malformed** one. A bad read must
+never wipe the graph. This is the da#309 / da#361 fail-loud-on-missing-input
+discipline (see :mod:`src.resolve._inputs`) applied to a destructive op.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+from src.utils.logging import get_logger
+from src.utils.neo4j_client import Neo4jClient
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "DEFAULT_BATCH_SIZE",
+    "EmptyCanonicalSetError",
+    "PruneResult",
+    "prune_narrators",
+    "read_canonical_ids",
+]
+
+DEFAULT_BATCH_SIZE = 1000
+# How many orphan ids to carry in the summary/dry-run sample. Enough to eyeball, not
+# so many that a 31k-orphan run prints a wall of ids.
+SAMPLE_SIZE = 20
+
+# Every Narrator id currently in the graph. The complement against the canonical set
+# (computed in Python) is the orphan set — see the module docstring for why the set
+# difference cannot be a graph-side degree/reference predicate.
+_ALL_NARRATOR_IDS = "MATCH (n:Narrator) RETURN n.id AS id"
+
+# Delete one batch of orphans by id, edges and all. ``count(n)`` is an aggregation
+# over the matched rows, computed as the rows are deleted, so it returns the number
+# actually removed without ever returning a deleted node object. We do not trust the
+# driver's node-deleted counter (execute_write surfaces record data, not a summary);
+# the integration test verifies the graph by reading it back regardless.
+_DETACH_DELETE_BY_ID = """\
+UNWIND $batch AS nid
+MATCH (n:Narrator {id: nid})
+DETACH DELETE n
+RETURN count(n) AS deleted
+"""
+
+
+class EmptyCanonicalSetError(Exception):
+    """The canonical keep-set is unusable, so ``prune-narrators`` deletes nothing.
+
+    Raised by :func:`read_canonical_ids` BEFORE any graph read or write. One
+    exception for three doors — a missing parquet, an unreadable/malformed one, and a
+    present-but-empty set — because each yields the same fact: there is no trustworthy
+    set of ids to keep, and a destructive op with no keep-set would delete the whole
+    graph. The message names which door fired so an operator can act without the
+    traceback. Maps to :attr:`~src.exit_codes.ExitCode.EMPTY_CANONICAL_SET`.
+    """
+
+    def __init__(self, *, reason: str, path: Path) -> None:
+        self.reason = reason
+        self.path = path
+        super().__init__(
+            f"refusing to prune narrators: {reason} (canonical master: {path}). "
+            "No node was deleted; the graph is exactly as it was. A destructive prune "
+            "against an empty/unreadable keep-set would delete every narrator, so it is "
+            "refused. Fix the canonical parquet and re-run."
+        )
+
+
+@dataclass(frozen=True)
+class PruneResult:
+    """Outcome of a :func:`prune_narrators` run.
+
+    ``deleted`` is 0 on a ``--dry-run`` (nothing was deleted) and on a real run that
+    found no orphans. ``orphans_identified`` is the count the run WOULD delete (dry
+    run) or DID delete (real run) — they are equal by construction, the sample is the
+    same set, and a dry run is exactly a real run with the delete batches suppressed.
+    """
+
+    canonical_ids_seen: int
+    graph_narrators_seen: int
+    orphans_identified: int
+    deleted: int
+    dry_run: bool
+    sample: list[str] = field(default_factory=list)
+
+
+def read_canonical_ids(canonical_path: Path) -> set[str]:
+    """Return the authoritative canonical-id keep-set, or raise the destructive-op guard.
+
+    Reads only the ``canonical_id`` column of ``narrators_canonical.parquet``. Raises
+    :class:`EmptyCanonicalSetError` — deleting nothing, touching nothing — when the
+    file is missing, unreadable/malformed, or present but empty. That refusal is the
+    load-bearing safety property of the whole subcommand: it is the only thing that
+    stands between a bad read and an emptied graph, so it happens here, before the
+    caller has a chance to touch Neo4j.
+    """
+    if not canonical_path.exists():
+        raise EmptyCanonicalSetError(reason="canonical parquet is missing", path=canonical_path)
+    try:
+        table = pq.read_table(canonical_path, columns=["canonical_id"])
+    except Exception as exc:  # noqa: BLE001 — a corrupt file, absent column, non-parquet: all "unreadable"
+        raise EmptyCanonicalSetError(
+            reason=f"canonical parquet is unreadable ({exc})", path=canonical_path
+        ) from exc
+    ids = {cid for cid in table.column("canonical_id").to_pylist() if cid}
+    if not ids:
+        raise EmptyCanonicalSetError(
+            reason="canonical parquet holds zero canonical_id values", path=canonical_path
+        )
+    return ids
+
+
+def prune_narrators(
+    client: Neo4jClient,
+    canonical_path: Path,
+    *,
+    dry_run: bool = False,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+) -> PruneResult:
+    """DETACH DELETE every ``Narrator`` whose ``id`` is not in the canonical master.
+
+    Order is load-bearing: :func:`read_canonical_ids` runs FIRST and raises the guard
+    on an unusable keep-set, so a bad read cannot reach the graph. Only once a
+    non-empty canonical set is in hand does this read the graph's Narrator ids, compute
+    the orphan complement in Python, and — unless ``dry_run`` — DETACH-DELETE it in
+    batches (removing each orphan's edges with it). A ``--dry-run`` computes the same
+    orphan set and reports it but issues no write.
+
+    The complement is a set difference, not a degree/reference test, which is the whole
+    reason this exists rather than a cypher one-liner (see the module docstring): a
+    canonical narrator with zero edges is kept, and an orphan with edges is deleted.
+    """
+    # Guard first, before ANY graph access. An unusable keep-set raises here.
+    canonical_ids = read_canonical_ids(canonical_path)
+
+    graph_rows = client.execute_read(_ALL_NARRATOR_IDS)
+    graph_ids = [row["id"] for row in graph_rows if row.get("id")]
+    orphans = [gid for gid in graph_ids if gid not in canonical_ids]
+    sample = orphans[:SAMPLE_SIZE]
+
+    if dry_run:
+        logger.info(
+            "prune_narrators_dry_run",
+            canonical_ids_seen=len(canonical_ids),
+            graph_narrators_seen=len(graph_ids),
+            orphans_identified=len(orphans),
+        )
+        return PruneResult(
+            canonical_ids_seen=len(canonical_ids),
+            graph_narrators_seen=len(graph_ids),
+            orphans_identified=len(orphans),
+            deleted=0,
+            dry_run=True,
+            sample=sample,
+        )
+
+    deleted = 0
+    for i in range(0, len(orphans), batch_size):
+        chunk = orphans[i : i + batch_size]
+        result = client.execute_write(_DETACH_DELETE_BY_ID, {"batch": chunk})
+        if result:
+            value = result[0].get("deleted", 0)
+            deleted += value if isinstance(value, int) else 0
+
+    logger.info(
+        "prune_narrators_complete",
+        canonical_ids_seen=len(canonical_ids),
+        graph_narrators_seen=len(graph_ids),
+        orphans_identified=len(orphans),
+        deleted=deleted,
+    )
+    return PruneResult(
+        canonical_ids_seen=len(canonical_ids),
+        graph_narrators_seen=len(graph_ids),
+        orphans_identified=len(orphans),
+        deleted=deleted,
+        dry_run=False,
+        sample=sample,
+    )

--- a/src/graph/prune.py
+++ b/src/graph/prune.py
@@ -52,6 +52,7 @@ __all__ = [
     "PruneResult",
     "prune_narrators",
     "read_canonical_ids",
+    "summary_line",
 ]
 
 DEFAULT_BATCH_SIZE = 1000
@@ -64,16 +65,14 @@ SAMPLE_SIZE = 20
 # difference cannot be a graph-side degree/reference predicate.
 _ALL_NARRATOR_IDS = "MATCH (n:Narrator) RETURN n.id AS id"
 
-# Delete one batch of orphans by id, edges and all. ``count(n)`` is an aggregation
-# over the matched rows, computed as the rows are deleted, so it returns the number
-# actually removed without ever returning a deleted node object. We do not trust the
-# driver's node-deleted counter (execute_write surfaces record data, not a summary);
-# the integration test verifies the graph by reading it back regardless.
+# Delete one batch of orphans by id, edges and all. No RETURN: we do NOT trust a
+# driver-side deleted counter. ``deleted`` and the post-count of orphans are measured
+# by reading the graph back after the deletes (the count>=0 discipline: prove the
+# post-state, don't infer it from a write's own report).
 _DETACH_DELETE_BY_ID = """\
 UNWIND $batch AS nid
 MATCH (n:Narrator {id: nid})
 DETACH DELETE n
-RETURN count(n) AS deleted
 """
 
 
@@ -101,19 +100,32 @@ class EmptyCanonicalSetError(Exception):
 
 @dataclass(frozen=True)
 class PruneResult:
-    """Outcome of a :func:`prune_narrators` run.
+    """Outcome of a :func:`prune_narrators` run, shaped to feed deploy#557's verify.
 
-    ``deleted`` is 0 on a ``--dry-run`` (nothing was deleted) and on a real run that
-    found no orphans. ``orphans_identified`` is the count the run WOULD delete (dry
-    run) or DID delete (real run) — they are equal by construction, the sample is the
-    same set, and a dry run is exactly a real run with the delete batches suppressed.
+    The fields map onto the machine-readable :func:`summary_line` its workflow greps:
+
+    * ``canonical_ids_seen`` → ``canonical=`` — size of the keep-set.
+    * ``graph_total`` → ``graph_total=`` — Narrator nodes in the graph AFTER the op
+      (for a dry run nothing is deleted, so this is the current total).
+    * ``orphans`` → ``orphans=`` — **its meaning differs by mode, by contract**: on a
+      dry run it is the count that WOULD be deleted (pre-count); on a real run it is
+      the orphans that REMAIN after the delete, re-measured by reading the graph back,
+      and it MUST be 0 (that is what proves exactly the orphans went and every
+      referenced/canonical narrator survived, not merely that the graph was not wiped).
+    * ``deleted`` → ``deleted=`` — nodes removed, measured as pre-total minus
+      post-total (readback truth), 0 on a dry run.
+
+    ``orphans_identified`` is always the pre-count (what a real run would delete); it
+    drives the human-readable line and the ``sample``. A dry run is exactly a real run
+    with the delete batches and the post-readback suppressed.
     """
 
     canonical_ids_seen: int
-    graph_narrators_seen: int
-    orphans_identified: int
+    graph_total: int
+    orphans: int
     deleted: int
     dry_run: bool
+    orphans_identified: int
     sample: list[str] = field(default_factory=list)
 
 
@@ -166,47 +178,69 @@ def prune_narrators(
     # Guard first, before ANY graph access. An unusable keep-set raises here.
     canonical_ids = read_canonical_ids(canonical_path)
 
-    graph_rows = client.execute_read(_ALL_NARRATOR_IDS)
-    graph_ids = [row["id"] for row in graph_rows if row.get("id")]
-    orphans = [gid for gid in graph_ids if gid not in canonical_ids]
+    graph_ids_pre = [row["id"] for row in client.execute_read(_ALL_NARRATOR_IDS) if row.get("id")]
+    orphans = [gid for gid in graph_ids_pre if gid not in canonical_ids]
     sample = orphans[:SAMPLE_SIZE]
 
     if dry_run:
         logger.info(
             "prune_narrators_dry_run",
             canonical_ids_seen=len(canonical_ids),
-            graph_narrators_seen=len(graph_ids),
+            graph_total=len(graph_ids_pre),
             orphans_identified=len(orphans),
         )
         return PruneResult(
             canonical_ids_seen=len(canonical_ids),
-            graph_narrators_seen=len(graph_ids),
-            orphans_identified=len(orphans),
+            graph_total=len(graph_ids_pre),
+            orphans=len(orphans),  # dry run: the WOULD-delete count
             deleted=0,
             dry_run=True,
+            orphans_identified=len(orphans),
             sample=sample,
         )
 
-    deleted = 0
     for i in range(0, len(orphans), batch_size):
         chunk = orphans[i : i + batch_size]
-        result = client.execute_write(_DETACH_DELETE_BY_ID, {"batch": chunk})
-        if result:
-            value = result[0].get("deleted", 0)
-            deleted += value if isinstance(value, int) else 0
+        client.execute_write(_DETACH_DELETE_BY_ID, {"batch": chunk})
+
+    # Read the graph BACK to measure the outcome — never trust a write's self-report.
+    # ``orphans_remaining`` must be 0: that is the proof that exactly the orphans went
+    # and every canonical narrator (edged or zero-degree) survived. ``deleted`` is the
+    # pre/post total difference, the honest count of what left the graph.
+    graph_ids_post = [row["id"] for row in client.execute_read(_ALL_NARRATOR_IDS) if row.get("id")]
+    orphans_remaining = [gid for gid in graph_ids_post if gid not in canonical_ids]
+    deleted = len(graph_ids_pre) - len(graph_ids_post)
 
     logger.info(
         "prune_narrators_complete",
         canonical_ids_seen=len(canonical_ids),
-        graph_narrators_seen=len(graph_ids),
+        graph_total=len(graph_ids_post),
         orphans_identified=len(orphans),
+        orphans_remaining=len(orphans_remaining),
         deleted=deleted,
     )
     return PruneResult(
         canonical_ids_seen=len(canonical_ids),
-        graph_narrators_seen=len(graph_ids),
-        orphans_identified=len(orphans),
+        graph_total=len(graph_ids_post),
+        orphans=len(orphans_remaining),  # real run: post-count, MUST be 0
         deleted=deleted,
         dry_run=False,
+        orphans_identified=len(orphans),
         sample=sample,
+    )
+
+
+def summary_line(result: PruneResult) -> str:
+    """The one machine-readable line deploy#557's graph-side verify greps from stdout.
+
+    Emitted on BOTH a dry run and a real run. Its absence is a hard failure in the
+    workflow — a missing instrument reading is a stop, not a silent pass — so it is
+    printed unconditionally by the CLI. ``orphans=`` carries the by-mode meaning
+    documented on :class:`PruneResult`: the would-delete count on a dry run, the
+    post-delete remaining count (``0`` on success) on a real run.
+    """
+    return (
+        f"PRUNE_NARRATORS_SUMMARY canonical={result.canonical_ids_seen} "
+        f"graph_total={result.graph_total} orphans={result.orphans} "
+        f"deleted={result.deleted}"
     )

--- a/src/graph/prune.py
+++ b/src/graph/prune.py
@@ -32,6 +32,48 @@ written if that set cannot be trusted — an **empty** set (which would delete e
 narrator), a **missing** parquet, or an **unreadable/malformed** one. A bad read must
 never wipe the graph. This is the da#309 / da#361 fail-loud-on-missing-input
 discipline (see :mod:`src.resolve._inputs`) applied to a destructive op.
+
+Binding the keep-set to the graph it prunes (da#413 review)
+-----------------------------------------------------------
+Those three doors all catch an **unusable** keep-set. None catches a **wrong-but-valid**
+one, and that is the more dangerous failure. ``parquet_ref`` is free text in the
+consumer (deploy#557/#574): a stale parquet from a *previous* resolve run is perfectly
+readable, perfectly non-empty, and names tens of thousands of ids that no longer exist —
+so pruning against it DETACH-DELETEs the live generation's legitimate narrators.
+
+Worse, it does so silently. Every post-op gate — pre minus orphans equals post, deleted
+equals predicted, zero orphans remain — is **derived from the same keep-set being
+validated**. They all prove the prune faithfully obeyed the parquet; not one of them can
+ask whether it was the *right* parquet. They pass for any parquet
+(``feedback_silent_zero_is_not_a_measurement``: a detector that cannot separate the two
+classes it exists to separate is not producing a measurement).
+
+The discriminator the gates lack is the **reverse** difference, at zero extra queries:
+
+    ``missing`` = ``|canonical − graph|`` — keep-set ids the graph has never seen.
+
+For the parquet the graph was actually loaded from, this is ~0. The da#352 join measures
+it exactly: 71,241 edged + 57,993 zero-degree = 129,234 = the whole canonical count, so
+today **every** canonical id is present in the graph. For a stale or foreign parquet it
+is large, in proportion to how wrong the parquet is. That is the provenance signal.
+
+Two rules govern it, and they pull in opposite directions on purpose:
+
+* **It is reported, not asserted to zero.** A legitimately partial load leaves canonical
+  ids unloaded by design — :attr:`~src.exit_codes.ExitCode.REFUSED_ROWS`,
+  :attr:`~src.exit_codes.ExitCode.STOPPED_AT_LIMIT`, a nodes-only load. A hard
+  ``missing == 0`` here would refuse a valid prune after any of them. So ``missing=`` is
+  surfaced as the fifth key of :func:`summary_line` and the **consumer owns the
+  refuse-or-proceed policy** (deploy#574 gates on ``missing == 0`` unless an explicit
+  ``allow_partial_load`` is set).
+* **It is refused on implausible magnitude**, as a backstop, before any write — see
+  :class:`ForeignCanonicalSetError` and :data:`DEFAULT_MAX_MISSING_FRACTION`.
+
+Note what this guard does and does not buy. It catches the *catastrophic* wrong parquet —
+one whose ids are mostly strangers to this graph. A *subtly* stale parquet (one generation
+back, most ids still present) slips under any plausible magnitude ceiling; catching that
+one is the consumer's ``missing == 0`` gate. The two are layered deliberately, and neither
+alone is sufficient.
 """
 
 from __future__ import annotations
@@ -48,8 +90,12 @@ logger = get_logger(__name__)
 
 __all__ = [
     "DEFAULT_BATCH_SIZE",
+    "DEFAULT_MAX_MISSING_FRACTION",
     "EmptyCanonicalSetError",
+    "ForeignCanonicalSetError",
+    "SUMMARY_KEYS",
     "PruneResult",
+    "UnusableCanonicalSetError",
     "prune_narrators",
     "read_canonical_ids",
     "summary_line",
@@ -59,6 +105,22 @@ DEFAULT_BATCH_SIZE = 1000
 # How many orphan ids to carry in the summary/dry-run sample. Enough to eyeball, not
 # so many that a 31k-orphan run prints a wall of ids.
 SAMPLE_SIZE = 20
+
+# The magnitude ceiling on ``missing`` (= |canonical - graph|), as a fraction of the
+# keep-set. Above it the keep-set is refused as not-this-graph's, before any write.
+#
+# Why one half, and why a fraction rather than a count. For the parquet the graph was
+# loaded from, ``missing`` is 0 — da#352 measures the join exactly (129,234 canonical =
+# 71,241 edged + 57,993 zero-degree, all present). A partial load pushes it up, but the
+# keep-set still describes THIS graph. At one half it no longer does: more of the keep-set
+# is unknown to the graph than known, so the parquet has lost majority authority over the
+# thing it is being used to prune. That is not a partial load; that is a different graph.
+#
+# It is deliberately NOT a tuned number pretending to precision — it is the "obviously
+# wrong" line. The subtle stale parquet is the consumer's ``missing == 0`` gate to catch,
+# not this one's (see the module docstring). Raise it with --max-missing-fraction when a
+# genuinely large partial load is intended; 1.0 disables the ceiling entirely.
+DEFAULT_MAX_MISSING_FRACTION = 0.5
 
 # Every Narrator id currently in the graph. The complement against the canonical set
 # (computed in Python) is the orphan set — see the module docstring for why the set
@@ -76,8 +138,25 @@ DETACH DELETE n
 """
 
 
-class EmptyCanonicalSetError(Exception):
-    """The canonical keep-set is unusable, so ``prune-narrators`` deletes nothing.
+class UnusableCanonicalSetError(Exception):
+    """``prune-narrators`` refused: the keep-set cannot be trusted. Nothing was deleted.
+
+    The common supertype of every refusal door, and the thing ``_cmd_prune_narrators``
+    catches. All of them share the one fact that defines
+    :attr:`~src.exit_codes.ExitCode.EMPTY_CANONICAL_SET` — **the graph is exactly as it
+    was**, zero nodes deleted, zero edges touched — which is why they share its exit
+    code rather than minting a second one for an identical on-disk state. The subclass
+    (and the message) says which door fired; the exit code says the graph is safe.
+    """
+
+    def __init__(self, *, reason: str, path: Path, message: str) -> None:
+        self.reason = reason
+        self.path = path
+        super().__init__(message)
+
+
+class EmptyCanonicalSetError(UnusableCanonicalSetError):
+    """The canonical keep-set is unusable *on its face*, so nothing is deleted.
 
     Raised by :func:`read_canonical_ids` BEFORE any graph read or write. One
     exception for three doors — a missing parquet, an unreadable/malformed one, and a
@@ -85,16 +164,75 @@ class EmptyCanonicalSetError(Exception):
     set of ids to keep, and a destructive op with no keep-set would delete the whole
     graph. The message names which door fired so an operator can act without the
     traceback. Maps to :attr:`~src.exit_codes.ExitCode.EMPTY_CANONICAL_SET`.
+
+    This door tests the keep-set **in isolation**. It cannot see the fourth door — a
+    keep-set that is perfectly well-formed but belongs to a *different graph* — because
+    that is a relation between the parquet and the graph, not a property of the parquet.
+    See :class:`ForeignCanonicalSetError`.
     """
 
     def __init__(self, *, reason: str, path: Path) -> None:
-        self.reason = reason
-        self.path = path
         super().__init__(
-            f"refusing to prune narrators: {reason} (canonical master: {path}). "
-            "No node was deleted; the graph is exactly as it was. A destructive prune "
-            "against an empty/unreadable keep-set would delete every narrator, so it is "
-            "refused. Fix the canonical parquet and re-run."
+            reason=reason,
+            path=path,
+            message=(
+                f"refusing to prune narrators: {reason} (canonical master: {path}). "
+                "No node was deleted; the graph is exactly as it was. A destructive prune "
+                "against an empty/unreadable keep-set would delete every narrator, so it is "
+                "refused. Fix the canonical parquet and re-run."
+            ),
+        )
+
+
+class ForeignCanonicalSetError(UnusableCanonicalSetError):
+    """The keep-set is well-formed but is not **this graph's**, so nothing is deleted.
+
+    The fourth door, and the one no post-op gate can see (module docstring). Raised when
+    ``missing`` — the count of canonical ids the graph has never seen — exceeds
+    ``max_missing_fraction`` of the keep-set. Raised after the graph is *read* (the
+    signal is a relation between the two sets, so it cannot be computed without reading
+    both) but strictly BEFORE any write: the refusal costs the graph nothing.
+
+    A stale ``parquet_ref`` is the most plausible operator error there is, and it is not
+    self-announcing: it is readable, non-empty, and every derived gate downstream would
+    green. Maps to :attr:`~src.exit_codes.ExitCode.EMPTY_CANONICAL_SET` — the on-disk
+    state is identical to the other doors (the graph, untouched), and the consumer
+    propagates the rc verbatim, so a distinct code would buy nothing and would re-open
+    the three-way collision hazard :mod:`src.exit_codes` exists to document.
+    """
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        missing: int,
+        canonical_total: int,
+        graph_total: int,
+        max_missing_fraction: float,
+    ) -> None:
+        self.missing = missing
+        self.canonical_total = canonical_total
+        self.graph_total = graph_total
+        self.max_missing_fraction = max_missing_fraction
+        pct = 100.0 * missing / canonical_total
+        ceiling_pct = 100.0 * max_missing_fraction
+        super().__init__(
+            reason="canonical keep-set does not belong to this graph",
+            path=path,
+            message=(
+                f"refusing to prune narrators: the canonical keep-set does not belong to "
+                f"this graph — {missing} of its {canonical_total} canonical ids "
+                f"({pct:.1f}%) are absent from the graph, above the {ceiling_pct:.1f}% "
+                f"ceiling. The graph holds {graph_total} Narrator node(s). "
+                f"(canonical master: {path}). "
+                "No node was deleted; the graph is exactly as it was. A keep-set the graph "
+                "has never seen is a keep-set for a DIFFERENT graph: pruning against it "
+                "would DETACH DELETE legitimate narrators, and every post-op check would "
+                "still pass, because they are all derived from this same keep-set. Point "
+                "--canonical at the parquet the live graph was loaded from. If this graph "
+                "really is a partial load of this keep-set, raise the ceiling deliberately "
+                "with --max-missing-fraction."
+            ),
         )
 
 
@@ -114,6 +252,12 @@ class PruneResult:
       referenced/canonical narrator survived, not merely that the graph was not wiped).
     * ``deleted`` → ``deleted=`` — nodes removed, measured as pre-total minus
       post-total (readback truth), 0 on a dry run.
+    * ``missing`` → ``missing=`` — canonical ids the graph has never seen
+      (``|canonical - graph|``), the keep-set provenance signal. **Unlike ``orphans``,
+      its meaning does NOT vary by mode**: it is measured against the PRE-state in both,
+      and it is the same number either way, because deleting an orphan (by definition a
+      non-canonical id) can never remove a canonical id from the graph. ~0 for the
+      parquet the graph was loaded from; large for a stale or foreign one.
 
     ``orphans_identified`` is always the pre-count (what a real run would delete); it
     drives the human-readable line and the ``sample``. A dry run is exactly a real run
@@ -126,6 +270,7 @@ class PruneResult:
     deleted: int
     dry_run: bool
     orphans_identified: int
+    missing: int
     sample: list[str] = field(default_factory=list)
 
 
@@ -161,24 +306,54 @@ def prune_narrators(
     *,
     dry_run: bool = False,
     batch_size: int = DEFAULT_BATCH_SIZE,
+    max_missing_fraction: float = DEFAULT_MAX_MISSING_FRACTION,
 ) -> PruneResult:
     """DETACH DELETE every ``Narrator`` whose ``id`` is not in the canonical master.
 
-    Order is load-bearing: :func:`read_canonical_ids` runs FIRST and raises the guard
-    on an unusable keep-set, so a bad read cannot reach the graph. Only once a
-    non-empty canonical set is in hand does this read the graph's Narrator ids, compute
-    the orphan complement in Python, and — unless ``dry_run`` — DETACH-DELETE it in
-    batches (removing each orphan's edges with it). A ``--dry-run`` computes the same
-    orphan set and reports it but issues no write.
+    Order is load-bearing, and there are now two guards in it:
+
+    1. :func:`read_canonical_ids` runs FIRST and raises :class:`EmptyCanonicalSetError`
+       on a keep-set that is unusable on its face, so a bad read cannot reach the graph
+       at all.
+    2. The graph's Narrator ids are read, and the keep-set's **provenance** is checked
+       against them — ``missing`` = ``|canonical - graph|`` — raising
+       :class:`ForeignCanonicalSetError` if the keep-set is mostly strangers to this
+       graph. This one needs the graph, so it cannot precede the read; it does precede
+       every **write**, which is the property that matters. Both guards fire in dry-run
+       mode too: the operator's mandatory dry run is exactly where a wrong parquet
+       should surface.
+
+    Only then does this compute the orphan complement in Python and — unless ``dry_run``
+    — DETACH-DELETE it in batches (removing each orphan's edges with it). A ``--dry-run``
+    computes the same orphan set and reports it but issues no write.
 
     The complement is a set difference, not a degree/reference test, which is the whole
     reason this exists rather than a cypher one-liner (see the module docstring): a
     canonical narrator with zero edges is kept, and an orphan with edges is deleted.
     """
-    # Guard first, before ANY graph access. An unusable keep-set raises here.
+    if not 0.0 <= max_missing_fraction <= 1.0:
+        msg = f"max_missing_fraction must be in [0.0, 1.0], got {max_missing_fraction}"
+        raise ValueError(msg)
+
+    # Guard 1, before ANY graph access. An unusable keep-set raises here.
     canonical_ids = read_canonical_ids(canonical_path)
 
     graph_ids_pre = [row["id"] for row in client.execute_read(_ALL_NARRATOR_IDS) if row.get("id")]
+    graph_id_set = set(graph_ids_pre)
+
+    # The provenance signal: keep-set ids this graph has never seen. Measured against the
+    # PRE-state, and mode-invariant (a deleted orphan is by definition not canonical, so
+    # the delete cannot move this number). Guard 2 refuses on it BEFORE any write.
+    missing = sum(1 for cid in canonical_ids if cid not in graph_id_set)
+    if missing > max_missing_fraction * len(canonical_ids):
+        raise ForeignCanonicalSetError(
+            path=canonical_path,
+            missing=missing,
+            canonical_total=len(canonical_ids),
+            graph_total=len(graph_ids_pre),
+            max_missing_fraction=max_missing_fraction,
+        )
+
     orphans = [gid for gid in graph_ids_pre if gid not in canonical_ids]
     sample = orphans[:SAMPLE_SIZE]
 
@@ -188,6 +363,7 @@ def prune_narrators(
             canonical_ids_seen=len(canonical_ids),
             graph_total=len(graph_ids_pre),
             orphans_identified=len(orphans),
+            missing=missing,
         )
         return PruneResult(
             canonical_ids_seen=len(canonical_ids),
@@ -196,6 +372,7 @@ def prune_narrators(
             deleted=0,
             dry_run=True,
             orphans_identified=len(orphans),
+            missing=missing,
             sample=sample,
         )
 
@@ -218,6 +395,7 @@ def prune_narrators(
         orphans_identified=len(orphans),
         orphans_remaining=len(orphans_remaining),
         deleted=deleted,
+        missing=missing,
     )
     return PruneResult(
         canonical_ids_seen=len(canonical_ids),
@@ -226,8 +404,18 @@ def prune_narrators(
         deleted=deleted,
         dry_run=False,
         orphans_identified=len(orphans),
+        missing=missing,
         sample=sample,
     )
+
+
+# The summary line's key set, in emission order. An APPEND-ONLY namespace: the consumer
+# extracts a key with a greedy, unanchored `.*<key>=` (deploy#557 `summary_field`), so a
+# NEW key that ends with an OLD key's name silently hijacks it — `edges_deleted=` would
+# be read as `deleted=` (da#419). `missing` was chosen partly because it collides with
+# nothing here, and `test_summary_line` pins that invariant mechanically rather than
+# trusting anyone to remember it. Append; never rename, never insert a suffix-collider.
+SUMMARY_KEYS = ("canonical", "graph_total", "orphans", "deleted", "missing")
 
 
 def summary_line(result: PruneResult) -> str:
@@ -238,9 +426,16 @@ def summary_line(result: PruneResult) -> str:
     printed unconditionally by the CLI. ``orphans=`` carries the by-mode meaning
     documented on :class:`PruneResult`: the would-delete count on a dry run, the
     post-delete remaining count (``0`` on success) on a real run.
+
+    ``missing=`` is appended LAST and is the fifth key, so the consumer's existing
+    four-key extraction is untouched by its arrival. It is **reported, not asserted** —
+    a legitimately partial load (``REFUSED_ROWS``, ``STOPPED_AT_LIMIT``, nodes-only)
+    leaves canonical ids unloaded, so the refuse-or-proceed policy on a non-zero
+    ``missing`` belongs to the workflow, not here. This command refuses only on a
+    magnitude no partial load could produce (:class:`ForeignCanonicalSetError`).
     """
     return (
         f"PRUNE_NARRATORS_SUMMARY canonical={result.canonical_ids_seen} "
         f"graph_total={result.graph_total} orphans={result.orphans} "
-        f"deleted={result.deleted}"
+        f"deleted={result.deleted} missing={result.missing}"
     )

--- a/src/graph/prune.py
+++ b/src/graph/prune.py
@@ -27,7 +27,7 @@ The guard is the point
 ``DETACH DELETE`` is irreversible against a live box. The keep-set — the canonical id
 set — is the ONLY thing standing between this command and deleting a node, so
 :func:`read_canonical_ids` refuses (raises :class:`EmptyCanonicalSetError`, exit
-:attr:`~src.exit_codes.ExitCode.EMPTY_CANONICAL_SET`) BEFORE the graph is read or
+:attr:`~src.exit_codes.ExitCode.UNUSABLE_CANONICAL_SET`) BEFORE the graph is read or
 written if that set cannot be trusted — an **empty** set (which would delete every
 narrator), a **missing** parquet, or an **unreadable/malformed** one. A bad read must
 never wipe the graph. This is the da#309 / da#361 fail-loud-on-missing-input
@@ -74,6 +74,61 @@ one whose ids are mostly strangers to this graph. A *subtly* stale parquet (one 
 back, most ids still present) slips under any plausible magnitude ceiling; catching that
 one is the consumer's ``missing == 0`` gate. The two are layered deliberately, and neither
 alone is sufficient.
+
+The delete side needs its own bound (da#413 second review)
+----------------------------------------------------------
+``missing`` bounds the direction that **cannot delete anything**. ``canonical - graph`` is
+a set of ids that are not in the graph, so no element of it can be DETACH DELETEd. The
+quantity that actually deletes is the *other* difference, ``orphans = graph - canonical``,
+and ``missing`` says nothing whatever about its size.
+
+That gap is not theoretical. Consider a **truncated but same-generation** keep-set: a
+resolve run stopped early (:attr:`~src.exit_codes.ExitCode.STOPPED_AT_LIMIT`), a partial
+upload, a half-written parquet, a null-heavy ``canonical_id`` column. It holds 5,000 ids
+that are all **genuinely this graph's** — so ``missing`` is exactly **0**, and:
+
+* the empty/unreadable guard passes (it is readable, and 5,000 ids is not zero);
+* the ``missing`` ceiling passes (``0 > 0.5 * 5,000`` is false);
+* the consumer's whole-graph-wipe check passes (155,614 orphans is not >= 160,614);
+* and the consumer's ``missing == 0`` policy **actively blesses it**;
+
+while the prune DETACH DELETEs 155,614 of 160,614 narrators — **96.9% of the graph** — and
+every post-op gate greens, because they are all still derived from the keep-set being
+validated. The set is not *foreign*. It is merely *incomplete*, and incompleteness is
+invisible to every instrument that asks whether the keep-set's ids belong to this graph.
+
+So the delete side is bounded too, symmetrically:
+
+    ``orphan_fraction`` = ``|orphans| / |graph|`` — the share of the graph this would delete.
+
+:class:`ExcessiveDeletionError` refuses above :data:`DEFAULT_MAX_ORPHAN_FRACTION`, before
+any write, overridable with ``--max-orphan-fraction``.
+
+**Why that ceiling is 0.9 and emphatically not 0.5.** A ceiling near one half looks
+prudent and would be wrong, because it refuses this command's own primary use case. The
+graph is the union of every load ever run against it, so a re-resolve that re-mints ids
+*en masse* — exactly the da#356/da#376 event this subcommand was built to clean up after —
+legitimately orphans the entire previous generation. Working it in the measured numbers:
+an accumulated graph holding the old 160,614-node generation plus a freshly loaded,
+fully re-minted 129,234-node one is 289,848 nodes, of which 160,614 are legitimate
+orphans — **55.4%**, with ``missing == 0``, and it is a *correct* prune. A 0.5 ceiling
+refuses it; the operator overrides; the override becomes reflex; the guard is dead.
+
+The honest separation is wide and it is not centred on one half:
+
+===========================================  ==================  ==============
+class                                        ``orphan_fraction``  verdict
+===========================================  ==================  ==============
+single-generation prune (da#352 measured)    19.5%                proceed
+accumulated graph, full re-mint (worst legit) 55.4%               proceed
+truncated 5,000-id keep-set                  96.9%                REFUSE
+truncated 500-id keep-set                    99.7%                REFUSE
+===========================================  ==================  ==============
+
+0.9 sits in the empty band between ~55% and ~97% with margin on both sides. It is the
+"no legitimate prune looks like this" line, not a tuned parameter — and, like the
+``missing`` ceiling, it is a **backstop**, not a policy. Surviving fewer than one node in
+ten is not a prune; it is a wipe wearing a prune's clothes.
 """
 
 from __future__ import annotations
@@ -91,7 +146,9 @@ logger = get_logger(__name__)
 __all__ = [
     "DEFAULT_BATCH_SIZE",
     "DEFAULT_MAX_MISSING_FRACTION",
+    "DEFAULT_MAX_ORPHAN_FRACTION",
     "EmptyCanonicalSetError",
+    "ExcessiveDeletionError",
     "ForeignCanonicalSetError",
     "SUMMARY_KEYS",
     "PruneResult",
@@ -122,6 +179,25 @@ SAMPLE_SIZE = 20
 # genuinely large partial load is intended; 1.0 disables the ceiling entirely.
 DEFAULT_MAX_MISSING_FRACTION = 0.5
 
+# The magnitude ceiling on the DELETE side: |orphans| / |graph|, the share of the narrator
+# graph this prune would DETACH DELETE. Refused above it, before any write.
+#
+# 0.9, NOT 0.5 — see the module docstring for the full argument, because the intuitive
+# number is the wrong one here. A ceiling near one half would refuse a legitimate prune:
+# after a mass id re-mint (da#356/da#376), the accumulated graph legitimately orphans its
+# entire previous generation — 160,614 of 289,848 nodes = 55.4%, with missing == 0. That is
+# precisely the cleanup this subcommand exists to perform. Refuse it and the operator
+# overrides by reflex, which kills the guard.
+#
+# The threat class sits far above the legitimate one, and the band between them is empty:
+#   19.5%  single-generation prune (da#352 measured)   legit
+#   55.4%  accumulated graph, full re-mint             legit, worst case
+#   96.9%  truncated 5,000-id keep-set                 THREAT (missing == 0; all other guards pass)
+#   99.7%  truncated 500-id keep-set                   THREAT
+# 0.9 separates them with margin on both sides. Surviving fewer than one node in ten is not
+# a prune. Override with --max-orphan-fraction when a wipe is genuinely intended.
+DEFAULT_MAX_ORPHAN_FRACTION = 0.9
+
 # Every Narrator id currently in the graph. The complement against the canonical set
 # (computed in Python) is the orphan set — see the module docstring for why the set
 # difference cannot be a graph-side degree/reference predicate.
@@ -143,7 +219,7 @@ class UnusableCanonicalSetError(Exception):
 
     The common supertype of every refusal door, and the thing ``_cmd_prune_narrators``
     catches. All of them share the one fact that defines
-    :attr:`~src.exit_codes.ExitCode.EMPTY_CANONICAL_SET` — **the graph is exactly as it
+    :attr:`~src.exit_codes.ExitCode.UNUSABLE_CANONICAL_SET` — **the graph is exactly as it
     was**, zero nodes deleted, zero edges touched — which is why they share its exit
     code rather than minting a second one for an identical on-disk state. The subclass
     (and the message) says which door fired; the exit code says the graph is safe.
@@ -163,7 +239,7 @@ class EmptyCanonicalSetError(UnusableCanonicalSetError):
     present-but-empty set — because each yields the same fact: there is no trustworthy
     set of ids to keep, and a destructive op with no keep-set would delete the whole
     graph. The message names which door fired so an operator can act without the
-    traceback. Maps to :attr:`~src.exit_codes.ExitCode.EMPTY_CANONICAL_SET`.
+    traceback. Maps to :attr:`~src.exit_codes.ExitCode.UNUSABLE_CANONICAL_SET`.
 
     This door tests the keep-set **in isolation**. It cannot see the fourth door — a
     keep-set that is perfectly well-formed but belongs to a *different graph* — because
@@ -195,7 +271,7 @@ class ForeignCanonicalSetError(UnusableCanonicalSetError):
 
     A stale ``parquet_ref`` is the most plausible operator error there is, and it is not
     self-announcing: it is readable, non-empty, and every derived gate downstream would
-    green. Maps to :attr:`~src.exit_codes.ExitCode.EMPTY_CANONICAL_SET` — the on-disk
+    green. Maps to :attr:`~src.exit_codes.ExitCode.UNUSABLE_CANONICAL_SET` — the on-disk
     state is identical to the other doors (the graph, untouched), and the consumer
     propagates the rc verbatim, so a distinct code would buy nothing and would re-open
     the three-way collision hazard :mod:`src.exit_codes` exists to document.
@@ -232,6 +308,66 @@ class ForeignCanonicalSetError(UnusableCanonicalSetError):
                 "--canonical at the parquet the live graph was loaded from. If this graph "
                 "really is a partial load of this keep-set, raise the ceiling deliberately "
                 "with --max-missing-fraction."
+            ),
+        )
+
+
+class ExcessiveDeletionError(UnusableCanonicalSetError):
+    """The keep-set is this graph's, but keeps so little of it that the prune is a wipe.
+
+    The **fifth** door, and the one :class:`ForeignCanonicalSetError` is structurally
+    incapable of seeing. ``missing`` bounds ``canonical - graph`` — a set whose elements
+    are *not in the graph* and therefore cannot be deleted. It says nothing about
+    ``orphans = graph - canonical``, which is the set that actually gets DETACH DELETEd.
+
+    A **truncated same-generation** keep-set exploits exactly that blind spot: a resolve
+    run stopped at :attr:`~src.exit_codes.ExitCode.STOPPED_AT_LIMIT`, a half-written
+    parquet, a partial upload, a null-heavy ``canonical_id`` column. Every id in it is
+    real and current, so ``missing`` is **0** and every id-provenance instrument — here
+    and in the consumer — reports the keep-set as perfectly healthy, while the prune
+    deletes all but the truncated remnant.
+
+    So this refuses on the delete magnitude itself: ``|orphans| / |graph|`` above
+    ``max_orphan_fraction`` (:data:`DEFAULT_MAX_ORPHAN_FRACTION`). Raised after the graph
+    read it depends on and strictly BEFORE any write, in dry-run mode too. Shares
+    :attr:`~src.exit_codes.ExitCode.UNUSABLE_CANONICAL_SET` with its siblings: the on-disk
+    state is the same one that defines the code — the graph, exactly as it was.
+    """
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        orphans: int,
+        graph_total: int,
+        canonical_total: int,
+        missing: int,
+        max_orphan_fraction: float,
+    ) -> None:
+        self.orphans = orphans
+        self.graph_total = graph_total
+        self.canonical_total = canonical_total
+        self.missing = missing
+        self.max_orphan_fraction = max_orphan_fraction
+        pct = 100.0 * orphans / graph_total
+        ceiling_pct = 100.0 * max_orphan_fraction
+        survivors = graph_total - orphans
+        super().__init__(
+            reason="prune would delete an implausible share of the narrator graph",
+            path=path,
+            message=(
+                f"refusing to prune narrators: this would DETACH DELETE {orphans} of "
+                f"{graph_total} Narrator node(s) ({pct:.1f}%), above the {ceiling_pct:.1f}% "
+                f"ceiling, leaving only {survivors}. The keep-set holds {canonical_total} "
+                f"canonical id(s), of which {missing} are absent from the graph "
+                f"(canonical master: {path}). "
+                "No node was deleted; the graph is exactly as it was. Note that a low "
+                "'missing' does NOT clear this: a TRUNCATED keep-set (a resolve stopped "
+                "early, a half-written or partially uploaded parquet, a null-heavy "
+                "canonical_id column) holds ids that are all genuinely this graph's — so "
+                "every id-provenance check passes — while keeping only a remnant of it. "
+                "Check that the canonical parquet is COMPLETE, not merely valid. If a "
+                "prune this large is genuinely intended, say so with --max-orphan-fraction."
             ),
         )
 
@@ -307,6 +443,7 @@ def prune_narrators(
     dry_run: bool = False,
     batch_size: int = DEFAULT_BATCH_SIZE,
     max_missing_fraction: float = DEFAULT_MAX_MISSING_FRACTION,
+    max_orphan_fraction: float = DEFAULT_MAX_ORPHAN_FRACTION,
 ) -> PruneResult:
     """DETACH DELETE every ``Narrator`` whose ``id`` is not in the canonical master.
 
@@ -319,13 +456,20 @@ def prune_narrators(
        against them — ``missing`` = ``|canonical - graph|`` — raising
        :class:`ForeignCanonicalSetError` if the keep-set is mostly strangers to this
        graph. This one needs the graph, so it cannot precede the read; it does precede
-       every **write**, which is the property that matters. Both guards fire in dry-run
-       mode too: the operator's mandatory dry run is exactly where a wrong parquet
-       should surface.
+       every **write**, which is the property that matters.
+    3. The orphan complement is computed, and its **magnitude** is checked —
+       ``|orphans| / |graph|`` — raising :class:`ExcessiveDeletionError` if the prune
+       would delete an implausible share of the graph. Guard 2 cannot cover this: it
+       bounds the difference that deletes *nothing*, while this bounds the one that
+       deletes *everything it names*. A truncated same-generation keep-set has
+       ``missing == 0`` and would still wipe the graph.
 
-    Only then does this compute the orphan complement in Python and — unless ``dry_run``
-    — DETACH-DELETE it in batches (removing each orphan's edges with it). A ``--dry-run``
-    computes the same orphan set and reports it but issues no write.
+    All three fire in dry-run mode too: the operator's mandatory dry run is exactly where
+    a bad keep-set needs to surface.
+
+    Only then does this — unless ``dry_run`` — DETACH-DELETE the complement in batches
+    (removing each orphan's edges with it). A ``--dry-run`` computes the same orphan set
+    and reports it but issues no write.
 
     The complement is a set difference, not a degree/reference test, which is the whole
     reason this exists rather than a cypher one-liner (see the module docstring): a
@@ -333,6 +477,9 @@ def prune_narrators(
     """
     if not 0.0 <= max_missing_fraction <= 1.0:
         msg = f"max_missing_fraction must be in [0.0, 1.0], got {max_missing_fraction}"
+        raise ValueError(msg)
+    if not 0.0 <= max_orphan_fraction <= 1.0:
+        msg = f"max_orphan_fraction must be in [0.0, 1.0], got {max_orphan_fraction}"
         raise ValueError(msg)
 
     # Guard 1, before ANY graph access. An unusable keep-set raises here.
@@ -356,6 +503,21 @@ def prune_narrators(
 
     orphans = [gid for gid in graph_ids_pre if gid not in canonical_ids]
     sample = orphans[:SAMPLE_SIZE]
+
+    # Guard 3: the DELETE-side magnitude. `missing` above is structurally blind to this —
+    # it bounds `canonical - graph`, none of whose elements can be deleted. A truncated
+    # same-generation keep-set has missing == 0 and would still wipe the graph. Refuses
+    # BEFORE any write, in both modes. (An empty graph has nothing to delete and no
+    # fraction to speak of; guard 2 has already refused it unless deliberately overridden.)
+    if graph_ids_pre and len(orphans) > max_orphan_fraction * len(graph_ids_pre):
+        raise ExcessiveDeletionError(
+            path=canonical_path,
+            orphans=len(orphans),
+            graph_total=len(graph_ids_pre),
+            canonical_total=len(canonical_ids),
+            missing=missing,
+            max_orphan_fraction=max_orphan_fraction,
+        )
 
     if dry_run:
         logger.info(

--- a/tests/integration/test_prune_narrators.py
+++ b/tests/integration/test_prune_narrators.py
@@ -1,0 +1,134 @@
+"""Integration tests for the canonical-set SHRINK against a real Neo4j container (da#413).
+
+These are the load-bearing acceptance tests: the whole reason ``prune-narrators``
+exists rather than a cypher one-liner is that the orphan predicate is canonical-set
+membership, NOT node degree. Only a real graph can prove that an orphan WITH edges is
+deleted (edges and all) while a legitimate zero-degree canonical narrator survives —
+the two facts a degree-based prune gets backwards (deploy#557's measure-first).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.graph.prune import EmptyCanonicalSetError, prune_narrators
+from src.utils.neo4j_client import Neo4jClient
+from tests.test_graph.conftest import write_narrators_canonical
+
+pytestmark = pytest.mark.integration
+
+
+# The seeded graph, chosen to put each of deploy#557's measured classes on the board:
+#
+#   nar:keep_zero    canonical, ZERO edges  -> the 57,993 class a degree prune wipes.
+#   nar:keep_busy    canonical, HAS an edge -> a normal surviving narrator.
+#   nar:orphan_edged NOT canonical, HAS an edge -> the 18,518 class a degree prune misses.
+#   nar:orphan_lonely NOT canonical, zero edges -> a plain orphan.
+_KEEP_ZERO = "nar:keep_zero"
+_KEEP_BUSY = "nar:keep_busy"
+_ORPHAN_EDGED = "nar:orphan_edged"
+_ORPHAN_LONELY = "nar:orphan_lonely"
+
+_SEED = """\
+CREATE (kz:Narrator {id: $keep_zero})
+CREATE (kb:Narrator {id: $keep_busy})
+CREATE (oe:Narrator {id: $orphan_edged})
+CREATE (ol:Narrator {id: $orphan_lonely})
+// The orphan's edge lands on a surviving canonical narrator: DETACH must remove it
+// when the orphan goes, and the survivor must stay.
+CREATE (oe)-[:TRANSMITTED_TO {hadith_id: 'hdt:x:1'}]->(kb)
+"""
+
+
+def _seed_graph(client: Neo4jClient) -> None:
+    client.execute_write(
+        _SEED,
+        {
+            "keep_zero": _KEEP_ZERO,
+            "keep_busy": _KEEP_BUSY,
+            "orphan_edged": _ORPHAN_EDGED,
+            "orphan_lonely": _ORPHAN_LONELY,
+        },
+    )
+
+
+def _narrator_ids(client: Neo4jClient) -> set[str]:
+    rows = client.execute_read("MATCH (n:Narrator) RETURN n.id AS id")
+    return {r["id"] for r in rows}
+
+
+def _transmitted_edge_count(client: Neo4jClient) -> int:
+    rows = client.execute_read("MATCH ()-[r:TRANSMITTED_TO]->() RETURN count(r) AS c")
+    return int(rows[0]["c"])
+
+
+def _canonical(tmp_path: Path, ids: list[str]) -> Path:
+    return write_narrators_canonical(tmp_path, [{"canonical_id": i} for i in ids])
+
+
+class TestPruneAgainstRealGraph:
+    def test_orphan_with_edges_deleted_zero_degree_canonical_survives(
+        self, neo4j_client: Neo4jClient, tmp_path: Path
+    ) -> None:
+        _seed_graph(neo4j_client)
+        assert _narrator_ids(neo4j_client) == {
+            _KEEP_ZERO,
+            _KEEP_BUSY,
+            _ORPHAN_EDGED,
+            _ORPHAN_LONELY,
+        }
+        assert _transmitted_edge_count(neo4j_client) == 1
+
+        canonical = _canonical(tmp_path, [_KEEP_ZERO, _KEEP_BUSY])
+        result = prune_narrators(neo4j_client, canonical)
+
+        # Read the graph back — do not trust the returned count (count>=0 memory).
+        survivors = _narrator_ids(neo4j_client)
+        # (1) the edge-bearing orphan is gone; (2) the zero-degree canonical survives.
+        assert survivors == {_KEEP_ZERO, _KEEP_BUSY}
+        assert _ORPHAN_EDGED not in survivors
+        assert _KEEP_ZERO in survivors, "a zero-degree canonical narrator was wrongly deleted"
+        # DETACH removed the orphan's edge; the canonical endpoint stayed.
+        assert _transmitted_edge_count(neo4j_client) == 0
+        assert result.deleted == 2
+        assert result.orphans_identified == 2
+
+    def test_dry_run_deletes_nothing(self, neo4j_client: Neo4jClient, tmp_path: Path) -> None:
+        _seed_graph(neo4j_client)
+        before = _narrator_ids(neo4j_client)
+
+        canonical = _canonical(tmp_path, [_KEEP_ZERO, _KEEP_BUSY])
+        result = prune_narrators(neo4j_client, canonical, dry_run=True)
+
+        assert result.dry_run is True
+        assert result.orphans_identified == 2  # it counts
+        assert result.deleted == 0
+        assert _narrator_ids(neo4j_client) == before, "dry-run mutated the graph"
+        assert _transmitted_edge_count(neo4j_client) == 1
+
+    def test_guard_refuses_empty_canonical_without_touching_graph(
+        self, neo4j_client: Neo4jClient, tmp_path: Path
+    ) -> None:
+        _seed_graph(neo4j_client)
+        before = _narrator_ids(neo4j_client)
+
+        empty = _canonical(tmp_path, [])  # readable, zero canonical_id values
+        with pytest.raises(EmptyCanonicalSetError):
+            prune_narrators(neo4j_client, empty)
+
+        # The graph is EXACTLY as it was: a bad read wiped nothing.
+        assert _narrator_ids(neo4j_client) == before
+        assert _transmitted_edge_count(neo4j_client) == 1
+
+    def test_guard_refuses_missing_canonical_without_touching_graph(
+        self, neo4j_client: Neo4jClient, tmp_path: Path
+    ) -> None:
+        _seed_graph(neo4j_client)
+        before = _narrator_ids(neo4j_client)
+
+        with pytest.raises(EmptyCanonicalSetError):
+            prune_narrators(neo4j_client, tmp_path / "does_not_exist.parquet")
+
+        assert _narrator_ids(neo4j_client) == before

--- a/tests/integration/test_prune_narrators.py
+++ b/tests/integration/test_prune_narrators.py
@@ -15,6 +15,7 @@ import pytest
 
 from src.graph.prune import (
     EmptyCanonicalSetError,
+    ExcessiveDeletionError,
     ForeignCanonicalSetError,
     prune_narrators,
     summary_line,
@@ -164,6 +165,30 @@ class TestPruneAgainstRealGraph:
 
         assert raised.value.missing == 4  # none of the keep-set is in the graph
         # Nothing was deleted: every node AND the orphan's edge are exactly as seeded.
+        assert _narrator_ids(neo4j_client) == before
+        assert _transmitted_edge_count(neo4j_client) == 1
+
+    def test_truncated_keep_set_refused_against_a_real_graph(
+        self, neo4j_client: Neo4jClient, tmp_path: Path
+    ) -> None:
+        """A TRUNCATED keep-set: this graph's own ids, just too few of them (da#413 2nd review).
+
+        The keep-set names one real, current narrator. ``missing`` is therefore **0** —
+        every id-provenance instrument, here and in deploy#574, reports it healthy — while
+        the prune would DETACH DELETE 3 of the 4 narrators. Against a live graph, the
+        refusal must cost it nothing: no node, no edge.
+        """
+        _seed_graph(neo4j_client)
+        before = _narrator_ids(neo4j_client)
+
+        truncated = _canonical(tmp_path, [_KEEP_BUSY])  # 1 of 4: a half-written parquet
+        with pytest.raises(ExcessiveDeletionError) as raised:
+            prune_narrators(neo4j_client, truncated, max_orphan_fraction=0.5)
+
+        assert raised.value.missing == 0, "the keep-set is same-generation; missing must be 0"
+        assert raised.value.orphans == 3
+        assert raised.value.graph_total == 4
+        # Nothing deleted: every node AND the orphan's edge are exactly as seeded.
         assert _narrator_ids(neo4j_client) == before
         assert _transmitted_edge_count(neo4j_client) == 1
 

--- a/tests/integration/test_prune_narrators.py
+++ b/tests/integration/test_prune_narrators.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from src.graph.prune import EmptyCanonicalSetError, prune_narrators
+from src.graph.prune import EmptyCanonicalSetError, prune_narrators, summary_line
 from src.utils.neo4j_client import Neo4jClient
 from tests.test_graph.conftest import write_narrators_canonical
 
@@ -92,8 +92,15 @@ class TestPruneAgainstRealGraph:
         assert _KEEP_ZERO in survivors, "a zero-degree canonical narrator was wrongly deleted"
         # DETACH removed the orphan's edge; the canonical endpoint stayed.
         assert _transmitted_edge_count(neo4j_client) == 0
-        assert result.deleted == 2
-        assert result.orphans_identified == 2
+        # Readback-measured summary fields — the deploy#557 contract on a real graph.
+        assert result.deleted == 2  # pre(4) - post(2)
+        assert result.graph_total == 2  # survivors, re-read
+        assert result.orphans == 0  # post-count MUST be 0 (exactly the orphans went)
+        assert result.orphans_identified == 2  # would-delete, pre
+        assert (
+            summary_line(result)
+            == "PRUNE_NARRATORS_SUMMARY canonical=2 graph_total=2 orphans=0 deleted=2"
+        )
 
     def test_dry_run_deletes_nothing(self, neo4j_client: Neo4jClient, tmp_path: Path) -> None:
         _seed_graph(neo4j_client)

--- a/tests/integration/test_prune_narrators.py
+++ b/tests/integration/test_prune_narrators.py
@@ -13,7 +13,12 @@ from pathlib import Path
 
 import pytest
 
-from src.graph.prune import EmptyCanonicalSetError, prune_narrators, summary_line
+from src.graph.prune import (
+    EmptyCanonicalSetError,
+    ForeignCanonicalSetError,
+    prune_narrators,
+    summary_line,
+)
 from src.utils.neo4j_client import Neo4jClient
 from tests.test_graph.conftest import write_narrators_canonical
 
@@ -97,9 +102,10 @@ class TestPruneAgainstRealGraph:
         assert result.graph_total == 2  # survivors, re-read
         assert result.orphans == 0  # post-count MUST be 0 (exactly the orphans went)
         assert result.orphans_identified == 2  # would-delete, pre
+        assert result.missing == 0  # the keep-set IS this graph's — every id is present
         assert (
             summary_line(result)
-            == "PRUNE_NARRATORS_SUMMARY canonical=2 graph_total=2 orphans=0 deleted=2"
+            == "PRUNE_NARRATORS_SUMMARY canonical=2 graph_total=2 orphans=0 deleted=2 missing=0"
         )
 
     def test_dry_run_deletes_nothing(self, neo4j_client: Neo4jClient, tmp_path: Path) -> None:
@@ -139,3 +145,45 @@ class TestPruneAgainstRealGraph:
             prune_narrators(neo4j_client, tmp_path / "does_not_exist.parquet")
 
         assert _narrator_ids(neo4j_client) == before
+
+    def test_stale_keep_set_refused_against_a_real_graph(
+        self, neo4j_client: Neo4jClient, tmp_path: Path
+    ) -> None:
+        """A wrong-but-valid keep-set: readable, non-empty, and NOT this graph's (da#413
+        review). Against a live graph, the refusal must cost it nothing — no node, no edge.
+
+        The keep-set here names four narrators the graph has never heard of. It is exactly
+        as well-formed as the correct one; only ``missing`` tells them apart.
+        """
+        _seed_graph(neo4j_client)
+        before = _narrator_ids(neo4j_client)
+
+        stale = _canonical(tmp_path, ["nar:prev_a", "nar:prev_b", "nar:prev_c", "nar:prev_d"])
+        with pytest.raises(ForeignCanonicalSetError) as raised:
+            prune_narrators(neo4j_client, stale)
+
+        assert raised.value.missing == 4  # none of the keep-set is in the graph
+        # Nothing was deleted: every node AND the orphan's edge are exactly as seeded.
+        assert _narrator_ids(neo4j_client) == before
+        assert _transmitted_edge_count(neo4j_client) == 1
+
+    def test_partial_load_reports_missing_and_still_prunes(
+        self, neo4j_client: Neo4jClient, tmp_path: Path
+    ) -> None:
+        """The dual, on a real graph: a CORRECT keep-set whose load was partial.
+
+        ``nar:never_loaded`` is canonical but absent from the graph (the REFUSED_ROWS /
+        STOPPED_AT_LIMIT shape). ``missing`` is 1 — reported, not refused — and the prune
+        proceeds normally, removing exactly the orphans. A hard ``missing == 0`` in this
+        layer would have refused this legitimate prune.
+        """
+        _seed_graph(neo4j_client)
+
+        canonical = _canonical(tmp_path, [_KEEP_ZERO, _KEEP_BUSY, "nar:never_loaded"])
+        result = prune_narrators(neo4j_client, canonical)
+
+        assert result.missing == 1  # the canonical id the load never wrote
+        assert result.deleted == 2  # exactly the two orphans
+        assert _narrator_ids(neo4j_client) == {_KEEP_ZERO, _KEEP_BUSY}
+        assert result.orphans == 0
+        assert "missing=1" in summary_line(result)

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -310,7 +310,7 @@ class TestReservedSetIsEnumerated:
             "UNROUTED_CORPUS": 9,
             "PARSE_PRODUCER_DEFECT": 10,
             "RESOLVE_STAGE_FAILED": 11,
-            "EMPTY_CANONICAL_SET": 12,
+            "UNUSABLE_CANONICAL_SET": 12,
         }
 
     def test_the_ruling_table_is_pinned(self) -> None:
@@ -332,7 +332,7 @@ class TestReservedSetIsEnumerated:
         )  # da#386: parse fails loud on the da#355 gate (9 taken by da#369 UNROUTED_CORPUS)
         assert ExitCode.RESOLVE_STAGE_FAILED == 11  # da#360: 11 after 3-way 9-collision
         assert (
-            ExitCode.EMPTY_CANONICAL_SET == 12
+            ExitCode.UNUSABLE_CANONICAL_SET == 12
         )  # da#413: prune-narrators refused, graph untouched; next free code
 
     def test_every_member_documents_what_is_on_disk(self) -> None:

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -310,6 +310,7 @@ class TestReservedSetIsEnumerated:
             "UNROUTED_CORPUS": 9,
             "PARSE_PRODUCER_DEFECT": 10,
             "RESOLVE_STAGE_FAILED": 11,
+            "EMPTY_CANONICAL_SET": 12,
         }
 
     def test_the_ruling_table_is_pinned(self) -> None:
@@ -330,6 +331,9 @@ class TestReservedSetIsEnumerated:
             ExitCode.PARSE_PRODUCER_DEFECT == 10
         )  # da#386: parse fails loud on the da#355 gate (9 taken by da#369 UNROUTED_CORPUS)
         assert ExitCode.RESOLVE_STAGE_FAILED == 11  # da#360: 11 after 3-way 9-collision
+        assert (
+            ExitCode.EMPTY_CANONICAL_SET == 12
+        )  # da#413: prune-narrators refused, graph untouched; next free code
 
     def test_every_member_documents_what_is_on_disk(self) -> None:
         """The DOCSTRINGS are the specification. There is no ordering claim.

--- a/tests/test_graph/test_prune.py
+++ b/tests/test_graph/test_prune.py
@@ -1,0 +1,182 @@
+"""Unit tests for src.graph.prune — canonical-set SHRINK of Narrator nodes (da#413).
+
+These drive the orphan-computation and the guard against a :class:`MockNeo4jClient`,
+so they run with no Docker. The graph-truth acceptance (an edge-bearing orphan is
+deleted with its edges, a zero-degree canonical narrator survives) needs a real graph
+and lives in ``tests/integration/test_prune_narrators.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.graph.prune import (
+    EmptyCanonicalSetError,
+    PruneResult,
+    prune_narrators,
+    read_canonical_ids,
+)
+from tests.test_graph.conftest import MockNeo4jClient, write_narrators_canonical
+
+
+def _graph_rows(ids: list[str]) -> list[dict[str, str]]:
+    """Shape of ``MATCH (n:Narrator) RETURN n.id AS id`` records."""
+    return [{"id": nid} for nid in ids]
+
+
+def _write_calls(client: MockNeo4jClient) -> list[dict[str, object]]:
+    return [
+        params for _query, params in client.calls if isinstance(params, dict) and "batch" in params
+    ]
+
+
+class TestReadCanonicalIds:
+    def test_reads_the_canonical_id_set(self, curated_dir: Path) -> None:
+        path = write_narrators_canonical(
+            curated_dir, [{"canonical_id": "nar:001"}, {"canonical_id": "nar:002"}]
+        )
+        assert read_canonical_ids(path) == {"nar:001", "nar:002"}
+
+    def test_missing_parquet_refuses(self, curated_dir: Path) -> None:
+        missing = curated_dir / "does_not_exist.parquet"
+        with pytest.raises(EmptyCanonicalSetError, match="missing"):
+            read_canonical_ids(missing)
+
+    def test_unreadable_parquet_refuses(self, curated_dir: Path) -> None:
+        # A non-parquet file with the right extension: pq.read_table raises, and the
+        # guard folds that into a refusal rather than letting it crash mid-prune.
+        bogus = curated_dir / "narrators_canonical.parquet"
+        bogus.write_text("this is not a parquet file")
+        with pytest.raises(EmptyCanonicalSetError, match="unreadable"):
+            read_canonical_ids(bogus)
+
+    def test_empty_parquet_refuses(self, curated_dir: Path) -> None:
+        # Present, readable, zero canonical_id values: an empty keep-set would delete
+        # every narrator, so it is exactly the catastrophic case the guard exists for.
+        path = write_narrators_canonical(curated_dir, [])
+        with pytest.raises(EmptyCanonicalSetError, match="zero canonical_id"):
+            read_canonical_ids(path)
+
+    def test_blank_ids_do_not_count_as_a_keep_set(self, curated_dir: Path) -> None:
+        # Rows present but every canonical_id blank → no usable ids → refuse. (The
+        # schema is non-nullable, so blank is the reachable "no id here" value.)
+        path = write_narrators_canonical(curated_dir, [{"canonical_id": ""}, {"canonical_id": ""}])
+        with pytest.raises(EmptyCanonicalSetError):
+            read_canonical_ids(path)
+
+
+class TestGuardTouchesNothing:
+    """The load-bearing safety property: a bad read deletes nothing, reads no graph."""
+
+    @pytest.mark.parametrize("kind", ["missing", "empty", "unreadable"])
+    def test_guard_refuses_with_zero_client_calls(self, curated_dir: Path, kind: str) -> None:
+        if kind == "missing":
+            path = curated_dir / "nope.parquet"
+        elif kind == "empty":
+            path = write_narrators_canonical(curated_dir, [])
+        else:
+            path = curated_dir / "narrators_canonical.parquet"
+            path.write_text("garbage")
+
+        client = MockNeo4jClient()
+        with pytest.raises(EmptyCanonicalSetError):
+            prune_narrators(client, path)
+
+        # Neither the read of graph ids nor any DETACH DELETE was issued. The guard
+        # fired before the graph was touched at all.
+        assert client.calls == [], f"guard ({kind}) reached the graph: {client.calls}"
+
+
+class TestPruneComputesTheComplement:
+    def test_orphan_is_deleted_zero_degree_canonical_survives(self, curated_dir: Path) -> None:
+        """The whole reason pure-cypher failed, at the set level.
+
+        ``nar:keep_zero_degree`` is a canonical narrator with no edges — the 57,993
+        class that a degree prune wrongly deletes. It is in the keep-set, so it is
+        NOT in the delete batch. ``nar:orphan`` is absent from the keep-set, so it IS
+        — regardless of how many edges it has (DETACH removes them).
+        """
+        path = write_narrators_canonical(
+            curated_dir,
+            [{"canonical_id": "nar:keep_zero_degree"}, {"canonical_id": "nar:keep_busy"}],
+        )
+        client = MockNeo4jClient()
+        client.set_read_results(
+            _graph_rows(["nar:keep_zero_degree", "nar:keep_busy", "nar:orphan"])
+        )
+
+        result = prune_narrators(client, path)
+
+        writes = _write_calls(client)
+        assert writes, "expected a batched DETACH DELETE call"
+        deleted_batch = writes[0]["batch"]
+        assert deleted_batch == ["nar:orphan"]
+        assert "nar:keep_zero_degree" not in deleted_batch
+        assert result.orphans_identified == 1
+
+    def test_no_orphans_issues_no_write(self, curated_dir: Path) -> None:
+        path = write_narrators_canonical(
+            curated_dir, [{"canonical_id": "nar:001"}, {"canonical_id": "nar:002"}]
+        )
+        client = MockNeo4jClient()
+        client.set_read_results(_graph_rows(["nar:001", "nar:002"]))
+
+        result = prune_narrators(client, path)
+
+        assert result.orphans_identified == 0
+        assert _write_calls(client) == []
+
+    def test_batches_respect_batch_size(self, curated_dir: Path) -> None:
+        path = write_narrators_canonical(curated_dir, [{"canonical_id": "nar:keep"}])
+        client = MockNeo4jClient()
+        orphans = [f"nar:orphan{i}" for i in range(5)]
+        client.set_read_results(_graph_rows(["nar:keep", *orphans]))
+
+        prune_narrators(client, path, batch_size=2)
+
+        batches = [w["batch"] for w in _write_calls(client)]
+        assert batches == [orphans[0:2], orphans[2:4], orphans[4:5]]
+
+    def test_result_fields(self, curated_dir: Path) -> None:
+        path = write_narrators_canonical(
+            curated_dir, [{"canonical_id": "nar:001"}, {"canonical_id": "nar:002"}]
+        )
+        client = MockNeo4jClient()
+        client.set_read_results(_graph_rows(["nar:001", "nar:orphan"]))
+
+        result = prune_narrators(client, path)
+
+        assert isinstance(result, PruneResult)
+        assert result.canonical_ids_seen == 2
+        assert result.graph_narrators_seen == 2
+        assert result.orphans_identified == 1
+        assert result.sample == ["nar:orphan"]
+        assert result.dry_run is False
+
+
+class TestDryRun:
+    def test_dry_run_issues_no_write(self, curated_dir: Path) -> None:
+        path = write_narrators_canonical(curated_dir, [{"canonical_id": "nar:keep"}])
+        client = MockNeo4jClient()
+        client.set_read_results(_graph_rows(["nar:keep", "nar:orphan_a", "nar:orphan_b"]))
+
+        result = prune_narrators(client, path, dry_run=True)
+
+        assert result.dry_run is True
+        assert result.orphans_identified == 2  # counted
+        assert result.deleted == 0  # but nothing deleted
+        assert result.sample == ["nar:orphan_a", "nar:orphan_b"]
+        assert _write_calls(client) == [], "dry-run must not issue a DETACH DELETE"
+
+    def test_dry_run_still_reads_the_graph(self, curated_dir: Path) -> None:
+        # It reports a real count, so it does read the graph — it just writes nothing.
+        path = write_narrators_canonical(curated_dir, [{"canonical_id": "nar:keep"}])
+        client = MockNeo4jClient()
+        client.set_read_results(_graph_rows(["nar:keep", "nar:orphan"]))
+
+        prune_narrators(client, path, dry_run=True)
+
+        read_calls = [q for q, _p in client.calls if "MATCH (n:Narrator)" in q]
+        assert read_calls, "dry-run should have read the graph's narrator ids"

--- a/tests/test_graph/test_prune.py
+++ b/tests/test_graph/test_prune.py
@@ -9,6 +9,7 @@ and lives in ``tests/integration/test_prune_narrators.py``.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -17,6 +18,7 @@ from src.graph.prune import (
     PruneResult,
     prune_narrators,
     read_canonical_ids,
+    summary_line,
 )
 from tests.test_graph.conftest import MockNeo4jClient, write_narrators_canonical
 
@@ -30,6 +32,36 @@ def _write_calls(client: MockNeo4jClient) -> list[dict[str, object]]:
     return [
         params for _query, params in client.calls if isinstance(params, dict) and "batch" in params
     ]
+
+
+class StatefulFakeNeo4j:
+    """A minimal Narrator-set fake that actually applies the DETACH DELETE.
+
+    The shared :class:`MockNeo4jClient` is stateless — its ``execute_read`` always
+    returns the same rows — so it cannot exercise the post-delete readback that
+    ``deleted`` and the summary ``orphans=`` (post-count) are measured from. This fake
+    holds a live id set: reads return the current set, and a batched delete removes
+    those ids. Enough to prove the readback semantics without Docker; the real graph
+    confirms them in the integration suite.
+    """
+
+    def __init__(self, narrator_ids: list[str]) -> None:
+        self.narrators: list[str] = list(narrator_ids)
+        self.deleted_batches: list[list[str]] = []
+
+    def execute_read(
+        self, query: str, parameters: dict[str, Any] | None = None, *, timeout: float | None = None
+    ) -> list[dict[str, str]]:
+        return [{"id": nid} for nid in self.narrators]
+
+    def execute_write(
+        self, query: str, parameters: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        batch = list((parameters or {}).get("batch", []))
+        self.deleted_batches.append(batch)
+        drop = set(batch)
+        self.narrators = [n for n in self.narrators if n not in drop]
+        return []
 
 
 class TestReadCanonicalIds:
@@ -90,13 +122,15 @@ class TestGuardTouchesNothing:
 
 
 class TestPruneComputesTheComplement:
-    def test_orphan_is_deleted_zero_degree_canonical_survives(self, curated_dir: Path) -> None:
+    def test_delete_batch_targets_orphan_not_zero_degree_canonical(self, curated_dir: Path) -> None:
         """The whole reason pure-cypher failed, at the set level.
 
         ``nar:keep_zero_degree`` is a canonical narrator with no edges — the 57,993
         class that a degree prune wrongly deletes. It is in the keep-set, so it is
         NOT in the delete batch. ``nar:orphan`` is absent from the keep-set, so it IS
-        — regardless of how many edges it has (DETACH removes them).
+        — regardless of how many edges it has (DETACH removes them). This asserts the
+        batch TARGETING; the real deletion + survival is proven against the stateful
+        fake below and on a live graph in the integration suite.
         """
         path = write_narrators_canonical(
             curated_dir,
@@ -139,21 +173,47 @@ class TestPruneComputesTheComplement:
         batches = [w["batch"] for w in _write_calls(client)]
         assert batches == [orphans[0:2], orphans[2:4], orphans[4:5]]
 
-    def test_result_fields(self, curated_dir: Path) -> None:
+
+class TestReadbackSemantics:
+    """``deleted`` and the summary ``orphans=`` are measured by reading the graph BACK.
+
+    Driven against the stateful fake so the post-delete state is real, not the pre-read
+    echoed. This is where the by-mode ``orphans=`` contract and the pre/post ``deleted``
+    are pinned without Docker.
+    """
+
+    def test_real_run_deletes_and_post_orphans_is_zero(self, curated_dir: Path) -> None:
         path = write_narrators_canonical(
-            curated_dir, [{"canonical_id": "nar:001"}, {"canonical_id": "nar:002"}]
+            curated_dir, [{"canonical_id": "nar:keep_zero"}, {"canonical_id": "nar:keep_busy"}]
         )
-        client = MockNeo4jClient()
-        client.set_read_results(_graph_rows(["nar:001", "nar:orphan"]))
+        client = StatefulFakeNeo4j(
+            ["nar:keep_zero", "nar:keep_busy", "nar:orphan_a", "nar:orphan_b"]
+        )
 
         result = prune_narrators(client, path)
 
         assert isinstance(result, PruneResult)
         assert result.canonical_ids_seen == 2
-        assert result.graph_narrators_seen == 2
-        assert result.orphans_identified == 1
-        assert result.sample == ["nar:orphan"]
+        assert result.deleted == 2  # pre(4) - post(2), read back
+        assert result.graph_total == 2  # survivors, post
+        assert result.orphans == 0  # post-count MUST be 0
+        assert result.orphans_identified == 2  # would-delete, pre
         assert result.dry_run is False
+        # The graph actually shrank to exactly the canonical survivors.
+        assert set(client.narrators) == {"nar:keep_zero", "nar:keep_busy"}
+
+    def test_dry_run_fields_are_pre_state(self, curated_dir: Path) -> None:
+        path = write_narrators_canonical(curated_dir, [{"canonical_id": "nar:keep"}])
+        client = StatefulFakeNeo4j(["nar:keep", "nar:orphan_a", "nar:orphan_b"])
+
+        result = prune_narrators(client, path, dry_run=True)
+
+        assert result.dry_run is True
+        assert result.graph_total == 3  # current total, nothing removed
+        assert result.orphans == 2  # would-delete count
+        assert result.deleted == 0
+        assert client.deleted_batches == [], "dry-run issued a delete"
+        assert set(client.narrators) == {"nar:keep", "nar:orphan_a", "nar:orphan_b"}
 
 
 class TestDryRun:
@@ -166,6 +226,8 @@ class TestDryRun:
 
         assert result.dry_run is True
         assert result.orphans_identified == 2  # counted
+        assert result.orphans == 2  # summary field: would-delete on a dry run
+        assert result.graph_total == 3  # current total (nothing removed)
         assert result.deleted == 0  # but nothing deleted
         assert result.sample == ["nar:orphan_a", "nar:orphan_b"]
         assert _write_calls(client) == [], "dry-run must not issue a DETACH DELETE"
@@ -180,3 +242,94 @@ class TestDryRun:
 
         read_calls = [q for q, _p in client.calls if "MATCH (n:Narrator)" in q]
         assert read_calls, "dry-run should have read the graph's narrator ids"
+
+
+class TestSummaryLine:
+    """The one machine-readable line deploy#557's verify greps. Format is a contract."""
+
+    def test_dry_run_line_reports_would_delete(self, curated_dir: Path) -> None:
+        path = write_narrators_canonical(curated_dir, [{"canonical_id": "nar:keep"}])
+        client = StatefulFakeNeo4j(["nar:keep", "nar:orphan_a", "nar:orphan_b"])
+        result = prune_narrators(client, path, dry_run=True)
+        assert (
+            summary_line(result)
+            == "PRUNE_NARRATORS_SUMMARY canonical=1 graph_total=3 orphans=2 deleted=0"
+        )
+
+    def test_real_run_line_reports_zero_orphans_remaining(self, curated_dir: Path) -> None:
+        path = write_narrators_canonical(
+            curated_dir, [{"canonical_id": "nar:keep_a"}, {"canonical_id": "nar:keep_b"}]
+        )
+        client = StatefulFakeNeo4j(["nar:keep_a", "nar:keep_b", "nar:orphan_a"])
+        result = prune_narrators(client, path)
+        # canonical=2, graph_total (post survivors)=2, orphans (post)=0, deleted=1.
+        assert (
+            summary_line(result)
+            == "PRUNE_NARRATORS_SUMMARY canonical=2 graph_total=2 orphans=0 deleted=1"
+        )
+
+
+class TestNoWriteIntoCanonicalDir:
+    """deploy#557 mounts the parquet dir read-only: the subcommand must not write there.
+
+    Unlike ``load`` (which writes a manifest + audit entry into the data dir and trips
+    the ``:ro`` mount, da#348), ``prune-narrators`` reads the parquet and writes ONLY to
+    the graph. Proven structurally: no new file appears beside the canonical parquet on
+    either a dry run or a real run.
+    """
+
+    @pytest.mark.parametrize("dry_run", [True, False])
+    def test_no_side_file_written_next_to_canonical(self, curated_dir: Path, dry_run: bool) -> None:
+        path = write_narrators_canonical(curated_dir, [{"canonical_id": "nar:keep"}])
+        before = sorted(p.name for p in curated_dir.iterdir())
+        client = StatefulFakeNeo4j(["nar:keep", "nar:orphan"])
+
+        prune_narrators(client, path, dry_run=dry_run)
+
+        after = sorted(p.name for p in curated_dir.iterdir())
+        assert after == before == ["narrators_canonical.parquet"]
+
+
+class TestCliEmitsSummaryLine:
+    """deploy#557's verify HARD-FAILS if the summary line is absent from stdout, so the
+    CLI must always print it. Stub the DB layer and assert the line reaches stdout."""
+
+    @pytest.mark.parametrize("dry_run", [True, False])
+    def test_cmd_prints_summary_line(
+        self,
+        curated_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        dry_run: bool,
+    ) -> None:
+        import src.cli as cli
+
+        path = write_narrators_canonical(curated_dir, [{"canonical_id": "nar:keep"}])
+        canned = PruneResult(
+            canonical_ids_seen=1,
+            graph_total=1,
+            orphans=0,
+            deleted=3,
+            dry_run=dry_run,
+            orphans_identified=3,
+            sample=["nar:orphan"],
+        )
+
+        class _DummyClient:
+            def __enter__(self) -> _DummyClient:
+                return self
+
+            def __exit__(self, *_a: object) -> None:
+                return None
+
+        monkeypatch.setattr(cli, "_check_neo4j", lambda: None)
+        monkeypatch.setattr("src.utils.neo4j_client.Neo4jClient", lambda *_a, **_k: _DummyClient())
+        monkeypatch.setattr(
+            "src.graph.prune.prune_narrators",
+            lambda _client, _p, *, dry_run=False: canned,
+        )
+
+        cli._cmd_prune_narrators(canonical=str(path), dry_run=dry_run)
+
+        out = capsys.readouterr().out
+        assert "PRUNE_NARRATORS_SUMMARY canonical=1 graph_total=1 orphans=0 deleted=3" in out

--- a/tests/test_graph/test_prune.py
+++ b/tests/test_graph/test_prune.py
@@ -874,6 +874,49 @@ class TestLargeLegitimatePruneStillProceeds:
         assert client.deleted_batches == []
 
 
+class TestKnownBlindSpotMildTruncation:
+    """A CHARACTERIZATION test: what the two ceilings do NOT catch, pinned deliberately.
+
+    This test asserts a **hole**, not a fix. It exists so that nobody — including us in
+    three months — reads the two magnitude ceilings as closing truncation. They close the
+    catastrophic tail. They cannot close a *fraction*.
+
+    The delete-side ceiling catches a keep-set truncated to a REMNANT (a 500- or 5,000-id
+    parquet against a 160k graph — 97%+ deleted). It cannot catch one truncated to a
+    FRACTION: at 20% of its rows the parquet still deletes 83.9% of the narrator graph and
+    sails under 0.9. And **no ceiling fixes this**, because 83.9% (truncated) and 55.4%
+    (a legitimate full re-mint — see TestLargeLegitimatePruneStillProceeds) are the same
+    kind of number. The bands overlap; a magnitude cannot separate them.
+
+    Only a COMPLETENESS signal can — an expected row count, or the resolve manifest's md5
+    — so that a short parquet is caught by being *short* rather than by being *drastic*.
+    That is a different axis, and it is not plumbed to where the prune runs today.
+
+    If someone later adds that binding, this test should start failing. Deleting it then
+    is the correct action; deleting it *now*, or "fixing" it by lowering the ceiling until
+    it goes green, would break the legitimate prune the ceiling was raised to protect.
+    """
+
+    def test_a_keep_set_missing_a_fifth_of_its_rows_is_NOT_refused(self, curated_dir: Path) -> None:
+        # 200-node generation; the parquet lost 60% of its rows (kept 80 of 200). Real
+        # ids, same generation, so `missing` is 0 — and the delete magnitude is 60%,
+        # comfortably under the 0.9 ceiling. It deletes 120 legitimate narrators.
+        live = _generation_ids(200)
+        client = StatefulFakeNeo4j(list(live))
+        short = _canonical_parquet(curated_dir, live[:80], names=_generation_names(80))
+
+        result = prune_narrators(client, short)  # default ceilings: NO refusal
+
+        assert result.missing == 0, "same-generation, so no provenance signal fires"
+        assert result.deleted == 120  # 120 legitimate, current narrators destroyed
+        assert 0.5 < result.deleted / 200 < 0.9, (
+            "this is the overlap band: indistinguishable BY MAGNITUDE from a legitimate "
+            "full-re-mint cleanup, which is exactly why no ceiling can catch it"
+        )
+        # The only thing standing in front of this is the operator reading the dry run.
+        assert "missing=0" in summary_line(result)
+
+
 class TestOrphanCeiling:
     def test_at_the_ceiling_is_allowed_above_it_refuses(self, curated_dir: Path) -> None:
         # Strictly-greater, same as the missing ceiling. graph=10, orphans=9 -> exactly 0.9.

--- a/tests/test_graph/test_prune.py
+++ b/tests/test_graph/test_prune.py
@@ -18,6 +18,7 @@ import pytest
 from src.graph.prune import (
     SUMMARY_KEYS,
     EmptyCanonicalSetError,
+    ExcessiveDeletionError,
     ForeignCanonicalSetError,
     PruneResult,
     UnusableCanonicalSetError,
@@ -561,7 +562,7 @@ class TestStaleKeepSetIsRefused:
 
     def test_the_guard_is_catchable_as_the_cli_catches_it(self, curated_dir: Path) -> None:
         # _cmd_prune_narrators catches UnusableCanonicalSetError and exits
-        # EMPTY_CANONICAL_SET. If this door were not under that supertype it would escape
+        # UNUSABLE_CANONICAL_SET. If this door were not under that supertype it would escape
         # to CPython's handler and exit 1 (LOAD_FAILED) — "the load failed", for a command
         # that deleted nothing and is not a load.
         stale = _canonical_parquet(curated_dir, _stale_generation_ids())
@@ -645,6 +646,266 @@ class TestMissingIsReportedNotAsserted:
         # `missing` separates them cleanly, and it is the ONLY field that does.
         assert good.missing == 0
         assert bad.missing == 8
+
+
+# --------------------------------------------------------------------------------------
+# The TRUNCATED keep-set: same generation, right ids, just too few (da#413 2nd review)
+# --------------------------------------------------------------------------------------
+#
+# `missing` bounds `canonical - graph` — a set whose elements are NOT in the graph and so
+# cannot be deleted. It is structurally incapable of bounding the set that DOES delete,
+# `orphans = graph - canonical`. A truncated keep-set walks straight through that gap: a
+# resolve stopped early, a half-written parquet, a partial upload, a null-heavy
+# canonical_id column. Every id in it is real and current, so `missing` is EXACTLY 0 and
+# every id-provenance instrument — here and in deploy#574 — reports the keep-set healthy,
+# while the prune deletes all but the remnant.
+#
+# These fixtures work at generation scale rather than with a handful of ids, because the
+# guard is a FRACTION and a 3-node graph cannot express a realistic one. Names are composed
+# from real base names and real nisbas, and every id is minted by the production
+# `make_canonical_id` — the same discipline as the stale-keep-set fixtures above.
+_NISBAS = [
+    "الزهري",
+    "البصري",
+    "الكوفي",
+    "المدني",
+    "المكي",
+    "الشامي",
+    "اليماني",
+    "المصري",
+    "البغدادي",
+    "النيسابوري",
+    "الطبري",
+    "الرازي",
+    "الاصبهاني",
+    "الدمشقي",
+    "الحمصي",
+    "الواسطي",
+    "الانصاري",
+    "التميمي",
+    "القرشي",
+    "الهمداني",
+    "الجعفي",
+    "السلمي",
+    "الاسدي",
+    "العبدي",
+    "الثقفي",
+    "الخزاعي",
+    "النخعي",
+    "المزني",
+    "الغفاري",
+    "الجهني",
+    "الطائي",
+    "العبسي",
+    "الفزاري",
+    "الضبي",
+    "السدوسي",
+    "الحنفي",
+    "الازدي",
+    "الخولاني",
+    "الحضرمي",
+    "المرادي",
+]
+
+
+def _generation_names(count: int) -> list[str]:
+    """`count` real-shaped narrator names — base name + nisba, the actual naming morphology."""
+    names = [f"{base} {nisba}" for nisba in _NISBAS for base in _NARRATOR_NAMES]
+    assert count <= len(names), f"only {len(names)} distinct names available"
+    return names[:count]
+
+
+def _generation_ids(count: int, offset: int = 0) -> list[str]:
+    """`count` canonical ids minted by the PRODUCTION function from real-shaped names."""
+    return [make_canonical_id(n) for n in _generation_names(count + offset)[offset:]]
+
+
+class TestTruncatedKeepSetIsRefused:
+    """The second door to the same catastrophe (Kavitha Sundaramurthy + Jean-Claude, #414).
+
+    The keep-set is not foreign. It is this graph's own — every id real, every id current.
+    It is merely INCOMPLETE, and incompleteness is invisible to every instrument that asks
+    whether the keep-set's ids belong to this graph. `missing` is the wrong axis for it,
+    by construction, so the delete magnitude has to be bounded on its own.
+    """
+
+    def test_the_truncated_keep_set_passes_every_pre_existing_guard(
+        self, curated_dir: Path
+    ) -> None:
+        """The control, and the whole reason the new guard is not theatre.
+
+        Kavitha asked for exactly this: prove the fixture sails through everything that
+        already exists — INCLUDING `missing`, which is not merely small here but exactly
+        **zero**. Without this control, the new ceiling could be guarding a state nothing
+        can reach, and we would believe it. (`feedback_fixture_makes_guard_assertion_inert`.)
+        """
+        live = _generation_ids(200)
+        graph = [*live, *_ORPHANS]  # 202 nodes: a real generation + 2 real orphans
+        truncated = _canonical_parquet(  # a resolve that stopped after 10 rows
+            curated_dir, live[:10], names=_generation_names(10)
+        )
+
+        # (1) the empty / missing / unreadable guard: passes — readable, 10 real ids.
+        keep_set = read_canonical_ids(truncated)
+        assert len(keep_set) == 10
+
+        # (2) `missing` is EXACTLY 0 — every id in the keep-set really is in the graph.
+        #     So the ForeignCanonicalSetError ceiling passes, AND deploy#574's planned
+        #     `missing == 0` policy does not merely miss this: it BLESSES it.
+        graph_set = set(graph)
+        missing = sum(1 for cid in keep_set if cid not in graph_set)
+        assert missing == 0, "the truncated keep-set must be same-generation, or it proves nothing"
+
+        # (3) the consumer's whole-graph-wipe check (`orphans >= graph_pre`) passes too:
+        #     10 nodes survive, so it is not a total wipe by that test's reckoning.
+        orphans = [g for g in graph if g not in keep_set]
+        assert len(orphans) < len(graph)
+
+        # (4) and Weronika's proposed invariant, EXPECTED_POST == CANON_N, also passes.
+        assert len(graph) - len(orphans) == len(keep_set)
+
+        # Every guard we have ever designed says this keep-set is fine. It would delete:
+        assert len(orphans) / len(graph) > 0.95  # 95%+ of the narrator graph
+
+    def test_without_the_ceiling_a_truncated_keep_set_wipes_the_graph(
+        self, curated_dir: Path
+    ) -> None:
+        """The red: measured damage, not asserted danger."""
+        live = _generation_ids(200)
+        client = StatefulFakeNeo4j([*live, *_ORPHANS])
+        truncated = _canonical_parquet(curated_dir, live[:10], names=_generation_names(10))
+
+        result = prune_narrators(client, truncated, max_orphan_fraction=1.0)
+
+        assert result.missing == 0  # every provenance instrument stays silent
+        assert result.deleted == 192  # 202 - 10
+        assert len(client.narrators) == 10
+        assert result.deleted / 202 > 0.95
+        # And every post-op gate greens, exactly as with the stale keep-set.
+        assert result.orphans == 0
+        assert result.deleted == result.orphans_identified
+        assert result.graph_total > 0
+
+    def test_truncated_keep_set_is_refused_before_any_write(self, curated_dir: Path) -> None:
+        """The green: refused by the delete-side ceiling, ZERO rows deleted."""
+        live = _generation_ids(200)
+        client = StatefulFakeNeo4j([*live, *_ORPHANS])
+        before = list(client.narrators)
+        truncated = _canonical_parquet(curated_dir, live[:10], names=_generation_names(10))
+
+        with pytest.raises(ExcessiveDeletionError) as raised:
+            prune_narrators(client, truncated)
+
+        assert client.deleted_batches == [], "a refused prune issued a DETACH DELETE"
+        assert client.narrators == before
+        assert raised.value.orphans == 192
+        assert raised.value.graph_total == 202
+        # The refusal names the trap explicitly: a clean `missing` does NOT clear this.
+        assert raised.value.missing == 0
+        assert "TRUNCATED" in str(raised.value)
+
+    def test_refusal_fires_on_a_dry_run_too(self, curated_dir: Path) -> None:
+        live = _generation_ids(200)
+        client = StatefulFakeNeo4j([*live, *_ORPHANS])
+        truncated = _canonical_parquet(curated_dir, live[:10], names=_generation_names(10))
+
+        with pytest.raises(ExcessiveDeletionError):
+            prune_narrators(client, truncated, dry_run=True)
+
+        assert client.deleted_batches == []
+
+    def test_the_guard_is_catchable_as_the_cli_catches_it(self, curated_dir: Path) -> None:
+        live = _generation_ids(200)
+        client = StatefulFakeNeo4j([*live, *_ORPHANS])
+        truncated = _canonical_parquet(curated_dir, live[:10], names=_generation_names(10))
+
+        with pytest.raises(UnusableCanonicalSetError):
+            prune_narrators(client, truncated)
+
+
+class TestLargeLegitimatePruneStillProceeds:
+    """The dual — and the reason the ceiling is 0.9 rather than the intuitive 0.5.
+
+    This subcommand EXISTS to clean up after a mass id re-mint (da#356/da#376). The graph
+    is the union of every load ever run against it, so that cleanup legitimately orphans
+    the entire previous generation — well over half the graph. A ceiling near one half
+    refuses this command's own primary use case, the operator overrides, the override
+    becomes reflex, and the guard is dead. Jean-Claude caught this; it is pinned here so
+    nobody "tightens" the ceiling later and quietly breaks the tool.
+    """
+
+    def test_full_regeneration_orphans_the_majority_and_still_proceeds(
+        self, curated_dir: Path
+    ) -> None:
+        # The accumulated graph: an old generation (200) still resident, plus a freshly
+        # loaded, fully re-minted new one (150). The keep-set is the new generation — it
+        # is CORRECT, and it orphans every node of the old one.
+        old_generation = _generation_ids(200)
+        new_generation = _generation_ids(150, offset=200)
+        assert not (set(old_generation) & set(new_generation)), "re-mint must change the ids"
+
+        client = StatefulFakeNeo4j([*old_generation, *new_generation])
+        correct = _canonical_parquet(
+            curated_dir, new_generation, names=_generation_names(350)[200:]
+        )
+
+        result = prune_narrators(client, correct)  # default ceiling: NO refusal
+
+        # 200 of 350 = 57.1% of the graph deleted — a majority — and it is CORRECT.
+        assert result.deleted == 200
+        assert result.deleted / 350 > 0.5, "the whole point: a legit prune CAN exceed half"
+        assert result.missing == 0
+        assert result.orphans == 0
+        assert set(client.narrators) == set(new_generation)
+
+    def test_a_ceiling_at_one_half_would_have_refused_that(self, curated_dir: Path) -> None:
+        # Pin the counterfactual, so the choice of 0.9 is defended by a test and not only
+        # by a comment. This is the prune the intuitive ceiling would have destroyed.
+        old_generation = _generation_ids(200)
+        new_generation = _generation_ids(150, offset=200)
+        client = StatefulFakeNeo4j([*old_generation, *new_generation])
+        correct = _canonical_parquet(
+            curated_dir, new_generation, names=_generation_names(350)[200:]
+        )
+
+        with pytest.raises(ExcessiveDeletionError):
+            prune_narrators(client, correct, max_orphan_fraction=0.5)
+
+        assert client.deleted_batches == []
+
+
+class TestOrphanCeiling:
+    def test_at_the_ceiling_is_allowed_above_it_refuses(self, curated_dir: Path) -> None:
+        # Strictly-greater, same as the missing ceiling. graph=10, orphans=9 -> exactly 0.9.
+        live = _generation_ids(10)
+        keep = live[:1]
+        client = StatefulFakeNeo4j(list(live))
+        path = _canonical_parquet(curated_dir, keep, names=_generation_names(1))
+
+        at_ceiling = prune_narrators(client, path, dry_run=True, max_orphan_fraction=0.9)
+        assert at_ceiling.orphans == 9  # dry-run: the would-delete count
+
+        with pytest.raises(ExcessiveDeletionError):
+            prune_narrators(client, path, dry_run=True, max_orphan_fraction=0.89)
+
+    def test_empty_graph_does_not_divide_by_zero(self, curated_dir: Path) -> None:
+        # Nothing to delete, no fraction to speak of. The `missing` guard owns the empty
+        # graph (it refuses it by default); this one must simply not explode when the
+        # operator has deliberately waived that one.
+        path = _canonical_parquet(curated_dir, _live_generation_ids())
+        client = StatefulFakeNeo4j([])
+
+        result = prune_narrators(client, path, dry_run=True, max_missing_fraction=1.0)
+
+        assert result.graph_total == 0
+        assert result.orphans == 0
+
+    @pytest.mark.parametrize("bad", [-0.1, 1.1])
+    def test_out_of_range_fraction_raises(self, curated_dir: Path, bad: float) -> None:
+        path = _canonical_parquet(curated_dir, _live_generation_ids())
+        client = StatefulFakeNeo4j(_live_generation_ids())
+        with pytest.raises(ValueError, match=r"max_orphan_fraction.*\[0.0, 1.0\]"):
+            prune_narrators(client, path, max_orphan_fraction=bad)
 
 
 class TestMissingCeiling:
@@ -744,12 +1005,14 @@ class TestCliEmitsSummaryLine:
             def __exit__(self, *_a: object) -> None:
                 return None
 
+        def _canned_prune(
+            _client: object, _p: Path, **_kwargs: object
+        ) -> PruneResult:  # accepts whatever ceilings the CLI passes
+            return canned
+
         monkeypatch.setattr(cli, "_check_neo4j", lambda: None)
         monkeypatch.setattr("src.utils.neo4j_client.Neo4jClient", lambda *_a, **_k: _DummyClient())
-        monkeypatch.setattr(
-            "src.graph.prune.prune_narrators",
-            lambda _client, _p, *, dry_run=False, max_missing_fraction=0.5: canned,
-        )
+        monkeypatch.setattr("src.graph.prune.prune_narrators", _canned_prune)
 
         cli._cmd_prune_narrators(canonical=str(path), dry_run=dry_run)
 
@@ -792,7 +1055,7 @@ class TestCliRefusesStaleKeepSet:
         with pytest.raises(SystemExit) as exit_info:
             cli._cmd_prune_narrators(canonical=str(stale))
 
-        assert exit_info.value.code == ExitCode.EMPTY_CANONICAL_SET
+        assert exit_info.value.code == ExitCode.UNUSABLE_CANONICAL_SET
         assert client.deleted_batches == [], "the CLI deleted rows before refusing"
         err = capsys.readouterr().err
         assert "does not belong to this graph" in err

--- a/tests/test_graph/test_prune.py
+++ b/tests/test_graph/test_prune.py
@@ -8,18 +8,24 @@ and lives in ``tests/integration/test_prune_narrators.py``.
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from src.graph.prune import (
+    SUMMARY_KEYS,
     EmptyCanonicalSetError,
+    ForeignCanonicalSetError,
     PruneResult,
+    UnusableCanonicalSetError,
     prune_narrators,
     read_canonical_ids,
     summary_line,
 )
+from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
 from tests.test_graph.conftest import MockNeo4jClient, write_narrators_canonical
 
 
@@ -253,7 +259,7 @@ class TestSummaryLine:
         result = prune_narrators(client, path, dry_run=True)
         assert (
             summary_line(result)
-            == "PRUNE_NARRATORS_SUMMARY canonical=1 graph_total=3 orphans=2 deleted=0"
+            == "PRUNE_NARRATORS_SUMMARY canonical=1 graph_total=3 orphans=2 deleted=0 missing=0"
         )
 
     def test_real_run_line_reports_zero_orphans_remaining(self, curated_dir: Path) -> None:
@@ -262,11 +268,426 @@ class TestSummaryLine:
         )
         client = StatefulFakeNeo4j(["nar:keep_a", "nar:keep_b", "nar:orphan_a"])
         result = prune_narrators(client, path)
-        # canonical=2, graph_total (post survivors)=2, orphans (post)=0, deleted=1.
+        # canonical=2, graph_total (post survivors)=2, orphans (post)=0, deleted=1, missing=0.
         assert (
             summary_line(result)
-            == "PRUNE_NARRATORS_SUMMARY canonical=2 graph_total=2 orphans=0 deleted=1"
+            == "PRUNE_NARRATORS_SUMMARY canonical=2 graph_total=2 orphans=0 deleted=1 missing=0"
         )
+
+    def test_missing_is_the_fifth_key_and_comes_last(self, curated_dir: Path) -> None:
+        # deploy#557's four-key extraction must be undisturbed by the arrival of a fifth,
+        # which is only true if it is APPENDED. Pin the position, not just the presence.
+        path = write_narrators_canonical(curated_dir, [{"canonical_id": "nar:keep"}])
+        client = StatefulFakeNeo4j(["nar:keep"])
+        line = summary_line(prune_narrators(client, path, dry_run=True))
+
+        keys = [field.split("=", 1)[0] for field in line.split()[1:]]
+        assert keys == list(SUMMARY_KEYS)
+        assert keys[-1] == "missing"
+
+
+class TestSummaryKeyNamespace:
+    """The keys are an APPEND-ONLY namespace, because the consumer's regex is unanchored.
+
+    deploy#557's ``summary_field`` extracts a key with a greedy, unanchored ``.*<key>=``
+    (da#419). A key whose name *ends with* another key's name is therefore read as that
+    other key: ``edges_deleted=`` is silently harvested as ``deleted=``, feeding an edge
+    count into a node-count gate. Adding a fifth key is exactly when that bites, so the
+    invariant is pinned mechanically here rather than left to whoever adds the sixth.
+    """
+
+    def test_no_key_is_a_suffix_of_another(self) -> None:
+        for key in SUMMARY_KEYS:
+            colliders = [other for other in SUMMARY_KEYS if other != key and other.endswith(key)]
+            assert not colliders, (
+                f"summary key {key!r} is a suffix of {colliders!r}: the consumer's "
+                f"unanchored `.*{key}=` would harvest the wrong field (da#419)"
+            )
+
+    def test_summary_line_emits_exactly_the_declared_keys(self, curated_dir: Path) -> None:
+        # SUMMARY_KEYS is the thing the suffix invariant above is checked against, so it
+        # has to actually BE the line's key set — otherwise the invariant guards a
+        # constant nobody emits.
+        path = write_narrators_canonical(curated_dir, [{"canonical_id": "nar:keep"}])
+        client = StatefulFakeNeo4j(["nar:keep", "nar:orphan"])
+        line = summary_line(prune_narrators(client, path))
+
+        assert line.split()[0] == "PRUNE_NARRATORS_SUMMARY"
+        emitted = tuple(field.split("=", 1)[0] for field in line.split()[1:])
+        assert emitted == SUMMARY_KEYS
+
+
+# The consumer's extractor, copied VERBATIM from deploy#557 PR#574's
+# `.github/workflows/graph-prune-narrators.yml:359-361` at head eef7ea7:
+#
+#     summary_field() {
+#       printf '%s\n' "$1" | sed -n "s/.*PRUNE_NARRATORS_SUMMARY .*$2=\([0-9][0-9]*\).*/\1/p" ...
+#
+# Re-implementing it in Python `re` would be testing a translation, not the consumer, and
+# POSIX BRE is not Python's dialect — so this shells out to the real `sed` with the real
+# expression. The producer is the right place for this: it is the producer that breaks the
+# consumer by adding a key.
+_CONSUMER_SED = r"s/.*PRUNE_NARRATORS_SUMMARY .*{key}=\([0-9][0-9]*\).*/\1/p"
+
+
+def _consumer_extract(line: str, key: str) -> str:
+    """Run deploy#557's actual `summary_field` sed over `line` and return what it reads."""
+    proc = subprocess.run(  # noqa: S603
+        ["sed", "-n", _CONSUMER_SED.format(key=key)],  # noqa: S607
+        input=line + "\n",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout.splitlines()[0] if proc.stdout.strip() else ""
+
+
+@pytest.mark.skipif(shutil.which("sed") is None, reason="needs POSIX sed (the consumer's tool)")
+class TestConsumerExtractionCoVerifies:
+    """Co-verify the five-key line against deploy#557's REAL sed, not against a paraphrase.
+
+    ``feedback_silent_zero_is_not_a_measurement``: verify the instrument before you read
+    it. A test that only asserts "all five keys extract correctly" would pass just as
+    happily against a sed that cannot detect a collision at all — so
+    :meth:`test_the_harness_can_actually_detect_a_collision` feeds it a line that MUST be
+    misread, and requires it to be misread. Only then does the clean read below mean
+    anything.
+    """
+
+    def test_the_harness_can_actually_detect_a_collision(self) -> None:
+        # The positive control. `edges_deleted=` ends with `deleted`, so the unanchored
+        # `.*deleted=` harvests 999 — the exact da#419 hazard. If this ever passes as
+        # `4`, the harness has stopped reproducing the consumer and every assertion in
+        # the sibling test below is vacuous.
+        hijacked = (
+            "PRUNE_NARRATORS_SUMMARY canonical=1 graph_total=2 orphans=3 "
+            "deleted=4 edges_deleted=999"
+        )
+        assert _consumer_extract(hijacked, "deleted") == "999", (
+            "the consumer's regex is supposed to be hijackable by a suffix-colliding key; "
+            "if it is not, this harness is no longer the consumer and proves nothing"
+        )
+
+    def test_missing_does_not_collide_with_any_existing_key(self, curated_dir: Path) -> None:
+        # The reading, now that the instrument is known live. Every key — including the
+        # four deploy#557 already extracts — must read its OWN value off the five-key line.
+        path = write_narrators_canonical(
+            curated_dir, [{"canonical_id": f"nar:{c}"} for c in "abcd"]
+        )
+        # Five DISTINCT values (4/5/2/0/1), so a key that harvests a neighbour's field
+        # shows up as a wrong number rather than coincidentally matching the right one.
+        client = StatefulFakeNeo4j(["nar:a", "nar:b", "nar:c", "nar:orphan_x", "nar:orphan_y"])
+        line = summary_line(prune_narrators(client, path, dry_run=True))
+        assert line == (
+            "PRUNE_NARRATORS_SUMMARY canonical=4 graph_total=5 orphans=2 deleted=0 missing=1"
+        )
+
+        assert _consumer_extract(line, "canonical") == "4"
+        assert _consumer_extract(line, "graph_total") == "5"
+        assert _consumer_extract(line, "orphans") == "2"
+        assert _consumer_extract(line, "deleted") == "0"
+        assert _consumer_extract(line, "missing") == "1"
+
+
+# --------------------------------------------------------------------------------------
+# The stale keep-set: a WRONG-BUT-VALID parquet (da#413 review blocker)
+# --------------------------------------------------------------------------------------
+#
+# The fixture has to be able to PRODUCE the bad state, or the guard it tests is inert and
+# we will believe it anyway (`feedback_fixture_makes_guard_assertion_inert`). So the stale
+# keep-set below is not a toy and not an empty file: it is built by the SAME production
+# minting functions a real resolve run uses, re-keyed by the SAME mechanism that re-keys
+# ids between runs.
+#
+# The mechanism is real. `make_discriminated_canonical_id` (da#337 same-name split) mints
+# a DIFFERENT `nar:` id for the same person once the splitter assigns a discriminator, and
+# is byte-identical to `make_canonical_id` when it does not (its documented backward-compat
+# contract). So a run whose splitter discriminated a narrator, followed by a re-resolve
+# whose splitter did not (or chose differently), yields exactly this: a previous canonical
+# parquet whose ids are mostly strangers to the live graph — readable, non-empty, schema-
+# valid, full of real narrators, and catastrophic if handed to a prune.
+#
+# These are real narrators from the corpus, not `nar:foo`.
+_NARRATOR_NAMES = [
+    "ابو هريره",
+    "عايشه",
+    "عبد الله بن عمر",
+    "انس بن مالك",
+    "جابر بن عبد الله",
+    "ابو سعيد الخدري",
+    "عبد الله بن عباس",
+    "عمر بن الخطاب",
+    "علي بن ابي طالب",
+    "محمد بن شهاب الزهري",
+]
+# The previous run's splitter discriminated the first eight (death-year tags, the shape
+# da#337 uses) and left the last two alone.
+_PRIOR_RUN_DISCRIMINATORS = {
+    "ابو هريره": "d.59",
+    "عايشه": "d.58",
+    "عبد الله بن عمر": "d.73",
+    "انس بن مالك": "d.93",
+    "جابر بن عبد الله": "d.78",
+    "ابو سعيد الخدري": "d.74",
+    "عبد الله بن عباس": "d.68",
+    "عمر بن الخطاب": "d.23",
+}
+
+
+def _live_generation_ids() -> list[str]:
+    """The ids the LIVE graph was loaded from — this run's minting, undiscriminated."""
+    return [make_canonical_id(name) for name in _NARRATOR_NAMES]
+
+
+def _stale_generation_ids() -> list[str]:
+    """The PREVIOUS run's canonical ids: eight re-keyed by the splitter, two unchanged."""
+    return [
+        make_discriminated_canonical_id(name, _PRIOR_RUN_DISCRIMINATORS.get(name, ""))
+        for name in _NARRATOR_NAMES
+    ]
+
+
+def _canonical_parquet(curated: Path, ids: list[str], names: list[str] | None = None) -> Path:
+    """A realistic narrators_canonical.parquet — full rows, not bare ids."""
+    names = names or _NARRATOR_NAMES
+    return write_narrators_canonical(
+        curated,
+        [
+            {
+                "canonical_id": cid,
+                "name_ar": name,
+                "name_ar_normalized": name,
+                "mention_count": 100 + i,
+                "source_corpora": ["sunnah"],
+            }
+            for i, (cid, name) in enumerate(zip(ids, names, strict=True))
+        ],
+    )
+
+
+_ORPHANS = ["nar:orphan_a", "nar:orphan_b"]
+
+
+class TestStaleKeepSetIsRefused:
+    """The blocker: nothing bound the keep-set to the graph it prunes (Jean-Claude, #414).
+
+    A stale ``parquet_ref`` is the single most plausible operator error, and it is not
+    self-announcing. It passes every guard this command had, and — the reason it needed
+    a guard in *this* layer rather than a gate in the consumer's — it passes every
+    post-op check too, because they are all derived from the same keep-set they would be
+    validating. They prove the prune obeyed the parquet. None can ask if it was the right
+    parquet.
+    """
+
+    def test_the_stale_keep_set_passes_every_pre_existing_guard(self, curated_dir: Path) -> None:
+        """First: prove the fixture really does reach the bad state.
+
+        If the empty/missing/unreadable guard already caught this, the new guard would be
+        guarding nothing and the tests below would be theatre. It does not: the stale
+        parquet is readable, non-empty, and yields a full ten-id keep-set.
+        """
+        stale = _canonical_parquet(curated_dir, _stale_generation_ids())
+
+        keep_set = read_canonical_ids(stale)  # does NOT raise
+
+        assert len(keep_set) == 10
+        assert all(cid.startswith("nar:") for cid in keep_set)
+        # And it is genuinely a DIFFERENT set from the graph's: eight of its ten ids were
+        # re-keyed by the splitter, so the live graph has never seen them.
+        live = set(_live_generation_ids())
+        assert len(keep_set - live) == 8
+        assert len(keep_set & live) == 2  # the two the previous run left undiscriminated
+
+    def test_without_the_ceiling_the_stale_keep_set_deletes_the_live_generation(
+        self, curated_dir: Path
+    ) -> None:
+        """The red. This is what the code did before the guard, and what it still does if
+        an operator lifts the ceiling — so the damage is measured, not asserted.
+
+        Eight legitimate, edge-bearing, current-generation narrators are DETACH DELETEd
+        because a stale parquet does not list them. Every gate downstream would go green.
+        """
+        stale = _canonical_parquet(curated_dir, _stale_generation_ids())
+        live = _live_generation_ids()
+        client = StatefulFakeNeo4j([*live, *_ORPHANS])
+
+        # max_missing_fraction=1.0 disables the ceiling — i.e. the pre-fix behaviour.
+        result = prune_narrators(client, stale, max_missing_fraction=1.0)
+
+        # 8 legitimate narrators destroyed, plus the 2 real orphans: 10 of 12 gone.
+        assert result.deleted == 10
+        assert len(client.narrators) == 2
+        for name in _NARRATOR_NAMES[:8]:
+            assert make_canonical_id(name) not in client.narrators, (
+                f"{name} is a live, canonical narrator and was deleted by a stale keep-set"
+            )
+        # And here is the whole point: EVERY post-op gate still passes. The graph was not
+        # emptied, no orphan remains, and deleted equals what the dry run predicted. A
+        # workflow reading only these would print "post-op verification PASSED".
+        assert result.graph_total > 0  # gate A: not emptied
+        assert result.orphans == 0  # gate D: no orphan remains
+        assert result.deleted == result.orphans_identified  # gate C: matches prediction
+        # Only `missing` separates this from a correct run. It is 8.
+        assert result.missing == 8
+
+    def test_stale_keep_set_is_refused_before_any_write(self, curated_dir: Path) -> None:
+        """The green. Default ceiling: refused, and NOT ONE ROW DELETED."""
+        stale = _canonical_parquet(curated_dir, _stale_generation_ids())
+        live = _live_generation_ids()
+        client = StatefulFakeNeo4j([*live, *_ORPHANS])
+        before = list(client.narrators)
+
+        with pytest.raises(ForeignCanonicalSetError) as raised:
+            prune_narrators(client, stale)
+
+        # Zero deletion. The graph is exactly as it was — the load-bearing guarantee.
+        assert client.deleted_batches == [], "a refused prune issued a DETACH DELETE"
+        assert client.narrators == before
+        # The refusal reports the signal that produced it, so the operator can act.
+        assert raised.value.missing == 8
+        assert raised.value.canonical_total == 10
+        assert "does not belong to this graph" in str(raised.value)
+
+    def test_refusal_fires_on_a_dry_run_too(self, curated_dir: Path) -> None:
+        # The operator's mandatory dry run is precisely where a wrong parquet should
+        # surface — refusing only on the real run would let the dry run bless it.
+        stale = _canonical_parquet(curated_dir, _stale_generation_ids())
+        client = StatefulFakeNeo4j([*_live_generation_ids(), *_ORPHANS])
+
+        with pytest.raises(ForeignCanonicalSetError):
+            prune_narrators(client, stale, dry_run=True)
+
+        assert client.deleted_batches == []
+
+    def test_the_guard_is_catchable_as_the_cli_catches_it(self, curated_dir: Path) -> None:
+        # _cmd_prune_narrators catches UnusableCanonicalSetError and exits
+        # EMPTY_CANONICAL_SET. If this door were not under that supertype it would escape
+        # to CPython's handler and exit 1 (LOAD_FAILED) — "the load failed", for a command
+        # that deleted nothing and is not a load.
+        stale = _canonical_parquet(curated_dir, _stale_generation_ids())
+        client = StatefulFakeNeo4j(_live_generation_ids())
+
+        with pytest.raises(UnusableCanonicalSetError):
+            prune_narrators(client, stale)
+
+
+class TestMissingIsReportedNotAsserted:
+    """The dual. A guard that refuses every non-zero ``missing`` trades one failure for
+    another: :attr:`REFUSED_ROWS`, :attr:`STOPPED_AT_LIMIT` and a nodes-only load each
+    leave canonical ids legitimately unloaded, and a hard ``missing == 0`` in the CLI
+    would refuse a valid prune after any of them. The CLI reports; deploy#557 owns the
+    refuse-or-proceed policy.
+    """
+
+    def test_correct_keep_set_complete_load_reports_zero(self, curated_dir: Path) -> None:
+        # The da#352 property: for the parquet the graph was loaded from, every canonical
+        # id is present in the graph (129,234 = 71,241 edged + 57,993 zero-degree).
+        correct = _canonical_parquet(curated_dir, _live_generation_ids())
+        client = StatefulFakeNeo4j([*_live_generation_ids(), *_ORPHANS])
+
+        result = prune_narrators(client, correct)
+
+        assert result.missing == 0
+        assert result.deleted == 2  # exactly the orphans
+        assert set(client.narrators) == set(_live_generation_ids())
+
+    def test_correct_keep_set_partial_load_is_reported_and_proceeds(
+        self, curated_dir: Path
+    ) -> None:
+        """A legitimately partial load must still be PRUNABLE, and its ``missing`` visible.
+
+        The graph was loaded from this very parquet, but two canonical narrators never
+        made it in (REFUSED_ROWS). ``missing`` is 2 — non-zero, correctly so — and the
+        prune proceeds: it is well under any plausible magnitude, and the CLI is not the
+        layer that decides whether a partial load may be pruned.
+        """
+        correct = _canonical_parquet(curated_dir, _live_generation_ids())
+        live = _live_generation_ids()
+        loaded = live[:8]  # two canonical narrators refused at load time
+        client = StatefulFakeNeo4j([*loaded, *_ORPHANS])
+
+        result = prune_narrators(client, correct)  # default ceiling: NO refusal
+
+        assert result.missing == 2  # reported…
+        assert result.canonical_ids_seen == 10
+        assert result.deleted == 2  # …and exactly the orphans went
+        assert result.orphans == 0
+        assert set(client.narrators) == set(loaded), "a partial load's narrators were pruned"
+        assert "missing=2" in summary_line(result)
+
+    def test_the_two_classes_are_separated_by_missing(
+        self, curated_dir: Path, tmp_path: Path
+    ) -> None:
+        """The separation, side by side — a number for one class alone proves nothing.
+
+        Same graph, same command, two keep-sets. The four keys deploy#557 already reads
+        cannot tell them apart on the thing that matters; ``missing`` can.
+        """
+        good_dir = tmp_path / "good"
+        good_dir.mkdir()
+        bad_dir = tmp_path / "bad"
+        bad_dir.mkdir()
+        correct = _canonical_parquet(good_dir, _live_generation_ids())
+        stale = _canonical_parquet(bad_dir, _stale_generation_ids())
+        graph = [*_live_generation_ids(), *_ORPHANS]
+
+        good = prune_narrators(StatefulFakeNeo4j(list(graph)), correct, dry_run=True)
+        bad = prune_narrators(
+            StatefulFakeNeo4j(list(graph)), stale, dry_run=True, max_missing_fraction=1.0
+        )
+
+        # Both keep-sets are the same SIZE and both "work". The correct one would delete
+        # the 2 orphans; the stale one would delete 10 nodes — but a workflow cannot know
+        # 10 is wrong without knowing the right answer, which is the whole problem.
+        assert good.canonical_ids_seen == bad.canonical_ids_seen == 10
+        assert good.graph_total == bad.graph_total == 12
+
+        # `missing` separates them cleanly, and it is the ONLY field that does.
+        assert good.missing == 0
+        assert bad.missing == 8
+
+
+class TestMissingCeiling:
+    def test_at_the_ceiling_is_allowed_above_it_refuses(self, curated_dir: Path) -> None:
+        # Strictly-greater: the ceiling is the last ACCEPTABLE value, not the first
+        # rejected one. Pinned because "> vs >=" is exactly the kind of thing a later
+        # refactor flips without noticing.
+        correct = _canonical_parquet(curated_dir, _live_generation_ids())
+        client = StatefulFakeNeo4j(_live_generation_ids()[:5])  # missing = 5 of 10 = 0.5
+
+        at_ceiling = prune_narrators(client, correct, dry_run=True, max_missing_fraction=0.5)
+        assert at_ceiling.missing == 5
+
+        with pytest.raises(ForeignCanonicalSetError):
+            prune_narrators(client, correct, dry_run=True, max_missing_fraction=0.49)
+
+    def test_fraction_of_one_disables_the_ceiling(self, curated_dir: Path) -> None:
+        # The documented escape hatch: even a keep-set with ZERO overlap is allowed
+        # through at 1.0, because the operator asked for it explicitly.
+        stale = _canonical_parquet(curated_dir, _stale_generation_ids())
+        client = StatefulFakeNeo4j([])  # empty graph: missing == canonical
+
+        result = prune_narrators(client, stale, dry_run=True, max_missing_fraction=1.0)
+
+        assert result.missing == 10
+        assert result.graph_total == 0
+
+    def test_empty_graph_is_refused_by_default(self, curated_dir: Path) -> None:
+        # A graph holding none of the keep-set's ids is the most-wrong case there is, and
+        # "the graph is empty" is the correct diagnosis to hand the operator — not a
+        # cheerful no-op that reports zero orphans and zero deletions.
+        correct = _canonical_parquet(curated_dir, _live_generation_ids())
+        client = StatefulFakeNeo4j([])
+
+        with pytest.raises(ForeignCanonicalSetError, match="100.0%"):
+            prune_narrators(client, correct)
+
+    @pytest.mark.parametrize("bad", [-0.1, 1.1])
+    def test_out_of_range_fraction_raises(self, curated_dir: Path, bad: float) -> None:
+        correct = _canonical_parquet(curated_dir, _live_generation_ids())
+        client = StatefulFakeNeo4j(_live_generation_ids())
+        with pytest.raises(ValueError, match=r"\[0.0, 1.0\]"):
+            prune_narrators(client, correct, max_missing_fraction=bad)
 
 
 class TestNoWriteIntoCanonicalDir:
@@ -312,6 +733,7 @@ class TestCliEmitsSummaryLine:
             deleted=3,
             dry_run=dry_run,
             orphans_identified=3,
+            missing=0,
             sample=["nar:orphan"],
         )
 
@@ -326,10 +748,51 @@ class TestCliEmitsSummaryLine:
         monkeypatch.setattr("src.utils.neo4j_client.Neo4jClient", lambda *_a, **_k: _DummyClient())
         monkeypatch.setattr(
             "src.graph.prune.prune_narrators",
-            lambda _client, _p, *, dry_run=False: canned,
+            lambda _client, _p, *, dry_run=False, max_missing_fraction=0.5: canned,
         )
 
         cli._cmd_prune_narrators(canonical=str(path), dry_run=dry_run)
 
         out = capsys.readouterr().out
-        assert "PRUNE_NARRATORS_SUMMARY canonical=1 graph_total=1 orphans=0 deleted=3" in out
+        assert (
+            "PRUNE_NARRATORS_SUMMARY canonical=1 graph_total=1 orphans=0 deleted=3 missing=0" in out
+        )
+
+
+class TestCliRefusesStaleKeepSet:
+    """End to end through the CLI: a stale --canonical exits 12 with the graph untouched.
+
+    The unit tests above prove `prune_narrators` raises. This proves the CLI *catches* the
+    new door — it catches the supertype, so a subclass that escaped would exit 1
+    (LOAD_FAILED, "the load failed") for a command that is not a load and deleted nothing.
+    """
+
+    def test_stale_canonical_exits_empty_canonical_set(
+        self,
+        curated_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import src.cli as cli
+        from src.exit_codes import ExitCode
+
+        stale = _canonical_parquet(curated_dir, _stale_generation_ids())
+        client = StatefulFakeNeo4j([*_live_generation_ids(), *_ORPHANS])
+
+        class _DummyClient:
+            def __enter__(self) -> StatefulFakeNeo4j:
+                return client
+
+            def __exit__(self, *_a: object) -> None:
+                return None
+
+        monkeypatch.setattr(cli, "_check_neo4j", lambda: None)
+        monkeypatch.setattr("src.utils.neo4j_client.Neo4jClient", lambda *_a, **_k: _DummyClient())
+
+        with pytest.raises(SystemExit) as exit_info:
+            cli._cmd_prune_narrators(canonical=str(stale))
+
+        assert exit_info.value.code == ExitCode.EMPTY_CANONICAL_SET
+        assert client.deleted_batches == [], "the CLI deleted rows before refusing"
+        err = capsys.readouterr().err
+        assert "does not belong to this graph" in err


### PR DESCRIPTION
## What

Adds a `prune-narrators` CLI subcommand (symmetric with `load`/`migrate`/`enrich`) that performs the canonical-set **SHRINK**: DETACH DELETE every `Narrator` node whose `id` is absent from `narrators_canonical.parquet`.

`deploy#557` (Aisha Idrissi) builds the destructive-op workflow that invokes this — the subcommand contract below is fixed and this PR confirms it.

## Why this can't be pure cypher (deploy#557 measure-first)

The only correct orphan predicate is `Narrator.id NOT IN narrators_canonical.parquet`, and that set exists only in the parquet:

- **18,518 of the 31,380 orphans HAVE edges** → a zero-degree/"unreferenced" predicate misses them.
- **57,993 zero-degree canonical narrators are legitimate** (owner da#352) → a zero-degree prune wrongly deletes them.

So this reads the keep-set in Python (the same shape `src.graph.migrate` uses), computes the graph complement, and DETACH-DELETEs it in batches. The complement is a **set difference, not a degree test** — that is the whole point.

## The guard (load-bearing, red-first)

`read_canonical_ids` refuses — `EmptyCanonicalSetError`, **ZERO deletion**, before the graph is read or written — when the keep-set is **empty**, **missing**, or **unreadable/malformed**. A bad read must never wipe the graph (da#309/da#361 fail-loud-on-missing-input applied to a destructive op).

## Exit-code semantics for deploy#557 to map

| Condition | Exit | Meaning |
|-----------|------|---------|
| success (real run or dry-run) | `0` | prune ran; graph in intended state |
| canonical set empty / missing / unreadable | `12` `ExitCode.EMPTY_CANONICAL_SET` (**new**) | **refused, graph EXACTLY as before** — fix the parquet and retry |
| Neo4j unreachable (pre-flight) | `8` `ExitCode.DB_UNREACHABLE` | reused via `_check_neo4j()`, like `load`/`migrate` |

**New code 12, not `LOAD_FAILED`:** a prune is not a load (the registry is emphatic about not naming a stage you're not in), and the safe "deleted nothing" state must be **unambiguous** so the workflow can tell "refused, safe to retry" apart from any partial-deletion failure. Named for the concept (empty/missing/unreadable all fold to "no usable keep-set"), per the `REFUSED_ROWS` precedent. `--dry-run` reports the count that would be deleted (plus a sample) and deletes nothing.

## Acceptance (green, red-first + controls)

**Neo4j testcontainer** (`tests/integration/test_prune_narrators.py`) proves on a real graph:
1. an orphan (`id ∉ canonical`) **with an edge** is DETACH DELETEd, edge and all;
2. a **legitimate zero-degree canonical narrator SURVIVES** (the 57,993-class control — the whole reason pure-cypher failed);
3. the guard **REFUSES with zero deletion** on empty and on missing canonical (graph verified unchanged by reading it back);
4. `--dry-run` deletes nothing.

Unit tests (`tests/test_graph/test_prune.py`, MockNeo4jClient) cover the complement computation, guard-touches-nothing (zero client calls), batching, and dry-run. Full suite green; pre-push mypy + pytest passed.

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfSWqUCjCr8d3h8TfoDsqi
