### PR TITLE
fix(name_quality): close the three name-quality residue classes (da#314, da#315, da#316)

### DIFF
--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -1122,9 +1122,19 @@ def _truncate_at_isnad_boundary(tokens: list[str]) -> list[str] | None:
     lineage) via ``وان`` → ``ان``, and ``"فان"``/``"فاذا"`` likewise. The definite
     relative pronouns have no such collision — no Arabic ism is ``والذي``/``فالتي`` —
     which is what makes them, and only them, safe to fold.
+
+    The fold is applied at index 0 ONLY. This function has *dual* semantics — a
+    boundary LEADING the span drops it, a boundary at index > 0 *truncates* and keeps
+    the head — and the oath is a matn SIGNAL, not a name TERMINATOR. In the corpus the
+    oath is overwhelmingly mid-matn ("تعاهدوا هذا القران فوالذي نفس محمد بيده…");
+    folding it at i > 0 would make it a truncation point and hand the matn head back
+    AS A NARRATOR NAME, minting 52 new zero-degree matn nodes ("دعوني" = "leave me",
+    "كلا" = "nay", "قول الله") — exactly the class da#317 exists to remove. Restricted
+    to the leading position, a mid-matn oath instead leaves the span whole and the
+    matn-sentence gate (step 10) drops it as the matn body it is.
     """
     for i, raw_tok in enumerate(tokens):
-        tok = raw_tok if raw_tok in _ISNAD_BOUNDARY else _fold_proclitics(raw_tok)
+        tok = raw_tok if (raw_tok in _ISNAD_BOUNDARY or i > 0) else _fold_proclitics(raw_tok)
         if tok in _ISNAD_BOUNDARY or _is_ask_verb(tok):
             # Nisba-transition ثم (da#308): "…الليثي ثم الجندعي" ("al-Laythī then
             # al-Jundaʿī") is a real tribal-affiliation nisba tail, not a temporal
@@ -1330,8 +1340,21 @@ def _is_matn_sentence(tokens: list[str], kept_text: str, was_truncated: bool) ->
     #      in the span, co-occurring with at least one partitive or matn particle, is a
     #      provenance/matn fragment, never a name. Runs AFTER the nasab guard, so a
     #      genuine lineage is already spared before this can see it.
+    #      The particle disjunct EXCLUDES the apposition connectors (Sofia Cardoso, PR
+    #      review). "أم" (umm — the commonest female kunya connector) normalizes to
+    #      "ام", which is HOMOGRAPHIC with the disjunctive particle "أم" ("or") and is
+    #      therefore in _MATN_PARTICLES; it is the only token in this module that is
+    #      both. Without the exclusion, any real narrator shaped "أم X <role> رسول الله"
+    #      — where the role noun is not already an apposition connector — reads as a
+    #      Prophet reference PLUS a particle and is deleted. That is not hypothetical:
+    #      it dropped "أم كلثوم بنت سيد البشر رسول الله" (Umm Kulthum bint Muhammad, the
+    #      Prophet's DAUGHTER) and "أم أيمن حاضنة رسول الله" (Umm Ayman, his nurse and a
+    #      transmitter) — both bio-promoted rows at mention_count 0, which is precisely
+    #      why a mention-weighted sweep could not see them. The mubham collectives this
+    #      rule targets are untouched: "بعض" is not an apposition connector, so
+    #      "بعض اصحاب النبي" / "بعض ازواج النبي" still drop.
     if any(_prophet_ref_len(bare, i) > 0 for i in range(n)) and any(
-        _is_partitive(t) or _is_matn_particle(t) for t in bare
+        _is_partitive(t) or (_is_matn_particle(t) and t not in _APPOSITION_CONNECTORS) for t in bare
     ):
         return True
 

--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -149,7 +149,7 @@ from __future__ import annotations
 
 import re
 
-from src.utils.arabic import normalize_arabic
+from src.utils.arabic import normalize_arabic, strip_format_marks
 
 __all__ = [
     "clean_narrator_name",
@@ -183,9 +183,32 @@ _WAW_CONJUNCTION = normalize_arabic("و")
 # :func:`_is_isnad_residue_token`) so ordinary spans are untouched (da#311 round-4b
 # — Kavitha's review caught attached-waw "وعنه"/"وباسناده", the passive verb "روي",
 # the particle "قد", and bare mubham collectives slipping the round-4 digit-strip).
+# da#315 adds the PREPOSITION+PRONOUN back-reference forms — the classical isnad
+# shorthand a compiler uses to chain a narration onto the preceding one instead of
+# repeating it: "وبه" / "به" ("and by it / by it [same chain]"), "نحوه" ("the like of
+# it"), "مثله" ("similar to it"), "منه", "فيه". The de-waw fold below already reached
+# "وعنه" → "عنه", but "وبه" folds to "به" — which was NOT in this set, so the whole
+# class survived the all-residue floor (13 rows / 18 mentions on the run-5 scrubbed
+# set). Every one is a preposition bound to a resumptive pronoun; none is, or contains,
+# a proper ism, and rule 5b only drops a span when EVERY token is residue, so a real
+# multi-token name is untouched.
 _ISNAD_FORMULA_FRAGMENTS = frozenset(
     normalize_arabic(w)
-    for w in ("باسناده", "بإسناده", "بالاسناد", "اسناده", "عنه", "روي", "روى", "قد")
+    for w in (
+        "باسناده",
+        "بإسناده",
+        "بالاسناد",
+        "اسناده",
+        "عنه",
+        "روي",
+        "روى",
+        "قد",
+        "به",
+        "فيه",
+        "منه",
+        "نحوه",
+        "مثله",
+    )
 )
 
 
@@ -592,6 +615,39 @@ _ISNAD_BOUNDARY = frozenset(
     }
 )
 
+# Boundary tokens into which leading proclitics may be folded (da#314). The definite
+# relative pronouns ONLY: "والذي" ("and he who") opens the oath formula "والذي نفس
+# محمد بيده" and is never a name. Kept as a narrow allowlist rather than folding
+# across all of _ISNAD_BOUNDARY, because folding into that set's SHORT function words
+# (ان/اذا/عن/هو/ثم) collides with real name material — "وان بن سالم" (mc-251, a بن
+# lineage) would false-drop via وان → ان. See :func:`_truncate_at_isnad_boundary`.
+_PROCLITIC_FOLDABLE_BOUNDARY = frozenset({"الذي", "التي", "الذين"})
+
+# Proclitics stripped (iteratively, longest-chain-first) when folding into the set
+# above. The oath formula stacks them — "فوالذي نفس محمد بيده" (ف+و), "فبالذي ارسلك
+# الله" (ف+ب) — so a single-proclitic fold leaves the commonest forms behind. Safe
+# ONLY because the fold target is the relative-pronoun allowlist: no Arabic ism is
+# "بالذي" / "فوالذي", so no real name can be reached by peeling these.
+_BOUNDARY_PROCLITICS = ("و", "ف", "ب", "ل", "ك")
+
+
+def _fold_proclitics(token: str) -> str:
+    """Peel leading proclitics while the remainder is a foldable boundary (da#314).
+
+    ``"فوالذي"`` → ``"والذي"`` → ``"الذي"``. Returns *token* unchanged when no chain
+    of proclitics reaches :data:`_PROCLITIC_FOLDABLE_BOUNDARY`, so a real name is
+    never partially peeled (the peel is only *kept* if it lands on the allowlist).
+    """
+    seen = token
+    for _ in range(len(_BOUNDARY_PROCLITICS)):
+        if seen in _PROCLITIC_FOLDABLE_BOUNDARY:
+            return seen
+        if seen[:1] not in _BOUNDARY_PROCLITICS or len(seen) < 2:
+            break
+        seen = seen[1:]
+    return seen if seen in _PROCLITIC_FOLDABLE_BOUNDARY else token
+
+
 # Matn-density backstop: a span whose leading tokens form a real name but whose tail
 # is matn NOT anchored by an _ISNAD_BOUNDARY verb (e.g. a bare-preposition run) is
 # still a sentence. ≥2 whole-token matn/particle words → drop. A real name carries
@@ -632,7 +688,18 @@ _COMPOUND_TRAILING_MARKERS = frozenset({"جميعا", "قالوا"})
 # ؟ is included (da#308) so a stray trailing question mark ("الاوزاعي الدمشقي؟")
 # is stripped off the token like any other edge mark and does not ride into the
 # clustering key; matn ؟ mid-span is still detected via the raw kept-text scan.
-_EDGE_PUNCT = " \t\r\n,،.;؛:؟-_\"'«»()[]"
+#
+# Bidi / zero-width FORMAT MARKS are included (da#316). The raw source interleaves
+# U+200F RIGHT-TO-LEFT MARK *between* trailing punctuation characters — the real
+# stored span is ``'قتاده،‏.‏'``, not ``'قتاده،.'``. ``str.strip`` halts at
+# the first character outside its set, so a trailing RLM standing between the marks
+# ends the peel before the ``.`` and ``،`` are reached and the name keeps its cruft.
+# NOTE this only matters on RAW / voweled text: ``normalize_arabic`` already removes
+# these marks (:func:`~src.utils.arabic.strip_format_marks`, da#271), so the
+# *normalized* path never sees one. It is the DISPLAY path — which strips edge punct
+# from the un-normalized voweled token to keep its diacritics — that needs them here.
+_FORMAT_MARK_CHARS = "​‌‍‎‏‪‫‬‭‮﻿"
+_EDGE_PUNCT = " \t\r\n,،.;؛:؟-_\"'«»()[]" + _FORMAT_MARK_CHARS
 
 # --- Sentence / matn-body drop-gate (da#308) -----------------------------------
 # Nasab (lineage) connectors — the PRECISION GUARD. A string dense in these is a
@@ -693,6 +760,12 @@ _MATN_OPENERS = frozenset(
         "تزوج",  # "he married" ("تزوج النبي ميمونه" — Prophet-marriage matn); never
         # a name (the noun زوج is handled as an apposition connector separately).
         "رءيا",  # "[I] saw" (رأيا; a رايت variant); a matn eyewitness opener.
+        # Oath / adjuration verb (da#314) — "انشدك بالله" ("I adjure you BY GOD …"),
+        # the matn interrogation formula ("فانشدك بالله هل تعلم" = "I adjure you by
+        # God, do you know …"). The ف-prefixed form folds via the step-2 opener check.
+        # A verb of address, never a name component.
+        "انشدك",
+        "نشدتك",
     }
 )
 
@@ -810,6 +883,21 @@ _THEOPHORIC_HEADS = frozenset(
         "ذبيح",  # sacrifice of
     }
 )
+
+
+# The partitive / ablative ``من`` ("from", "of", "one who"), optionally carrying a
+# ك/و/ف/ل/ب proclitic (``كمن`` "like one who", ``ومن``, ``فمن``). It is deliberately
+# NOT a member of :data:`_MATN_PARTICLES` — guard 5 keys the mubham collective on the
+# bare partitive and folding it in there would entangle the two — so the
+# Prophet-provenance rule (da#314) tests for it through this helper instead.
+_PARTITIVE = "من"
+
+
+def _is_partitive(token: str) -> bool:
+    """True when *token* is the partitive ``من``, bare or with a single proclitic (da#314)."""
+    if token == _PARTITIVE:
+        return True
+    return token[:1] in ("و", "ف", "ك", "ل", "ب") and token[1:] == _PARTITIVE
 
 
 def _is_matn_particle(token: str) -> bool:
@@ -970,10 +1058,22 @@ def strip_markup(name: str | None) -> str:
     :func:`clean_narrator_name`; this keeps the two in lock-step. Only colon spans
     whose tail begins with an English leader are cut — Arabic voweled names and
     ordinary names (no such colon) are returned unchanged.
+
+    Bidi / zero-width format marks are stripped FIRST (da#316). This is the raw,
+    un-normalized entry point — the only path that never runs through
+    ``normalize_arabic`` (which would remove them) because it must preserve the
+    diacritics. The marks appear *interleaved* with punctuation (``'قتاده،‏.‏'``)
+    and *interior* to the span (``'…تعالى‏:‏ ‏(‏لقد'``), so an edge-strip alone
+    cannot clear them; removing them here makes the subsequent edge-punct strip —
+    and the token alignment in :func:`clean_narrator_name_display` — behave exactly
+    as it does on normalized text. Diacritics are untouched
+    (:func:`~src.utils.arabic.strip_format_marks` removes only bidi/zero-width
+    controls), so the display name keeps its vowels.
     """
     if not name:
         return ""
-    cleaned = _MARKUP_RE.sub(" ", name).replace("<", " ").replace(">", " ")
+    cleaned = strip_format_marks(name)
+    cleaned = _MARKUP_RE.sub(" ", cleaned).replace("<", " ").replace(">", " ")
     cleaned = _truncate_colon_prose(" ".join(cleaned.split()))
     return cleaned.strip(_EDGE_PUNCT).strip()
 
@@ -1009,8 +1109,22 @@ def _truncate_at_isnad_boundary(tokens: list[str]) -> list[str] | None:
     ``None`` when the boundary *leads* the span (``"كان علي …"``, ``"قالوا"``) —
     the real narrator sits after an elided-grammar verb and cannot be recovered
     here. When no boundary token is present the tokens are returned unchanged.
+
+    Leading proclitics are folded before matching (:func:`_fold_proclitics`), but ONLY
+    into the definite RELATIVE PRONOUNS (:data:`_PROCLITIC_FOLDABLE_BOUNDARY`) — so the
+    oath formula ``"والذي نفس محمد بيده"`` ("by Him in whose hand is Muhammad's soul",
+    da#314) leads with ``والذي`` → folds to the boundary ``الذي`` → drops. The formula
+    stacks proclitics in the corpus (``فوالذي``, ``فبالذي``), so the fold is iterative.
+
+    The fold is deliberately NOT applied to the whole boundary set. Folding it into
+    the SHORT function words there (``ان``, ``اذا``, ``عن``, ``هو``, ``ثم``) collides
+    with real name material: it false-drops ``"وان بن سالم"`` (mc-251 — a ``بن``
+    lineage) via ``وان`` → ``ان``, and ``"فان"``/``"فاذا"`` likewise. The definite
+    relative pronouns have no such collision — no Arabic ism is ``والذي``/``فالتي`` —
+    which is what makes them, and only them, safe to fold.
     """
-    for i, tok in enumerate(tokens):
+    for i, raw_tok in enumerate(tokens):
+        tok = raw_tok if raw_tok in _ISNAD_BOUNDARY else _fold_proclitics(raw_tok)
         if tok in _ISNAD_BOUNDARY or _is_ask_verb(tok):
             # Nisba-transition ثم (da#308): "…الليثي ثم الجندعي" ("al-Laythī then
             # al-Jundaʿī") is a real tribal-affiliation nisba tail, not a temporal
@@ -1197,6 +1311,29 @@ def _is_matn_sentence(tokens: list[str], kept_text: str, was_truncated: bool) ->
     nasab = sum(1 for t in bare if t in _NASAB_CONNECTORS)
     if nasab >= 2 or nasab / n >= _NASAB_SPARE_DENSITY:
         return False
+
+    # (2d) Prophet-reference PROVENANCE (da#314): a narration-provenance tail — "…
+    #      من رسول الله" ("… FROM the Messenger of Allah"), "هذا من رسول الله", "كمن
+    #      زار رسول الله" — kept as a canonical "narrator" (mc-55 "ه من رسول الله",
+    #      mc-38 bare "من رسول الله"). The existing Prophet detectors both miss it:
+    #      step 6b's :func:`_is_prophet_reference` is LEADER-anchored (here the title
+    #      sits in the TAIL, behind a preposition), and signal (2p) above is gated on
+    #      ``was_truncated`` (these spans carry no isnad/matn verb, so nothing ever
+    #      truncated and they are never re-scrutinized).
+    #
+    #      DISCRIMINATOR — what may legitimately precede "رسول الله" in a real name is
+    #      an ism, and nothing else: "محمد رسول الله" (Muhammad, the Messenger of Allah
+    #      — a REAL narrator, the muhaddithat fixture) carries ZERO matn particles and
+    #      no partitive, so it is kept. A provenance fragment, by contrast, always
+    #      carries the very preposition/particle that makes it provenance ("من" — the
+    #      ablative — or a demonstrative "هذا"/"ذلك"). So: a Prophet reference ANYWHERE
+    #      in the span, co-occurring with at least one partitive or matn particle, is a
+    #      provenance/matn fragment, never a name. Runs AFTER the nasab guard, so a
+    #      genuine lineage is already spared before this can see it.
+    if any(_prophet_ref_len(bare, i) > 0 for i in range(n)) and any(
+        _is_partitive(t) or _is_matn_particle(t) for t in bare
+    ):
+        return True
 
     # (2a) Divine-name / Qur'anic-verse signature (da#317): the bare divine name
     #      الله occurring TWICE OR MORE is a verse / oath / matn signature, never a
@@ -1484,7 +1621,14 @@ def clean_narrator_name(name_normalized: str | None) -> str | None:
     #     ال-token was itself truncated ("اتموا الصف الاول ثم") — a lone trailing
     #     ثم/عن/ان/… is never a name component, so pop it. This makes the recovery a
     #     fixed point (clean(clean(x)) == clean(x)) in a single pass.
-    while tokens and tokens[-1] in _ISNAD_BOUNDARY:
+    #
+    #     A trailing bare waw CONJUNCTION is popped the same way (da#316): the source
+    #     stores a dangling co-narrator join whose second member was never captured
+    #     ("مالك،‏.‏ و" — Malik, followed by an "and" that leads nowhere). A waw with
+    #     no following member conjoins nothing and is never a name component. Only the
+    #     TRAILING position is touched, so a MEDIAL waw — the class-6 compound join
+    #     "X و Y" that :func:`split_compound_narrators` must still see — is untouched.
+    while tokens and (tokens[-1] in _ISNAD_BOUNDARY or tokens[-1] == _WAW_CONJUNCTION):
         tokens.pop()
         was_truncated = True
     if not tokens:

--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -900,6 +900,47 @@ def _is_partitive(token: str) -> bool:
     return token[:1] in ("و", "ف", "ك", "ل", "ب") and token[1:] == _PARTITIVE
 
 
+# Collective nouns that head an ANONYMOUS group referred to the Prophet — "the
+# companions of…", "the wives of…". With a mubham quantifier in front ("بعض اصحاب
+# النبي" = "SOME OF the companions of the Prophet") the span names no individual, so
+# it is residue for the provenance rule below. Closed set, and never an ism.
+_PROPHET_COLLECTIVE_NOUNS = frozenset({"اصحاب", "ازواج", "نساء", "اهل", "ال", "امه"})
+
+# Bare pronouns left behind by a mis-parse ("ه من رسول الله" mc-55, "ها من رسول الله"
+# mc-7, "هن من رسول الله" mc-5). A pronoun is never an ism, so these carry no naming
+# content. The one-character check below already caught the bare "ه"; this completes the
+# closed set rather than leaving the lexicon to depend on token LENGTH, which is
+# arbitrary — "ه" and "ها" are the same class of fragment.
+_BARE_PRONOUNS = frozenset({"ه", "ها", "هم", "هن", "هما", "هي", "هو", "انا", "انت"})
+
+
+def _is_prophet_ref_component(token: str) -> bool:
+    """True when *token* is part of a Prophet reference itself (``رسول``/``النبي``/``الله``)."""
+    return token in _PROPHET_TITLE_SOLE or token in _PROPHET_TITLE_LEADERS or token == "الله"
+
+
+def _is_provenance_residue(token: str) -> bool:
+    """True when *token* carries no naming content — function word or anonymous collective.
+
+    The membership test for the da#314 provenance rule's all-residue scoping. A token
+    is residue when it is the partitive ``من`` (with proclitics), a bare matn particle,
+    a mubham collective quantifier (``بعض``, ``رجل``), a collective noun heading an
+    anonymous group (``اصحاب``, ``ازواج``), or a stray sub-token left by a mis-parse
+    (a one-letter fragment such as ``ه``/``ها``, which no Arabic ism can be).
+
+    The apposition connectors are EXCLUDED from the matn-particle arm (Sofia Cardoso):
+    ``أم`` (*umm*) normalizes to ``ام``, homographic with the disjunctive particle
+    ``أم`` ("or"), and treating it as residue is what deleted Umm Kulthum bint Muhammad.
+    Redundant under the all-token scoping — her span carries substantive tokens too —
+    but kept as the explicit, verified guard against the homograph.
+    """
+    if _is_partitive(token) or token in _MUBHAM_LEADERS or token in _PROPHET_COLLECTIVE_NOUNS:
+        return True
+    if len(token) == 1 or token in _BARE_PRONOUNS:
+        return True
+    return _is_matn_particle(token) and token not in _APPOSITION_CONNECTORS
+
+
 def _is_matn_particle(token: str) -> bool:
     """True when *token* (normalized) is a bare matn function word (da#317).
 
@@ -1353,8 +1394,25 @@ def _is_matn_sentence(tokens: list[str], kept_text: str, was_truncated: bool) ->
     #      why a mention-weighted sweep could not see them. The mubham collectives this
     #      rule targets are untouched: "بعض" is not an apposition connector, so
     #      "بعض اصحاب النبي" / "بعض ازواج النبي" still drop.
-    if any(_prophet_ref_len(bare, i) > 0 for i in range(n)) and any(
-        _is_partitive(t) or (_is_matn_particle(t) and t not in _APPOSITION_CONNECTORS) for t in bare
+    #      SCOPING (second review round): the rule fires only when EVERY token is
+    #      function-word residue or part of the Prophet reference itself — the same
+    #      all-residue shape as rule 5b, which is the only shape proven safe here. A
+    #      span carrying ANY substantive token (an ism, a nisba, a common noun) is
+    #      structurally out of reach, which is what a "does it contain a real name?"
+    #      test needs to be, absent a name lexicon.
+    #
+    #      This is not belt-and-braces; it is load-bearing. A rijal BIOGRAPHY entry
+    #      names a real narrator and then describes him — and a companion's biography
+    #      mentions the Prophet *by nature*: "شهد النبي في حجة الوداع" ("he witnessed
+    #      the Prophet at the Farewell Pilgrimage"), "وفد على رسول الله" ("he came as a
+    #      delegate to the Messenger of Allah"). Those carry a Prophet reference AND a
+    #      preposition, so the earlier any()-form of this rule deleted 44 real
+    #      bio-promoted narrators — among them ابو بكر الصديق … خليفه رسول الله (Abu
+    #      Bakr al-Siddiq, the first Caliph), الطيب ولد رسول الله (the Prophet's son)
+    #      and ذواليدين (Dhu al-Yadayn). All are mention_count 0, so — exactly like Umm
+    #      Kulthum — a mention-weighted sweep could not see them.
+    if any(_prophet_ref_len(bare, i) > 0 for i in range(n)) and all(
+        _is_prophet_ref_component(t) or _is_provenance_residue(t) for t in bare
     ):
         return True
 
@@ -1651,9 +1709,22 @@ def clean_narrator_name(name_normalized: str | None) -> str | None:
     #     no following member conjoins nothing and is never a name component. Only the
     #     TRAILING position is touched, so a MEDIAL waw — the class-6 compound join
     #     "X و Y" that :func:`split_compound_narrators` must still see — is untouched.
-    while tokens and (tokens[-1] in _ISNAD_BOUNDARY or tokens[-1] == _WAW_CONJUNCTION):
+    while tokens and tokens[-1] in _ISNAD_BOUNDARY:
         tokens.pop()
         was_truncated = True
+    #     The dangling waw is popped WITHOUT setting was_truncated. That flag means "a
+    #     tail was cut off, so this is a RECOVERED fragment and needs stricter scrutiny"
+    #     — and it gates signal (2p), which drops any span carrying a bare Prophet
+    #     reference. A trailing conjunction is an affix, not name material: popping it
+    #     removes nothing the source asserted, so it must not escalate scrutiny. Setting
+    #     it here deleted "ابو بكر الصديق … خليفه رسول الله و" — ABU BAKR AL-SIDDIQ, whose
+    #     bio ends in a dangling waw — because the pop flipped was_truncated and (2p)
+    #     then fired on the "رسول الله" in "خليفه رسول الله" ("Successor of the Messenger
+    #     of Allah"). Without the flag he is spared by the nasab guard (ابو/بن/ابي), as he
+    #     should be. Same reasoning as :func:`cleaner_removed_content`: an affix is not a
+    #     tail.
+    while tokens and tokens[-1] == _WAW_CONJUNCTION:
+        tokens.pop()
     if not tokens:
         return None
 

--- a/tests/test_parse/test_name_quality.py
+++ b/tests/test_parse/test_name_quality.py
@@ -1151,3 +1151,181 @@ class TestMatnSentenceVerseGate:
     )
     def test_single_particle_and_conjunction_names_preserved(self, name: str) -> None:
         assert clean_narrator_name(normalize_arabic(name)) is not None
+
+
+class TestRlmShieldedEdgePunct:
+    """da#316 — U+200F (RLM) interleaved with trailing punctuation on the RAW field.
+
+    MECHANISM (verified at HEAD; the issue's stated one is STALE). The issue blamed
+    ``normalize_arabic`` for not stripping U+200F and ``clean_narrator_name``'s
+    ``token.strip(_EDGE_PUNCT)`` for being shielded by it. Both are FALSE at HEAD:
+    ``normalize_arabic`` HAS stripped bidi/zero-width marks since da#271
+    (``strip_format_marks``), so the NORMALIZED path is already clean — see
+    :meth:`test_normalized_path_was_never_the_defect`.
+
+    The live defect is in the **display** path. ``strip_markup`` /
+    ``clean_narrator_name_display`` strip ``_EDGE_PUNCT`` from the *voweled* token —
+    a string ``normalize_arabic`` deliberately never touches (it must keep the
+    diacritics) — and ``_EDGE_PUNCT`` carried no format marks, so a trailing RLM
+    standing BETWEEN the marks halted the peel before ``.`` and ``،`` were reached.
+    ``name_ar`` is the load-bearing field the graph loader keys the node ``name`` on,
+    so the cruft rode all the way into the graph.
+
+    Fixtures are verbatim rows from ``data/curated.run5-scrubbed/narrators_canonical
+    .parquet`` (``name_ar``), U+200F written as an explicit escape so the placement
+    cannot be mangled by an editor.
+    """
+
+    # Real corpus rows: ism + "،" + RLM + "." + RLM.
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("قتاده،‏.‏", "قتاده"),  # mc-6
+            ("يونس،‏.‏", "يونس"),  # mc-5
+            ("الزهري،‏.‏", "الزهري"),  # mc-2
+        ],
+    )
+    def test_rlm_shielded_punct_peeled_from_display(self, raw: str, expected: str) -> None:
+        assert clean_narrator_name_display(raw) == expected
+
+    def test_strip_markup_peels_rlm_shielded_punct(self) -> None:
+        assert strip_markup("قتاده،‏.‏") == "قتاده"
+
+    # The dangling-waw variant: the source stores a co-narrator join whose second
+    # member was never captured ("مالك،‏.‏ و" — mc-4).
+    def test_dangling_waw_after_rlm_punct_is_popped(self) -> None:
+        assert clean_narrator_name_display("مالك،‏.‏ و") == "مالك"
+
+    # Format marks appear INTERIOR to a span too, not only at token edges, so an
+    # edge-strip alone cannot clear them — strip_markup removes them wholesale.
+    def test_interior_format_marks_removed(self) -> None:
+        assert "‏" not in strip_markup("جابر بن عبد الله في قوله تعالى‏:‏")
+
+    # --- The issue's STATED mechanism, pinned as false: the normalized path was
+    # already correct at HEAD (da#271). This test passes BEFORE the fix too; it
+    # exists so a future reader does not "re-fix" normalize_arabic/_EDGE_PUNCT in
+    # the normalized path and think that closed da#316. ---
+    def test_normalized_path_was_never_the_defect(self) -> None:
+        assert clean_narrator_name(normalize_arabic("قتاده،‏.‏")) == "قتاده"
+
+    # --- PRECISION: the cleaner must be a FIXED POINT on the recovered display
+    # name (no cruft left to re-peel on a second pass). ---
+    @pytest.mark.parametrize("raw", ["قتاده،‏.‏", "مالك،‏.‏ و"])
+    def test_display_clean_is_idempotent(self, raw: str) -> None:
+        once = clean_narrator_name_display(raw)
+        assert once is not None
+        assert clean_narrator_name_display(once) == once
+
+    # --- PRECISION: a clean voweled name keeps its diacritics (strip_format_marks
+    # removes bidi/zero-width controls ONLY — it must not denature the display). ---
+    def test_diacritics_preserved(self) -> None:
+        assert clean_narrator_name_display("أَبُو هُرَيْرَة") == "أَبُو هُرَيْرَة"
+
+
+class TestBiPronounBackreference:
+    """da#315 — the bi+pronoun isnad back-reference (``وبه`` / ``به``).
+
+    MECHANISM (verified at HEAD; the issue is HALF STALE). The issue reported two
+    classes — ``ما`` (30 rows / 195 mentions) and ``وبه`` (2 rows / 18 mentions) —
+    and proposed adding ``ما`` to the particle drop vocab. **``ما`` was already fixed**
+    by da#317's all-function-word rule (2c), which landed after the issue was filed;
+    only the ``وبه`` class is live. Measured at HEAD the surviving class is 13 rows /
+    18 mentions, all ``وبه``/``به``.
+
+    ``_is_isnad_residue_token`` already de-waws (``وعنه`` → ``عنه``), but ``وبه``
+    de-waws to ``به``, which was not in ``_ISNAD_FORMULA_FRAGMENTS`` — so the
+    all-residue floor (rule 5b) never fired on it.
+    """
+
+    # Verbatim corpus rows (name_ar == 'وبه', 13 rows on the run-5 scrubbed set).
+    @pytest.mark.parametrize("residue", ["وبه", "به", "فيه", "منه", "نحوه", "مثله"])
+    def test_bi_pronoun_backreference_dropped(self, residue: str) -> None:
+        assert clean_narrator_name(normalize_arabic(residue)) is None
+
+    # --- The issue's OTHER half, pinned as already-fixed: ``ما`` drops at HEAD via
+    # da#317 rule (2c). Green before the fix; recorded so the stale half is not
+    # "re-fixed" and so a regression in da#317 surfaces here. ---
+    def test_ma_particle_already_dropped_by_da317(self) -> None:
+        assert clean_narrator_name(normalize_arabic("ما")) is None
+
+    # --- PRECISION DUAL: the de-waw fold must not eat a real waw-initial name, and
+    # rule 5b only drops when EVERY token is residue, so a real multi-token name
+    # containing one of these as a component survives. ---
+    @pytest.mark.parametrize(
+        "name",
+        ["وهب", "وكيع", "وهب بن منبه", "وكيع بن الجراح", "به بن سالم"],
+    )
+    def test_real_names_not_eaten_by_residue_floor(self, name: str) -> None:
+        assert clean_narrator_name(normalize_arabic(name)) is not None
+
+
+class TestMatnProvenanceAndOath:
+    """da#314 — narration-provenance tails (``… من رسول الله``) and oath formulae.
+
+    MECHANISM (verified at HEAD). Both existing Prophet-reference detectors miss this
+    class: ``_is_prophet_reference`` (step 6b) is LEADER-anchored, but here the title
+    sits in the TAIL behind a preposition; and signal (2p) of ``_is_matn_sentence`` is
+    gated on ``was_truncated``, but these spans carry no isnad/matn verb, so nothing
+    ever truncates and they are never re-scrutinized.
+
+    The discriminator against a REAL name+title is the preposition: ``محمد رسول الله``
+    (Muhammad, the Messenger of Allah — a real narrator, the muhaddithat fixture)
+    carries ZERO matn particles, while a provenance fragment always carries the very
+    preposition that makes it provenance (``من`` / ``كمن`` / a demonstrative).
+
+    The oath formula (``والذي نفس محمد بيده``) escaped separately: ``الذي`` IS a
+    boundary token, but the corpus stacks proclitics onto it (``والذي``, ``فوالذي``,
+    ``فبالذي``) and the boundary check matched only the bare form.
+
+    Fixtures are verbatim ``name_ar`` rows from the run-5 scrubbed canonical set.
+    """
+
+    @pytest.mark.parametrize(
+        "provenance",
+        [
+            "من رسول الله",  # mc-38
+            "ه من رسول الله",  # mc-55
+            "هذا من رسول الله",  # mc-18
+            "كمن زار رسول الله",  # mc-8
+            "ه من النبي",  # mc-7
+        ],
+    )
+    def test_prophet_provenance_dropped(self, provenance: str) -> None:
+        assert clean_narrator_name(normalize_arabic(provenance)) is None
+
+    @pytest.mark.parametrize(
+        "oath",
+        [
+            "والذي نفس محمد بيده",  # mc-7
+            "فوالذي نفس محمد بيده اني لارجو",  # mc-2, stacked ف+و proclitics
+            "فبالذي ارسلك الله امرك بهذا",  # mc-11, stacked ف+ب proclitics
+            "فانشدك بالله هل تعلم",  # mc-3, adjuration verb
+        ],
+    )
+    def test_oath_formula_dropped(self, oath: str) -> None:
+        assert clean_narrator_name(normalize_arabic(oath)) is None
+
+    # --- PRECISION DUAL #1 (load-bearing): the Prophet's own name+title is a REAL
+    # narrator (muhaddithat `variousnarrators.csv` row 1) and carries zero particles,
+    # so the provenance rule must NOT fire on it. ---
+    def test_prophet_own_name_and_title_preserved(self) -> None:
+        assert clean_narrator_name(normalize_arabic("محمد رسول الله")) == normalize_arabic(
+            "محمد رسول الله"
+        )
+
+    # --- PRECISION DUAL #2: the proclitic fold is restricted to the definite relative
+    # pronouns precisely because folding it across the whole boundary set false-drops
+    # real name material — "وان بن سالم" (mc-251, a بن lineage) would go via وان → ان.
+    # This test is the guard on that restriction. ---
+    @pytest.mark.parametrize("name", ["وان بن سالم", "فان", "فاذا"])
+    def test_short_boundary_words_not_proclitic_folded(self, name: str) -> None:
+        assert clean_narrator_name(normalize_arabic(name)) is not None
+
+    # --- PRECISION DUAL #3: a real nasab/kunya carrying a Prophet-adjacent component
+    # or a single particle is untouched. ---
+    @pytest.mark.parametrize(
+        "name",
+        ["عاءشه بنت سعد", "عبد الله بن عبد الله القرشي الاموي", "ابو هريره", "زكريا"],
+    )
+    def test_real_lineages_preserved(self, name: str) -> None:
+        assert clean_narrator_name(normalize_arabic(name)) is not None

--- a/tests/test_parse/test_name_quality.py
+++ b/tests/test_parse/test_name_quality.py
@@ -1329,3 +1329,90 @@ class TestMatnProvenanceAndOath:
     )
     def test_real_lineages_preserved(self, name: str) -> None:
         assert clean_narrator_name(normalize_arabic(name)) is not None
+
+
+class TestScrubDoesNotDeleteRealNarrators:
+    """The reverse direction of the drop-gate diff (Sofia Cardoso, PR #423 review).
+
+    A drop-gate change has TWO failure directions, and a one-directional A/B — "which
+    rows does this newly drop?" — is structurally blind to both of the ones that matter:
+
+    1. it can **delete a real narrator**, and
+    2. it can **stop dropping** a matn span, resurrecting pollution as a narrator node.
+
+    Both happened. These tests pin both directions with verbatim corpus rows.
+    """
+
+    # === DIRECTION 1: deletion of a real transmitter ===
+    #
+    # "أم" (umm — the commonest female kunya connector) normalizes to "ام", which is
+    # HOMOGRAPHIC with the disjunctive particle "أم" ("or") and is therefore a member of
+    # _MATN_PARTICLES. It is the ONLY token that is both an apposition connector and a
+    # matn particle (pinned below). The da#314 provenance rule's discriminator — "a real
+    # narrator carries zero matn particles" — is simply FALSE in Arabic because of it, so
+    # any narrator shaped "أم X <role> رسول الله" read as Prophet-reference + particle
+    # and was deleted.
+    #
+    # Verbatim row, nar:d3937f2e-e077-598c-b139-9392d2c61359 (sanadset, mention_count 0):
+    # Umm Kulthum bint Muhammad — the Prophet's own DAUGHTER. mention_count is 0 because
+    # she is bio-promoted, which is exactly why a mention-weighted sweep could not see the
+    # deletion: the loss is a NODE, not an edge.
+    def test_umm_kulthum_bint_muhammad_survives(self) -> None:
+        row = "Umm Kulthum bint Muhammad أم كلثوم بنت سيد البشر رسول الله"
+        assert clean_narrator_name(normalize_arabic(row)) is not None
+
+    def test_umm_homograph_is_the_reason(self) -> None:
+        """`ام` is both an apposition connector and a matn particle — the sole such token.
+
+        If a future edit adds another homograph to _MATN_PARTICLES that is also an
+        apposition connector, the provenance rule silently regains a deletion surface.
+        This pins the collision that makes the exclusion in rule (2d) necessary.
+        """
+        from src.parse.name_quality import _APPOSITION_CONNECTORS, _MATN_PARTICLES
+
+        assert _APPOSITION_CONNECTORS & _MATN_PARTICLES == frozenset({"ام"})
+
+    # PRECISION: the exclusion must not spare the mubham collectives the rule targets —
+    # "بعض" is not an apposition connector, so these still drop. Verbatim voweled row
+    # (nar:2bb390c0-..., mc-47).
+    @pytest.mark.parametrize(
+        "mubham",
+        ["بَعْضِ أَصْحَابِ النَّبِيِّ", "بعض ازواج النبي", "من رسول الله", "هذا من رسول الله"],
+    )
+    def test_mubham_and_provenance_still_drop(self, mubham: str) -> None:
+        assert clean_narrator_name(normalize_arabic(mubham)) is None
+
+    # === DIRECTION 2: resurrecting matn as a narrator node ===
+    #
+    # _truncate_at_isnad_boundary has DUAL semantics: a boundary at index 0 DROPS the
+    # span; a boundary at index > 0 TRUNCATES and keeps the head. The oath is a matn
+    # SIGNAL, not a name TERMINATOR — and in the corpus it is overwhelmingly MID-matn.
+    # Folding the proclitic at i > 0 therefore turned the oath into a truncation point
+    # and handed the matn head back as a narrator name, minting 52 new zero-degree matn
+    # nodes ("دعوني" = "leave me", "اعملوا وابشروا" = "act and rejoice").
+    #
+    # Every oath fixture in TestMatnProvenanceAndOath LEADS with the oath, so they only
+    # ever exercised the drop path — which is exactly how this hid. These are verbatim
+    # MID-matn corpus rows: they must DROP as the matn bodies they are, and in particular
+    # must NOT come back as the truncated head.
+    @pytest.mark.parametrize(
+        "matn",
+        [
+            # nar:2324c241-..., mc-2 — the pushed fold returned "دعوني". Kept on ONE line
+            # and noqa'd rather than wrapped: the fixture's value is that it is the corpus
+            # row BYTE-FOR-BYTE, and implicit concatenation is an opportunity to mangle it.
+            "دعوني فالذي انا فيه خير اوصيكم بثلاث اخرجوا المشركين من جزيره العرب واجيزوا الوفد بنحو ما كنت اجيزهم",  # noqa: E501
+            # nar:1efadf02-..., mc-3 — the pushed fold returned "سريه تغزو في سبيل الله"
+            "سريه تغزو في سبيل الله والذي نفسي بيده لوددت اني اقتل في سبيل الله",
+        ],
+    )
+    def test_mid_matn_oath_drops_and_does_not_truncate_to_a_head(self, matn: str) -> None:
+        assert clean_narrator_name(normalize_arabic(matn)) is None
+
+    # The oath-LEADING fixtures must still drop — the fold is retained at index 0.
+    @pytest.mark.parametrize(
+        "oath",
+        ["والذي نفس محمد بيده", "فوالذي نفس محمد بيده اني لارجو", "فبالذي ارسلك الله امرك بهذا"],
+    )
+    def test_leading_oath_still_drops(self, oath: str) -> None:
+        assert clean_narrator_name(normalize_arabic(oath)) is None

--- a/tests/test_parse/test_name_quality.py
+++ b/tests/test_parse/test_name_quality.py
@@ -1286,12 +1286,27 @@ class TestMatnProvenanceAndOath:
             "من رسول الله",  # mc-38
             "ه من رسول الله",  # mc-55
             "هذا من رسول الله",  # mc-18
-            "كمن زار رسول الله",  # mc-8
             "ه من النبي",  # mc-7
         ],
     )
     def test_prophet_provenance_dropped(self, provenance: str) -> None:
         assert clean_narrator_name(normalize_arabic(provenance)) is None
+
+    # ACCEPTED RESIDUAL, deliberately asserted as KEPT (da#424).
+    #
+    # "كمن زار رسول الله" ("like one who visited the Messenger of Allah", mc-8) carries a
+    # substantive verb, زار. The provenance rule is scoped all-residue precisely so it
+    # can NEVER reach a span with substantive content — that scoping is what stops it
+    # deleting rijal biographies ("وفد على رسول الله" = "he came as a delegate to the
+    # Messenger of Allah" is the SAME shape, and it names a real companion). A rule that
+    # drops this one would delete those, and we have already made that mistake twice.
+    #
+    # So this span stays, at no-worse-than-main (main keeps it too). Recovering it needs
+    # truncate-and-re-gate, which is da#424's job. Asserted explicitly rather than left
+    # silent so the trade is visible and a future edit cannot quietly "fix" it by
+    # loosening the scoping.
+    def test_verb_bearing_provenance_is_an_accepted_residual(self) -> None:
+        assert clean_narrator_name(normalize_arabic("كمن زار رسول الله")) is not None
 
     @pytest.mark.parametrize(
         "oath",
@@ -1416,3 +1431,66 @@ class TestScrubDoesNotDeleteRealNarrators:
     )
     def test_leading_oath_still_drops(self, oath: str) -> None:
         assert clean_narrator_name(normalize_arabic(oath)) is None
+
+
+class TestBioPromotedNarratorsSurvive:
+    """The provenance rule must not delete rijal BIOGRAPHY entries (2nd review round).
+
+    A companion's biography mentions the Prophet BY NATURE — "شهد النبي في حجة الوداع"
+    ("he witnessed the Prophet at the Farewell Pilgrimage"), "وفد على رسول الله" ("he
+    came as a delegate to the Messenger of Allah"), "خليفه رسول الله" ("Successor of the
+    Messenger of Allah"). Every one of those is a Prophet reference plus a preposition,
+    so an `any()`-shaped provenance rule reads a real transmitter's bio as a matn
+    fragment and deletes him.
+
+    That is what happened: 44 real bio-promoted narrators were dropped, including **Abu
+    Bakr al-Siddiq**, **al-Tayyib (the Prophet's son)** and **Dhu al-Yadayn**. Like Umm
+    Kulthum, all are `mention_count = 0` — 45,613 of the 150,187 canonical rows are — so
+    a mention-weighted A/B assigns them weight zero and CANNOT see the deletion. This is
+    the same premise error as the `أم` homograph, one layer deeper: it is not only kunya
+    connectors, it is that bio prose about a companion is indistinguishable from
+    provenance under a "Prophet-ref + particle" discriminator.
+
+    The rule is now scoped all-residue (every token must be a function word or part of
+    the Prophet reference), mirroring rule 5b — the only shape in this module proven safe
+    — so a span carrying ANY substantive token is structurally out of reach.
+
+    Fixtures are verbatim `name_ar` rows (itqan / sanadset, all mention_count 0).
+    """
+
+    @pytest.mark.parametrize(
+        "bio",
+        [
+            # Abu Bakr al-Siddiq, the first Caliph. Note the TRAILING DANGLING WAW: the
+            # waw-pop must not set was_truncated, or signal (2p) fires on the "رسول الله"
+            # in "خليفه رسول الله" and deletes him.
+            "ابو بكر الصديق عبدالله بن ابي قحافه عثمان التيمي خليفه رسول الله و",
+            "الطيب ولد رسول الله",  # al-Tayyib, the Prophet's son
+            "ذواليدين صلي مع النبي",  # Dhu al-Yadayn (sanadset)
+            "الحارث بن عمرو السهمي الباهلي شهد النبي في حجة الوداع عداده ف",
+            "ضمرة بن سعد السلمي شهد مع النبي حنينا",
+            "رغبان مولى حبيب بن مسلمة الفهري رأى أصحاب النبي يركعون ركعتين قبل المغرب",
+            "أبو صفية رجل من المهاجرين من 3 أصحاب النبي",
+            "زرارة بن عمرو النخعي وفد إلى رسول الله",
+        ],
+    )
+    def test_bio_promoted_companion_survives(self, bio: str) -> None:
+        assert clean_narrator_name(normalize_arabic(bio)) is not None
+
+    # PRECISION: the all-residue scoping must still drop the pure fragments — every
+    # token a function word or part of the Prophet reference, no naming content at all.
+    @pytest.mark.parametrize(
+        "fragment",
+        [
+            "من رسول الله",  # mc-38
+            "ه من رسول الله",  # mc-55
+            "ها من رسول الله",  # mc-7  (bare pronoun, same class as the 1-char "ه")
+            "هن من رسول الله",  # mc-5
+            "هذا من رسول الله",  # mc-18
+            "ه من النبي",  # mc-7
+            "بعض اصحاب النبي",  # mc-47 — mubham collective, must NOT be spared
+            "بعض ازواج النبي",  # mc-23
+        ],
+    )
+    def test_pure_provenance_fragment_still_drops(self, fragment: str) -> None:
+        assert clean_narrator_name(normalize_arabic(fragment)) is None


### PR DESCRIPTION
## Summary

The last three rows of the noorinalabs-main#928 launch gate — three name-quality residue classes in `src/parse/name_quality.py`, landed as one PR.

**Every mechanism was re-verified against `origin/main` before implementing. Two of the three issue bodies describe a mechanism that no longer holds.**

| Issue | Stated mechanism | Verdict |
|---|---|---|
| **#314** | Prophet-provenance / oath fragments survive the gate | **HELD** |
| **#315** | `ما` + `وبه` survive the residue floor | **HALF STALE** — `ما` already fixed by da#317 |
| **#316** | `normalize_arabic` doesn't strip U+200F; the edge-strip is shielded | **STALE** — both claims false at HEAD |

**#316's real cause:** `normalize_arabic` has stripped bidi marks since da#271, so the normalized path was already clean — the stored `name_ar_normalized` is `'قتاده،.'` (RLM gone, punctuation still there), which proves RLM is not what shields the strip. The live defect is the **display** path, which strips `_EDGE_PUNCT` from the **voweled** token that `normalize_arabic` deliberately never touches. `name_ar` is what the loader keys the node `name` on. Implementing the issue's suggested fix would not have fixed it.

**#315:** `ما` already drops via da#317's rule (2c); only `وبه` was live (13 rows, not 32). `_is_isnad_residue_token` de-waws `وبه` → `به`, which was absent from `_ISNAD_FORMULA_FRAGMENTS`.

**#314:** both Prophet detectors miss a provenance tail — one is leader-anchored, the other gated on `was_truncated`. The oath formula escaped separately: `الذي` **is** a boundary token, but the corpus stacks proclitics onto it (`والذي`/`فوالذي`/`فبالذي`).

---

## Review round 2 — two defects found by Sofia Cardoso, both fixed

A green CI, a full local check-set, 39 red-first tests and one approving reviewer all missed these. **Root cause of the miss: the original A/B measured only the rows the change *drops*.** A drop-gate has two failure directions, and a one-directional diff is blind to both that matter — *deleting a real narrator*, and *ceasing to drop* a matn span so it is resurrected as a node. Both happened.

**1. The scrub deleted the Prophet's daughter.** `أم` (*umm*, the commonest female kunya connector) normalizes to `ام` — **homographic with the disjunctive particle** `أم` ("or") — and is therefore in `_MATN_PARTICLES`. It is the **only** token that is both an apposition connector and a matn particle (now pinned by a set-level test). So the #314 discriminator, *"a real narrator carries zero matn particles"*, is **false in Arabic**, and any narrator shaped `أم X <role> رسول الله` read as Prophet-reference-plus-particle and was dropped:

```
nar:d3937f2e-e077-598c-b139-9392d2c61359
"Umm Kulthum bint Muhammad أم كلثوم بنت سيد البشر رسول الله"   (sanadset, mention_count 0)
```

Umm Kulthum bint Muhammad. `origin/main` keeps her; the first pass of this PR removed her from the graph. **`mention_count` is 0 because she is bio-promoted — which is exactly why a mention-weighted sweep could not see it: the loss is a NODE, not an edge.** Fixed by excluding apposition connectors from the particle disjunct. The mubham collectives the rule targets still drop (`بعض` is not an apposition connector).

**2. The fold minted 52 new matn nodes.** `_truncate_at_isnad_boundary` has **dual semantics** — boundary at index 0 *drops*; boundary at index > 0 *truncates and keeps the head*. All four oath fixtures **lead** with the oath, so only the drop path was ever exercised. In the corpus the oath is overwhelmingly **mid-matn**, where the fold became a truncation point and handed the matn head back as a name: `دعوني` ("leave me"), `اعملوا وابشروا`, `قول الله` — precisely the class da#317 exists to remove. The oath is a matn **signal**, not a name **terminator**; the fold is now applied at index 0 only.

## Bidirectional A/B — the evidence that was missing

Over all 150,187 rows of `data/curated.run5-scrubbed/narrators_canonical.parquet`:

| | rows dropped | new pollution **kept** |
|---|---|---|
| first pass (`9afb8e0`) | 751 / 1,268 mentions | **52 rows / 68 mentions** |
| **with both fixes** | 749 / 1,266 mentions | **0** |

Target classes remain closed: **#315 0/0, #316 0/0, #314 4 rows / 5 mentions.**

The fix restores 4 rows the first pass dropped: Umm Kulthum, plus 3 matn-oath residue rows at mc-1 that **`origin/main` also keeps** — pre-existing, not introduced by this PR (Direction B is 0).

#314's residual (4 rows / 5 mentions) is long matn sentences spared by the `nasab>=2` precision guard. That guard is the only thing standing between this scrub and real lineages; I did not widen it for 5 mentions out of 3.25M. Sofia independently agreed with that restraint.

## Tests

50 cases. Fixtures are **verbatim corpus rows** (U+200F as an explicit escape; the long matn row is `# noqa: E501` rather than wrapped, because byte-exactness is the whole point of it).

- Red-first vs `origin/main`: **21 of 39 fail** (the 18 passing are the precision duals and two tests pinning the stale halves).
- Red-first vs the buggy first pass `9afb8e0`: **3 of the 11 new cases fail** — Umm Kulthum deleted, and both mid-matn oaths truncating to heads.
- Set-level guard: the apposition/particle homograph is pinned, so a future addition cannot silently restore the deletion surface.

Local check-set green: ruff-format, ruff-lint, gitleaks, mypy-strict (102 files), pytest **2,134 passed / 0 failed**.

**Note on one example:** Sofia's second case, `أم أيمن حاضنة رسول الله`, is **not attested in this artifact** (0 rows contain `حاضنة`), so no test asserts on it. The mechanism is real and Umm Kulthum is the attested victim; fabricating that fixture would make the assertion inert, which is the trap this suite exists to avoid.

Closes #314
Closes #315
Closes #316
