### PR TITLE
fix(deps): bump soupsieve 2.8.3 → 2.8.4 to clear CVE-2026-49476/49477 (#415)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1949,11 +1949,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`Publish to GHCR` has been red on `main` since the merge of #412. The Trivy gate (`severity: CRITICAL,HIGH`, `ignore-unfixed: true`, `exit-code: 1`) fails the `load` image on two HIGH advisories in **soupsieve 2.8.3**, both fixed in **2.8.4**:

| CVE | Severity | Installed | Fixed in |
|---|---|---|---|
| CVE-2026-49476 — memory exhaustion via large comma-separated selector lists | HIGH | 2.8.3 | 2.8.4 |
| CVE-2026-49477 — ReDoS via the selector parser | HIGH | 2.8.3 | 2.8.4 |

`soupsieve` is **transitive** via `beautifulsoup4` (declared `beautifulsoup4>=4.12`). Nothing in our code constrains it — the lock simply predated the 2.8.4 release. The fix is a lock bump, no source change, no new direct dependency:

```
uv lock --upgrade-package soupsieve
```

**Why this is on the critical path:** the `load` image is the artifact the #928 re-run-from-`parse` pipeline consumes. While the publish is red, `stg-latest` is not refreshed and the graph-load side of the reload stays pinned to a stale image.

## The diff

Only the `soupsieve` block moves — version, sdist, and the single wheel. Nothing else in the lock changed, and `uv sync --frozen` (the CI install step) resolves cleanly.

```diff
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
```

## Verification

Trivy 0.72.0, invoked with the publish workflow's own settings (`--severity HIGH,CRITICAL --ignore-unfixed`):

- **Control** — `trivy fs` over the *pre-fix* lock at `origin/main` reproduces **exactly the two soupsieve HIGHs**. The detector demonstrably separates the two classes, so the post-fix zero below is a measurement rather than a silent zero.
- **Treatment** — `trivy fs` over this branch's lock reports **0 findings and exits 0** (the gate uses `exit-code: 1`). It is clean at *all* severities, including unfixed.
- **OS layer** — a remote scan of the digest-pinned base (`python:3.14-slim@sha256:44dd0449…`, debian 13.5) reports **0 fixed HIGH/CRITICAL** *before* the Dockerfile's `apt-get -y upgrade`, which can only improve on it.
- **Full local check-set green** — commit stage (ruff-format, ruff-lint, gitleaks, actionlint, cspell, dockerfile-base-pin, fixture-realism) and push stage (mypy strict, pytest), plus the sync-drift gate and its 50 unit tests. No `--no-verify`.

## What this does NOT prove

`ghcr-publish.yml` triggers on **`push: [main]`, tags, and `workflow_dispatch` only — there is no `pull_request` trigger**, so the `Publish to GHCR` / Trivy check **cannot appear on this PR's status rollup**. A green PR here is therefore not proof the `main` publish goes green; that is only confirmed post-merge (charter / `verify_deployable_merge`). The evidence above is the strongest available pre-merge substitute.

One residual gap: the built image also carries `gcc` + `libpq-dev` (apt-installed on top of the base). Scanning those requires an actual image build, and this box has no Docker daemon, so that delta is unproven. The base and Python layers — where the reported CVEs live — are both proven clean.

## Not in scope

The base-image OS-package CVE class on the sibling ingest-platform image (buildx cache defeating the in-image `apt-get upgrade`) is a **separate defect**, tracked as noorinalabs-main#947. This is the Python-dependency half and it stands alone.

Closes #415
