### PR TITLE
feat(resolve): declare the canonical tally at the WRITE, not at publish (da#428)

### DIFF
--- a/scripts/publish_parquet.py
+++ b/scripts/publish_parquet.py
@@ -11,6 +11,8 @@ box one-offs, da#342).
 
 CONTRACT — objects published under ``noorinalabs-pipeline/<parquet_ref>/``:
 
+    curated/_resolve_run.txt              (written by RESOLVE; copied forward, da#428)
+    curated/_manifest.txt                 (written HERE, uploaded LAST; md5 + bytes ONLY)
     curated/narrators_canonical.parquet
     curated/narrator_mentions_resolved.parquet
     curated/narrator_mentions_resolved_muhaddithat.parquet
@@ -45,6 +47,7 @@ stderr.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import shutil
 import subprocess
@@ -81,6 +84,51 @@ STAGING_FULL_ONLY_GLOBS: tuple[str, ...] = (
 )
 
 
+CANONICAL_PARQUET_NAME = "narrators_canonical.parquet"
+
+# --- The da#428 provenance contract -----------------------------------------
+# Two artifacts, each declaring ONLY what its author can honestly attest.
+#
+#   curated/_resolve_run.txt   Written by RESOLVE (src/resolve/_run_record.py) — the
+#                              process that WROTE the parquet. It alone holds an
+#                              in-memory tally taken BEFORE the write, so its count
+#                              does NOT agree with a short file, and it alone knows
+#                              whether the run reached its terminal stage.
+#
+#                                RESOLVE_RUN canonical_ids=<n> run_status=complete git_sha=<sha>
+#
+#   curated/_manifest.txt      Written HERE. md5 + bytes ONLY — and it is FORBIDDEN
+#                              from declaring a count.
+#
+#                                CANONICAL_MANIFEST file=<name> md5=<32hex> bytes=<n>
+#
+# WHY THIS SCRIPT MUST NOT DECLARE A COUNT, AND WHY IT CANNOT IMPORT THE PRODUCER
+#
+# This is a SEPARATE PROCESS. It starts after resolve has exited, reads data/curated/
+# off disk and uploads it. Resolve's in-memory tally does not exist any more. So the
+# only way this script could produce `canonical_ids` is by READING BACK the parquet it
+# is about to upload — and a read-back agrees perfectly with a truncated file. It would
+# be a gate certifying coverage it cannot see, wearing the words "producer-signed
+# provenance" and a green md5. da#426 measured that shape deleting 83.9% of the graph.
+#
+# That is why this module imports NO pyarrow and does NOT import src.resolve (which
+# would pull pyarrow in transitively and hand it the ability to count). The inability
+# is STRUCTURAL, not a convention — `tests/test_scripts/test_publish_provenance.py`
+# executes this module in a subprocess and asserts pyarrow never enters sys.modules.
+# The consumer enforces the other side: noorinalabs-deploy's verify_prune_provenance.sh
+# REFUSES outright a manifest that carries `canonical_ids=`.
+#
+# So publish COPIES THE TALLY FORWARD, byte for byte, and never recomputes it.
+RESOLVE_RUN_FILENAME = "_resolve_run.txt"
+MANIFEST_FILENAME = "_manifest.txt"
+
+# Both provenance objects are REQUIRED — the consumer refuses the prune without either.
+PROVENANCE_REQUIRED: tuple[str, ...] = (RESOLVE_RUN_FILENAME, MANIFEST_FILENAME)
+
+_RUN_KEYWORD = "RESOLVE_RUN"
+_MANIFEST_KEYWORD = "CANONICAL_MANIFEST"
+
+
 class PublishError(RuntimeError):
     """A publish precondition or post-publish verification failed."""
 
@@ -91,6 +139,122 @@ class PlannedUpload:
 
     local: Path
     remote_subpath: str  # e.g. "curated/narrators_canonical.parquet"
+
+
+@dataclass(frozen=True)
+class ResolveRunDeclaration:
+    """What resolve declared about the canonical parquet — parsed, never recomputed.
+
+    ``line`` is kept verbatim so the record is copied forward exactly as the producer
+    wrote it. This script re-derives none of these fields.
+    """
+
+    canonical_ids: int
+    run_status: str
+    parquet_md5: str
+    line: str
+
+
+def parse_resolve_run(text: str) -> ResolveRunDeclaration | None:
+    """Parse the ``RESOLVE_RUN`` line of ``curated/_resolve_run.txt``.
+
+    ``None`` for absent/malformed — which :func:`assert_run_publishable` turns into a
+    hard refusal. A missing instrument reading is a stop, never a silent zero.
+
+    Whole-token extraction (``split`` on spaces, exact ``key=``), matching the
+    consumer's ``token_value``: no key can be hijacked by a longer one ending in its
+    name (``parquet_md5=`` can never answer for ``md5=``).
+    """
+    head = next((ln for ln in text.splitlines() if ln.startswith(f"{_RUN_KEYWORD} ")), None)
+    if head is None:
+        return None
+    tokens: dict[str, str] = {}
+    for tok in head.split(" ")[1:]:
+        key, sep, value = tok.partition("=")
+        if sep and key:
+            tokens[key] = value
+    try:
+        return ResolveRunDeclaration(
+            canonical_ids=int(tokens["canonical_ids"]),
+            run_status=tokens["run_status"],
+            parquet_md5=tokens.get("parquet_md5", ""),
+            line=head,
+        )
+    except (KeyError, ValueError):
+        return None
+
+
+def assert_run_publishable(decl: ResolveRunDeclaration | None, canonical_md5: str) -> None:
+    """Refuse to publish a keep-set that carries no honest, matching tally.
+
+    Each door names a distinct failure, and none of them can be answered by reading
+    the parquet — which is the point.
+    """
+    if decl is None:
+        raise PublishError(
+            f"curated/{RESOLVE_RUN_FILENAME} is absent or malformed. The keep-set carries no "
+            "declaration from the process that WROTE it, and this publisher holds no tally of "
+            "its own — it is a separate process and any count it computed would be a read-back "
+            "of the parquet it is uploading, which agrees with a truncated file. Re-run resolve "
+            "so it declares the tally (da#428); do NOT hand-author this file."
+        )
+    if decl.run_status != "complete":
+        raise PublishError(
+            f"the resolve run that produced this keep-set did NOT complete "
+            f"(run_status={decl.run_status!r}). Its canonical set is partial BY THE PRODUCER'S "
+            "OWN ACCOUNT — every id in it is real, so 'missing' would be 0 and every derived "
+            "gate would go green while the prune deleted the narrators the run never got to "
+            "name. No count equality of any kind can see this; only the producer can attest it."
+        )
+    if decl.canonical_ids <= 0:
+        raise PublishError(
+            f"resolve declares canonical_ids={decl.canonical_ids} — a prune against a zero-id "
+            "keep-set would delete every narrator."
+        )
+    if decl.parquet_md5 != canonical_md5:
+        raise PublishError(
+            f"curated/{CANONICAL_PARQUET_NAME} is NOT the file resolve took its tally over.\n"
+            f"  tally was taken over md5: {decl.parquet_md5}\n"
+            f"  file on disk has     md5: {canonical_md5}\n"
+            "The declared count therefore describes different bytes than the ones about to be "
+            "uploaded, so it cannot bind them. This is what a resume that skipped every "
+            "canonical-writing stage looks like, and what a scrub script that rewrote the "
+            "parquet outside the sanctioned writer looks like. A skipped tally is not a smaller "
+            "number — it is NO number. Re-run resolve through a canonical writer; the publisher "
+            "must never fall back to counting the file itself."
+        )
+
+
+def file_md5(path: Path) -> str:
+    """md5 of ``path``'s bytes, streamed. Transfer integrity — NOT a count."""
+    digest = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def manifest_line(name: str, md5: str, size_bytes: int) -> str:
+    """One ``CANONICAL_MANIFEST`` line. md5 + bytes ONLY — never a count."""
+    return f"{_MANIFEST_KEYWORD} file={name} md5={md5} bytes={size_bytes}"
+
+
+def render_manifest(uploads: list[PlannedUpload]) -> str:
+    """The ``_manifest.txt`` body: one line per curated object.
+
+    Transfer integrity is the only thing a publisher is in a position to know, so it
+    is the only thing this declares. It carries no ``canonical_ids`` and no ``rows``:
+    the consumer REFUSES a manifest that declares a count, because a publisher that
+    thinks it knows the count has read the file back.
+    """
+    return (
+        "\n".join(
+            manifest_line(u.local.name, file_md5(u.local), u.local.stat().st_size)
+            for u in uploads
+            if u.remote_subpath.startswith("curated/")
+        )
+        + "\n"
+    )
 
 
 # --- Pure logic (unit-tested; no I/O) ---------------------------------------
@@ -179,6 +343,12 @@ def verify_remote(listing: set[str], planned: list[PlannedUpload]) -> None:
     ``listing`` is the set of bucket-relative keys under ``<parquet_ref>/`` as
     returned by ``rclone lsf --recursive`` (e.g. ``curated/narrators_canonical.parquet``).
     Raises :class:`PublishError` loudly on any absence.
+
+    The two provenance objects are required exactly as the curated parquets are
+    (da#428). A ref whose parquets landed but whose ``_resolve_run.txt`` did not is a
+    ref the consumer will refuse to prune against — and it must fail HERE, loudly, at
+    publish time, rather than surfacing as a mysterious refusal on the production box
+    at the moment someone is trying to run a destructive op.
     """
     uploaded_missing = [pu.remote_subpath for pu in planned if pu.remote_subpath not in listing]
     if uploaded_missing:
@@ -186,9 +356,8 @@ def verify_remote(listing: set[str], planned: list[PlannedUpload]) -> None:
             "post-publish verification failed — object(s) absent from B2 listing: "
             f"{', '.join(sorted(uploaded_missing))}"
         )
-    curated_missing = [
-        f"curated/{name}" for name in CURATED_REQUIRED if f"curated/{name}" not in listing
-    ]
+    required = [f"curated/{name}" for name in (*CURATED_REQUIRED, *PROVENANCE_REQUIRED)]
+    curated_missing = [key for key in required if key not in listing]
     if curated_missing:
         raise PublishError(
             "post-publish verification failed — required curated object(s) missing: "
@@ -338,11 +507,38 @@ def _run(argv: list[str] | None) -> int:
     log(f"[publish-parquet] mode        = {mode}")
     log(f"[publish-parquet] curated dir = {curated_dir}")
     log(f"[publish-parquet] staging dir = {staging_dir}")
-    log(f"[publish-parquet] {len(plan)} object(s) to publish under {BUCKET}/{ref}/")
+
+    # --- The completeness gate (da#428) --------------------------------------
+    # BEFORE anything is uploaded. Resolve's record is the only number in the whole
+    # prune path not derived from the artifact being validated; if it is absent, if
+    # the run did not finish, or if it describes different bytes than the ones about
+    # to be shipped, we refuse — we never fall back to counting the parquet.
+    canonical_local = curated_dir / CANONICAL_PARQUET_NAME
+    canonical_md5 = file_md5(canonical_local)
+    run_record = curated_dir / RESOLVE_RUN_FILENAME
+    decl = (
+        parse_resolve_run(run_record.read_text(encoding="utf-8")) if run_record.is_file() else None
+    )
+    assert_run_publishable(decl, canonical_md5)
+    assert decl is not None  # narrowed by assert_run_publishable
+    log(
+        f"[publish-parquet] resolve declared canonical_ids={decl.canonical_ids} "
+        f"run_status={decl.run_status} (tally minted in-memory by the writing process; "
+        "this publisher computes no count)"
+    )
+
+    # Written from the same bytes the gate just approved. md5 + bytes ONLY.
+    manifest_local = curated_dir / MANIFEST_FILENAME
+    provenance = [
+        PlannedUpload(run_record, f"curated/{RESOLVE_RUN_FILENAME}"),
+        PlannedUpload(manifest_local, f"curated/{MANIFEST_FILENAME}"),
+    ]
+    total = len(plan) + len(provenance)
+    log(f"[publish-parquet] {total} object(s) to publish under {BUCKET}/{ref}/")
 
     if args.dry_run:
         log("[publish-parquet] --dry-run: the following WOULD be published (nothing uploaded):")
-        for upload in plan:
+        for upload in [*plan, *provenance]:
             log(f"  {upload.local} -> {remote_base(ref)}/{upload.remote_subpath}")
         print(ref)
         return 0
@@ -350,14 +546,23 @@ def _run(argv: list[str] | None) -> int:
     if shutil.which(args.rclone_bin) is None:
         raise PublishError(f"rclone binary {args.rclone_bin!r} not found on PATH")
 
+    manifest_local.write_text(render_manifest(plan), encoding="utf-8")
+
     env = build_rclone_env()
     for upload in plan:
         rclone_copy_file(upload, ref, env, rclone_bin=args.rclone_bin)
 
+    # Provenance LAST, manifest last of all: its presence is itself the evidence that
+    # the publish ran to completion. _resolve_run.txt is copied forward verbatim —
+    # the publisher never re-derives what only the producer could honestly attest.
+    for upload in provenance:
+        rclone_copy_file(upload, ref, env, rclone_bin=args.rclone_bin)
+
+    full_plan = [*plan, *provenance]
     log("[publish-parquet] verifying published objects (rclone lsf)...")
     listing = rclone_list(ref, env, rclone_bin=args.rclone_bin)
-    verify_remote(listing, plan)
-    log(f"[publish-parquet] OK - {len(plan)} object(s) verified present under {BUCKET}/{ref}/")
+    verify_remote(listing, full_plan)
+    log(f"[publish-parquet] OK - {len(full_plan)} object(s) verified present under {BUCKET}/{ref}/")
 
     # Final stdout line: the ref for the operator to paste into deploy-data-load.yml.
     print(ref)

--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -31,6 +31,7 @@ from src.resolve._checkpoint import EXIT_STOPPED_AT_LIMIT, StopAfterReached
 from src.resolve._deps import EXIT_MISSING_DEPENDENCY, MissingDependencyError
 from src.resolve._inputs import MissingInputError
 from src.resolve._provenance import DetectorProvenance, DetectorStatus, read_provenance
+from src.resolve._run_record import finalize_run
 from src.resolve.ner import EXIT_UNROUTED_CORPUS, UnroutedCorpusError
 from src.utils.logging import get_logger
 
@@ -127,6 +128,33 @@ class ResolveStageError(Exception):
 def _outcome_files(outcome: StageOutcome | None) -> list[Path]:
     """Files a stage produced, or ``[]`` for a skipped/errored/absent stage."""
     return outcome.files if isinstance(outcome, StageRan) else []
+
+
+def _stage_provenance(outcomes: dict[str, StageOutcome]) -> tuple[str, ...]:
+    """Render each stage's outcome as a ``RESOLVE_STAGE`` body for the run record.
+
+    Forensics, not a gate — the consumer keys only on ``canonical_ids`` and
+    ``run_status``. But a counts-only record cannot be told apart from one an
+    operator hand-authored in a single line straight off the parquet, and the
+    pressure to hand-mint is maximal exactly when the gate bites. Recording which
+    stages ran, skipped and why makes hand-minting an act of forgery rather than
+    one of convenience (da#428, Jean-Claude Habimana). Deliberately unsigned:
+    pre-launch, no adversary, not worth the key management.
+    """
+    rendered: list[str] = []
+    for step in RESOLVE_STEP_ORDER:
+        outcome = outcomes.get(step)
+        match outcome:
+            case StageRan():
+                detail = f"outcome=ran files={len(outcome.files)}"
+            case StageSkipped():
+                detail = f"outcome=skipped reason={outcome.reason}"
+            case StageErrored():
+                detail = f"outcome=errored exc={outcome.exc_type}"
+            case _:
+                detail = "outcome=absent"
+        rendered.append(f"step={step} {detail}")
+    return tuple(rendered)
 
 
 # Canonical execution order of the resolve steps. ``run_all(from_step=...)`` skips
@@ -846,6 +874,16 @@ def run_all(
     # StageErrored now forces a non-zero exit via the CLI's ResolveStageError
     # handler, aggregating every failed stage from this one (possibly 7.5-hour) run.
     errored = [o for o in outcomes.values() if isinstance(o, StageErrored)]
+
+    # da#428: stamp the run's terminal status onto curated/_resolve_run.txt. This is
+    # the ONLY place run_status may be upgraded to `complete`; every write_canonical
+    # stamps `incomplete`, so a killed process, a raised stage or a --stop-after probe
+    # all leave `incomplete` on disk and the publish refuses. `complete` is exactly
+    # "reached this line with no stage in error" — the one fact no count can supply,
+    # because a run that halts after writing a coherent partial file is internally
+    # consistent and its tally matches what it managed to write.
+    finalize_run(output_dir, _stage_provenance(outcomes), complete=not errored)
+
     if errored:
         for e in errored:
             logger.error("resolve_stage_errored", step=e.step, exc_type=e.exc_type)

--- a/src/resolve/_run_record.py
+++ b/src/resolve/_run_record.py
@@ -1,0 +1,382 @@
+"""The resolve run's own record of what it wrote — ``curated/_resolve_run.txt`` (da#428).
+
+``prune-narrators`` DETACH-DELETEs every ``Narrator`` absent from the canonical
+keep-set. da#426 measured a *valid but truncated* ``narrators_canonical.parquet``
+deleting **83.9% of the graph** with ``missing == 0`` and every derived gate green:
+every gate in the prune path is derived from the keep-set it is meant to validate,
+so all of them prove the prune obeyed the parquet and none can ask whether it was
+the *right* parquet — nor whether it was the *whole* parquet.
+
+The missing signal is **completeness**, and it cannot be recovered downstream:
+
+* The parquet's own footer ``num_rows`` is self-consistent on a short file.
+* B2's per-object md5 binds the file to itself; a truncated-but-intact upload has
+  a perfectly good hash.
+* ``publish_parquet.py`` is a **separate process** that starts after resolve has
+  exited and reads ``data/curated/`` off disk. It holds no tally, so any count it
+  computed could only be a READ-BACK of the parquet it is about to upload — which
+  agrees with a short file by construction.
+
+**The tally exists only while the writing process is alive.** So the process that
+*wrote* the parquet must declare, before the write, how many canonical ids it
+intended to write; that declaration is this module's record, and it is the only
+number in the whole prune path not derived from the artifact being validated.
+
+The consumer contract (noorinalabs-deploy ``scripts/verify_prune_provenance.sh``)::
+
+    RESOLVE_RUN canonical_ids=<n> run_status=complete git_sha=<sha>
+
+Two artifacts, each declaring only what its author can honestly attest: this one
+carries the count and the run's terminal status; ``publish_parquet.py``'s
+``_manifest.txt`` carries md5 + bytes and is FORBIDDEN from carrying a count. The
+gate refuses a manifest that declares ``canonical_ids`` at all — a publisher that
+thinks it knows the count has read the file back.
+
+Why the tally is bound to the WRITE and not to a named stage
+------------------------------------------------------------
+``narrators_canonical.parquet`` does not have "a producing stage". It has **six**
+writers, every one of them in :data:`~src.resolve.RESOLVE_STEP_ORDER`:
+
+===============  ==========================================================
+stage            effect on ``narrators_canonical.parquet``
+===============  ==========================================================
+``disambiguate`` OVERWRITES it
+``bio_promote``  MERGEs into it (43,109 of 129,234 ids are bio-only, da#352)
+``cluster``      fuzzy-clusters in place, DROPPING merged ids
+``narrator_split`` rewrites it with peeled rows APPENDED
+``reconcile``    rewrites it (date fold; row set preserved, BYTES change)
+``tabaqa_dates`` rewrites it (date fallback; row set preserved, BYTES change)
+===============  ==========================================================
+
+A tally taken at ``disambiguate`` declares ~86k while the file holds ~129k, so the
+consumer's equality would **false-FAIL on every healthy run** — and a false-FAIL on
+a destructive op sends an operator to "restore from backup" after a prune that did
+exactly the right thing, after which the next person weakens the gate.
+
+Naming the "last" writer is equally wrong: it is a fact about the *current* stage
+list, and the last two writers were both added after the two this issue was filed
+against. So the tally is not a property of any stage — it is a property of **the
+write**. :func:`write_canonical` is the single sanctioned writer of the artifact,
+it re-mints the tally on every call, and whichever writer happens to run last is
+therefore the one whose tally survives. A seventh writer inherits the guarantee by
+construction (and ``tests/test_resolve/test_run_record.py`` fails if one is added
+that bypasses this function).
+
+Why the record is fail-closed
+-----------------------------
+:func:`write_canonical` always stamps ``run_status=incomplete``: at the moment of
+any write, the run has by definition not finished. Only :func:`finalize_run`, at
+the successful end of ``run_all``, upgrades it to ``complete``. A process killed
+mid-run, a stage that raised, a ``--stop-after`` probe — all leave ``incomplete``
+on disk and the publish refuses. Nothing has to remember to mark failure.
+
+``run_status`` describes **the run that minted the tally**, not merely the last run
+to execute. A later ``--from-step dedup`` run touches no canonical writer, so it
+leaves this record entirely alone rather than upgrading a partial run's tally to
+``complete`` — which would be a false PASS reached by a legitimate operation
+(da#268/da#272 resume).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import uuid
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from src.parse.base import write_parquet
+from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "CANONICAL_PARQUET_NAME",
+    "RESOLVE_RUN_FILENAME",
+    "ResolveRunRecord",
+    "RunStatus",
+    "canonical_id_tally",
+    "current_run_id",
+    "file_md5",
+    "finalize_run",
+    "read_run_record",
+    "write_canonical",
+]
+
+CANONICAL_PARQUET_NAME = "narrators_canonical.parquet"
+
+# The producer half of the da#428 contract. Read by noorinalabs-deploy's
+# scripts/verify_prune_provenance.sh, which requires this object to exist and to
+# carry BOTH canonical_ids and run_status before any node may be deleted.
+RESOLVE_RUN_FILENAME = "_resolve_run.txt"
+
+# The record keyword the consumer greps (`grep '^RESOLVE_RUN '`, first match wins).
+# Per-stage forensics go on RESOLVE_STAGE lines so they can never shadow it.
+_RUN_KEYWORD = "RESOLVE_RUN"
+_STAGE_KEYWORD = "RESOLVE_STAGE"
+
+
+class RunStatus(StrEnum):
+    """Whether the run that minted the tally reached its terminal stage.
+
+    Lowercase-and-underscore because the consumer extracts it with the charclass
+    ``[a-z_]``; a value outside that alphabet reads back as EMPTY, and an empty
+    read that nobody notices is precisely the silent zero this contract exists to
+    refuse (``feedback_silent_zero_is_not_a_measurement``).
+
+    The distinction is load-bearing and no count can supply it: a run that halts
+    after writing a coherent partial file is internally consistent, and its tally —
+    taken before that write — matches what it managed to write. Only the producer
+    can attest that it reached the end, so it must, explicitly.
+    """
+
+    COMPLETE = "complete"
+    """``run_all`` reached its terminal stage with no stage in error."""
+
+    INCOMPLETE = "incomplete"
+    """A write happened but the run has not (yet) finished. The default, always."""
+
+
+@dataclass(frozen=True)
+class ResolveRunRecord:
+    """What the writing process declares about the canonical parquet it produced.
+
+    ``canonical_ids`` is the in-memory tally taken BEFORE the write.
+    ``parquet_md5`` binds that tally to the exact bytes it was taken over — see
+    :func:`write_canonical` for why that binding is not a read-back.
+    """
+
+    canonical_ids: int
+    run_status: RunStatus
+    git_sha: str
+    run_id: str
+    last_writer: str
+    parquet_md5: str
+    parquet_bytes: int
+    stages: tuple[str, ...] = ()
+
+    def render(self) -> str:
+        """Serialise to the ``key=value`` instrument-line format the consumer parses.
+
+        Deliberately NOT JSON: the consumer parses this on the VPS inside an
+        ``ssh-action`` script, where no ``jq`` and no ``python3`` is used. This is
+        the same shape as ``PRUNE_NARRATORS_SUMMARY``, which both repos already
+        parse with an anchored whole-token extraction.
+        """
+        head = " ".join(
+            (
+                _RUN_KEYWORD,
+                f"canonical_ids={self.canonical_ids}",
+                f"run_status={self.run_status.value}",
+                f"git_sha={self.git_sha}",
+                f"run_id={self.run_id}",
+                f"last_writer={self.last_writer}",
+                f"parquet_md5={self.parquet_md5}",
+                f"parquet_bytes={self.parquet_bytes}",
+            )
+        )
+        lines = [head, *(f"{_STAGE_KEYWORD} {s}" for s in self.stages)]
+        return "\n".join(lines) + "\n"
+
+
+def canonical_id_tally(table: pa.Table) -> int:
+    """Count DISTINCT NON-EMPTY ``canonical_id`` values in an in-memory table.
+
+    **The definition must match the consumer's exactly.** ``read_canonical_ids()``
+    (:mod:`src.graph.prune`) returns a ``set`` and filters falsy ids::
+
+        ids = {cid for cid in table.column("canonical_id").to_pylist() if cid}
+
+    so the ``canonical=`` the prune reports is a distinct, non-empty count. A naive
+    ``len(df)`` here would false-FAIL the equality on any duplicate or null id — on
+    a *destructive* op, which is how a good gate gets weakened.
+
+    Same definition, different derivation: this one reads the rows the writer is
+    about to hand to parquet; the consumer reads the file that arrived. Both halves
+    are load-bearing, and the whole binding is the gap between them.
+    """
+    return len({cid for cid in table.column("canonical_id").to_pylist() if cid})
+
+
+def file_md5(path: Path) -> str:
+    """md5 of ``path``'s bytes, streamed."""
+    digest = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _git_sha() -> str:
+    """Short SHA of the code that produced this run, or ``unknown``.
+
+    Provenance, not a gate: it makes a hand-authored record an act of forgery
+    rather than an act of convenience. Never raises — a publish must not fail
+    because the producer was run from a tarball.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(Path(__file__).resolve().parent), "rev-parse", "--short", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+    return proc.stdout.strip() or "unknown"
+
+
+_RUN_ID = f"{os.getpid()}-{uuid.uuid4().hex[:12]}"
+
+
+def current_run_id() -> str:
+    """This process's run id — stable for the life of the process.
+
+    Process-scoped rather than threaded through every stage signature, because the
+    resolve stages all execute in one process. It is what lets :func:`finalize_run`
+    ask "did *I* mint this tally?" without enumerating writer stages by name.
+    """
+    return _RUN_ID
+
+
+def write_canonical(table: pa.Table, canonical_path: Path, *, stage: str) -> Path:
+    """Write ``narrators_canonical.parquet`` AND declare the tally. The only writer.
+
+    The tally is computed from ``table`` — the in-memory rows — **before**
+    :func:`write_parquet` is called. It is therefore not a function of the file, and
+    a file that ends up short (a partial write, a truncation, a botched copy) does
+    NOT agree with it. That disagreement is the entire completeness signal, and it
+    is the property ``tests/test_resolve/test_run_record.py::test_tally_survives_
+    truncation_of_the_written_parquet`` pins: truncate the parquet after the write
+    and the record still declares the original count.
+
+    ``parquet_md5`` is taken over the bytes just written. That is a hash of the
+    file, NOT a count of it — it cannot produce ``canonical_ids`` and does not
+    participate in deriving it, so it introduces no circularity. Its one job is to
+    bind the in-memory tally to the exact bytes it describes, so that a parquet
+    later rewritten by anything that did NOT come through this function (a scrub
+    script, a hand edit, a stale file left by a resumed run) fails to match and the
+    publish refuses. The count says *how many rows were meant*; the md5 says *which
+    bytes were meant*. Neither substitutes for the other.
+
+    ``run_status`` is stamped INCOMPLETE unconditionally: at the moment of a write,
+    the run has not finished. Only :func:`finalize_run` upgrades it.
+    """
+    tally = canonical_id_tally(table)
+
+    write_parquet(table, canonical_path, schema=NARRATORS_CANONICAL_SCHEMA)
+
+    record = ResolveRunRecord(
+        canonical_ids=tally,
+        run_status=RunStatus.INCOMPLETE,
+        git_sha=_git_sha(),
+        run_id=current_run_id(),
+        last_writer=stage,
+        parquet_md5=file_md5(canonical_path),
+        parquet_bytes=canonical_path.stat().st_size,
+    )
+    _write_record(canonical_path.parent, record)
+
+    logger.info(
+        "canonical_tally_declared",
+        stage=stage,
+        canonical_ids=tally,
+        rows=table.num_rows,
+        path=str(canonical_path),
+    )
+    return canonical_path
+
+
+def _record_path(curated_dir: Path) -> Path:
+    return curated_dir / RESOLVE_RUN_FILENAME
+
+
+def _write_record(curated_dir: Path, record: ResolveRunRecord) -> Path:
+    path = _record_path(curated_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(record.render(), encoding="utf-8")
+    return path
+
+
+def read_run_record(curated_dir: Path) -> ResolveRunRecord | None:
+    """Parse ``curated/_resolve_run.txt``, or ``None`` if it is absent/unreadable.
+
+    ``None`` means the keep-set carries no declaration from the process that wrote
+    it — which the publish treats as a hard refusal, never as a zero.
+    """
+    path = _record_path(curated_dir)
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    head = next((ln for ln in text.splitlines() if ln.startswith(f"{_RUN_KEYWORD} ")), None)
+    if head is None:
+        return None
+    tokens = dict(
+        tok.split("=", 1) for tok in head.split(" ")[1:] if "=" in tok and not tok.startswith("=")
+    )
+    try:
+        status = RunStatus(tokens["run_status"])
+        return ResolveRunRecord(
+            canonical_ids=int(tokens["canonical_ids"]),
+            run_status=status,
+            git_sha=tokens.get("git_sha", "unknown"),
+            run_id=tokens.get("run_id", ""),
+            last_writer=tokens.get("last_writer", ""),
+            parquet_md5=tokens.get("parquet_md5", ""),
+            parquet_bytes=int(tokens.get("parquet_bytes", "0")),
+            stages=tuple(
+                ln.removeprefix(f"{_STAGE_KEYWORD} ")
+                for ln in text.splitlines()
+                if ln.startswith(f"{_STAGE_KEYWORD} ")
+            ),
+        )
+    except (KeyError, ValueError):
+        return None
+
+
+def finalize_run(curated_dir: Path, stages: tuple[str, ...], *, complete: bool) -> None:
+    """Stamp the run's terminal status onto the record, at the end of ``run_all``.
+
+    Upgrades ``run_status`` to ``complete`` **only if this process minted the tally**
+    (``record.run_id == current_run_id()``). A resumed run that started past every
+    canonical writer (``--from-step dedup``) changed no canonical bytes, so it must
+    not re-status a record it did not produce: doing so would let a *partial* earlier
+    run's tally be promoted to ``complete`` by a later run that merely finished — a
+    false PASS reached by an entirely legitimate operation.
+
+    Absent record = a run that wrote no canonical parquet and found none. Nothing to
+    finalize; the publish refuses on the absence, which is the correct refusal.
+    """
+    record = read_run_record(curated_dir)
+    if record is None:
+        return
+    if record.run_id != current_run_id():
+        logger.info(
+            "resolve_run_record_not_ours",
+            minted_by=record.run_id,
+            this_run=current_run_id(),
+            run_status=record.run_status.value,
+        )
+        return
+
+    status = RunStatus.COMPLETE if complete else RunStatus.INCOMPLETE
+    from dataclasses import replace
+
+    _write_record(curated_dir, replace(record, run_status=status, stages=stages))
+    logger.info(
+        "resolve_run_record_finalized",
+        run_status=status.value,
+        canonical_ids=record.canonical_ids,
+        last_writer=record.last_writer,
+    )

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -26,7 +26,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from src.models.enums import DatePrecision
-from src.parse.base import safe_str, write_parquet
+from src.parse.base import safe_str
 from src.parse.identity import make_canonical_id
 from src.parse.name_quality import (
     clean_narrator_name,
@@ -34,6 +34,7 @@ from src.parse.name_quality import (
     is_mubham_relational,
 )
 from src.resolve._inputs import require_input
+from src.resolve._run_record import write_canonical
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
 from src.resolve.sect_affiliation import (
     derive_sect_affiliation,
@@ -380,7 +381,7 @@ def promote_bios_to_canonical(
     for col in ("birth_date_precision", "death_date_precision"):
         arrays[col] = [r.get(col) or DatePrecision.UNKNOWN.value for r in table_rows]
     out_table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
-    write_parquet(out_table, canonical_path, schema=NARRATORS_CANONICAL_SCHEMA)
+    write_canonical(out_table, canonical_path, stage="bio_promote")
 
     # An alias that matched no promoted bio (and was not a cleaner-dropped-bio case)
     # is the one non-attachment worth investigating — surface it loudly so the

--- a/src/resolve/date_reconcile.py
+++ b/src/resolve/date_reconcile.py
@@ -76,7 +76,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from src.models.enums import DatePrecision
-from src.parse.base import safe_str, write_parquet
+from src.parse.base import safe_str
 from src.parse.identity import make_canonical_id
 from src.parse.narrator_dates import (
     MAX_PLAUSIBLE_AH,
@@ -84,6 +84,7 @@ from src.parse.narrator_dates import (
     ParsedDate,
     parse_year_notation,
 )
+from src.resolve._run_record import write_canonical
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
 from src.utils.arabic import normalize_arabic
 from src.utils.hijri import ah_year_to_ce_range
@@ -523,7 +524,7 @@ def reconcile_canonical_dates(
 
     arrays = {f.name: [r.get(f.name) for r in rows] for f in NARRATORS_CANONICAL_SCHEMA}
     out_table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
-    write_parquet(out_table, canonical_path, schema=NARRATORS_CANONICAL_SCHEMA)
+    write_canonical(out_table, canonical_path, stage="reconcile")
 
     logger.info(
         "reconcile_dates_complete",

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -37,6 +37,7 @@ from src.resolve._checkpoint import (
     save_checkpoint,
 )
 from src.resolve._inputs import require_input
+from src.resolve._run_record import write_canonical
 from src.resolve.geography import regions_plausible, resolve_region
 from src.resolve.mononym_split import refine_mononym_name
 from src.resolve.schemas import (
@@ -1581,7 +1582,7 @@ def run(
     # 1. narrators_canonical.parquet
     canonical_table = _build_canonical_table(canonical_map)
     canonical_path = output_dir / "narrators_canonical.parquet"
-    write_parquet(canonical_table, canonical_path, schema=NARRATORS_CANONICAL_SCHEMA)
+    write_canonical(canonical_table, canonical_path, stage="disambiguate")
     output_paths.append(canonical_path)
 
     # 2. ambiguous_narrators.csv

--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -77,7 +77,7 @@ import pyarrow.parquet as pq
 from rapidfuzz import fuzz, process
 
 from src.models.enums import DatePrecision
-from src.parse.base import safe_str, write_parquet
+from src.parse.base import safe_str
 from src.parse.identity import make_canonical_id
 from src.parse.name_quality import is_mubham_relational
 from src.resolve._checkpoint import (
@@ -91,6 +91,7 @@ from src.resolve._checkpoint import (
     resolve_cadence,
     save_checkpoint,
 )
+from src.resolve._run_record import write_canonical
 from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
 from src.resolve.sect_affiliation import derive_sect_affiliation, normalize_corpus, primary_corpus
 from src.utils.logging import get_logger
@@ -1365,7 +1366,7 @@ def cluster_canonical_narrators(
             if len(merged.get("source_corpora") or []) > 1:
                 cross_source += 1
 
-    write_parquet(_build_table(merged_rows), canonical_path, schema=NARRATORS_CANONICAL_SCHEMA)
+    write_canonical(_build_table(merged_rows), canonical_path, stage="cluster")
 
     # Clustering completed and the canonical table is rewritten — drop the
     # checkpoint so the next cold run doesn't spuriously resume (da#272).

--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -129,6 +129,7 @@ from src.models.enums import DatePrecision, NarratorGeneration
 from src.parse.base import safe_str, write_parquet
 from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
 from src.resolve._inputs import require_input
+from src.resolve._run_record import write_canonical
 from src.resolve.generic_name import is_generic_name
 from src.resolve.mononym_split import _MAX_GAP, _MIN_GAP, is_registered_mononym
 from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
@@ -704,10 +705,10 @@ def split_generic_narrators(output_dir: Path, *, staging_dir: Path | None = None
 
     all_records = records + new_rows
     arrays = {f.name: [r.get(f.name) for r in all_records] for f in NARRATORS_CANONICAL_SCHEMA}
-    write_parquet(
+    write_canonical(
         pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA),
         canonical_path,
-        schema=NARRATORS_CANONICAL_SCHEMA,
+        stage="narrator_split",
     )
 
     remapped = _remap_split_mentions(mentions_path, remap)

--- a/src/resolve/tabaqa_dates.py
+++ b/src/resolve/tabaqa_dates.py
@@ -53,7 +53,8 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from src.models.enums import DatePrecision, NarratorGeneration
-from src.parse.base import safe_str, write_parquet
+from src.parse.base import safe_str
+from src.resolve._run_record import write_canonical
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
 from src.utils.hijri import ah_year_to_ce_range
 from src.utils.logging import get_logger
@@ -223,7 +224,7 @@ def apply_tabaqa_fallback(output_dir: Path) -> Path | None:
 
     arrays = {f.name: [r.get(f.name) for r in rows] for f in NARRATORS_CANONICAL_SCHEMA}
     out_table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
-    write_parquet(out_table, canonical_path, schema=NARRATORS_CANONICAL_SCHEMA)
+    write_canonical(out_table, canonical_path, stage="tabaqa_dates")
 
     logger.info(
         "tabaqa_fallback_complete",

--- a/tests/test_resolve/test_run_record.py
+++ b/tests/test_resolve/test_run_record.py
@@ -346,39 +346,180 @@ def test_absent_record_reads_as_none_never_as_zero(tmp_path: Path) -> None:
     assert read_run_record(tmp_path) is None
 
 
-# --- The branch that calls it: no seventh writer may bypass write_canonical ---
-def _bypassing_writers(source: str) -> list[int]:
-    """Line numbers of ``write_parquet(...)`` calls that pass NARRATORS_CANONICAL_SCHEMA.
+# --- run_all actually CALLS finalize_run (da#429 review) ---------------------
+def _run_all_with_spies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, boom: bool = False
+) -> Path:
+    """Drive the real ``run_all`` with no-op stages, except a ``disambiguate`` that
+    genuinely mints a tally through the sanctioned writer.
 
-    Such a call writes the canonical master WITHOUT minting a tally, leaving the record
-    describing bytes that no longer exist. A guard is pinned by the branch that calls it,
-    not by the existence of the function — so this walks the AST of every resolve module.
+    ``boom=True`` makes a later stage raise, so ``run_all`` finishes its sweep and then
+    raises ``ResolveStageError`` (da#360) — the errored path.
+    """
+    from src.resolve import (
+        bio_promote,
+        date_reconcile,
+        dedup,
+        disambiguate,
+        fuzzy_cluster,
+        muhaddithat_links,
+        narrator_split,
+        ner,
+        parallels,
+        run_all,
+        tabaqa_dates,
+    )
+
+    staging = tmp_path / "staging"
+    output = tmp_path / "curated"
+    staging.mkdir()
+    output.mkdir()
+    pq.write_table(pa.table({"x": [1]}), staging / "hadiths_test.parquet")
+
+    def _mint(*_a: object, **_k: object) -> list[Path]:
+        write_canonical(
+            _canonical_table(["nar:a", "nar:b"]), output / CANONICAL, stage="disambiguate"
+        )
+        return []
+
+    monkeypatch.setattr(ner, "run", lambda *_a, **_k: [])
+    monkeypatch.setattr(disambiguate, "run", _mint)
+    monkeypatch.setattr(bio_promote, "promote_bios_to_canonical", lambda *_a, **_k: None)
+    metrics = type("M", (), {"merged_records": 0, "multi_member_clusters": 0})()
+    monkeypatch.setattr(fuzzy_cluster, "cluster_canonical_narrators", lambda *_a, **_k: metrics)
+    monkeypatch.setattr(narrator_split, "split_generic_narrators", lambda *_a, **_k: None)
+    monkeypatch.setattr(date_reconcile, "reconcile_canonical_dates", lambda *_a, **_k: None)
+    monkeypatch.setattr(tabaqa_dates, "apply_tabaqa_fallback", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        muhaddithat_links, "build_muhaddithat_mention_links", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(dedup, "run", lambda *_a, **_k: [])
+
+    def _boom(*_a: object, **_k: object) -> list[Path]:
+        raise ValueError("parallels blew up mid-run")
+
+    monkeypatch.setattr(parallels, "run", _boom if boom else (lambda *_a, **_k: []))
+
+    if boom:
+        from src.resolve import ResolveStageError
+
+        with pytest.raises(ResolveStageError):
+            run_all(tmp_path / "raw", staging, output)
+    else:
+        run_all(tmp_path / "raw", staging, output)
+    return output
+
+
+def test_run_all_finalizes_a_successful_run_to_complete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``run_all`` must actually CALL ``finalize_run`` — the seam, not the function.
+
+    ``write_canonical`` stamps ``incomplete`` on every write, so ``complete`` can ONLY
+    appear if ``run_all`` reached its finalize call. Replace that call with ``pass`` and
+    the entire 2,229-test suite stays green (Oyunbileg Batbayar): nothing asserted that a
+    successful run yields ``complete``. The failure is fail-CLOSED — publish would refuse
+    every healthy run — but it would land as a false-FAIL at the end of a 7.5-hour re-run,
+    on the launch path, which is precisely how an operator gets trained to weaken a gate.
+    """
+    output = _run_all_with_spies(tmp_path, monkeypatch)
+
+    record = read_run_record(output)
+    assert record is not None
+    assert record.run_status is RunStatus.COMPLETE, "run_all never finalized the record"
+    assert record.canonical_ids == 2, "the tally was recomputed, not preserved"
+    assert record.last_writer == "disambiguate"
+    # The per-stage forensics landed too — a hand-authored record cannot fake these.
+    assert any(s.startswith("step=ner ") for s in record.stages)
+
+
+def test_run_all_leaves_an_errored_run_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other direction. A one-sided assertion is half a control.
+
+    Without this, ``finalize_run(..., complete=True)`` unconditionally would satisfy the
+    test above while blessing a run that raised — the exact 'resolve stopped early' mode
+    that no count equality can see.
+    """
+    output = _run_all_with_spies(tmp_path, monkeypatch, boom=True)
+
+    record = read_run_record(output)
+    assert record is not None
+    assert record.run_status is RunStatus.INCOMPLETE, "a run with a raised stage was blessed"
+
+
+# --- The branch that calls it: no seventh writer may bypass write_canonical ---
+# Every function name that can put bytes into a parquet file, in any call form. The
+# detector matches the bare name (`write_parquet(...)`) AND the dotted attribute form
+# (`pq.write_table(...)`, `base.write_parquet(...)`) — a gate must match every syntactic
+# form of the thing it forbids, or it merely relocates the bypass to the form it cannot
+# see. `pq.write_table` is exactly the form the scrub scripts use and the most natural
+# way a future writer would reach for (Jean-Claude Habimana, da#429 review).
+_PARQUET_WRITE_FUNCS = frozenset({"write_parquet", "write_table"})
+
+# The two names that identify the CANONICAL master as the target. `canonical_path` is the
+# load-bearing one: it survives a call form that passes no schema at all.
+_CANONICAL_MARKERS = frozenset({"canonical_path", "NARRATORS_CANONICAL_SCHEMA"})
+
+
+def _bypassing_writers(source: str) -> list[int]:
+    """Line numbers of parquet writes that target the canonical master directly.
+
+    Such a call writes ``narrators_canonical.parquet`` WITHOUT minting a tally, leaving
+    the record describing bytes that no longer exist. A guard is pinned by the branch that
+    calls it, not by the existence of the function — so this walks the AST of every
+    resolve module rather than trusting a convention.
+
+    Residual limit, stated rather than hidden: a schema reached through an alias variable
+    and a path built inline (``pq.write_table(t, out / "narrators_canonical.parquet")``)
+    would slip past. That is a narrower early-warning signal, NOT a safety hole — the md5
+    binding in :func:`write_canonical` is form-agnostic (it hashes bytes and does not care
+    how they arrived), so any bypass still fails closed at publish.
     """
     found: list[int] = []
     for node in ast.walk(ast.parse(source)):
-        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+        if not isinstance(node, ast.Call):
             continue
-        if node.func.id != "write_parquet":
+        func = node.func
+        if isinstance(func, ast.Name):
+            name = func.id
+        elif isinstance(func, ast.Attribute):
+            name = func.attr
+        else:
             continue
-        refs = {
-            n.id for n in ast.walk(node) if isinstance(n, ast.Name)
-        }  # args + keywords, any depth
-        if "NARRATORS_CANONICAL_SCHEMA" in refs:
+        if name not in _PARQUET_WRITE_FUNCS:
+            continue
+        refs = {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
+        if refs & _CANONICAL_MARKERS:
             found.append(node.lineno)
     return found
 
 
-def test_the_bypass_detector_separates_its_two_classes() -> None:
-    """Verify the instrument before reading it: it must FIRE on a bypass and stay silent
-    on the sanctioned writer. A detector that cannot separate the two classes it exists
-    to separate is not producing a measurement."""
-    bypass = "write_parquet(t, canonical_path, schema=NARRATORS_CANONICAL_SCHEMA)"
-    sanctioned = "write_canonical(t, canonical_path, stage='cluster')"
-    other_artifact = "write_parquet(t, audit_path, schema=NARRATOR_SPLITS_SCHEMA)"
+@pytest.mark.parametrize(
+    ("form", "is_bypass"),
+    [
+        # Known-POSITIVES — every call form that really does write the canonical master.
+        ("write_parquet(t, canonical_path, schema=NARRATORS_CANONICAL_SCHEMA)", True),
+        ("pq.write_table(t, canonical_path)", True),  # the form the scrub scripts use
+        ("base.write_parquet(t, canonical_path)", True),  # dotted
+        ("pyarrow.parquet.write_table(t, canonical_path, compression='snappy')", True),
+        # Known-NEGATIVES — must NOT fire.
+        ("write_canonical(t, canonical_path, stage='cluster')", False),
+        ("write_parquet(t, audit_path, schema=NARRATOR_SPLITS_SCHEMA)", False),
+        ("writer.write_table(table)", False),  # streaming ParquetWriter, other artifact
+        ("pq.read_table(canonical_path)", False),  # a READ of the canonical master
+    ],
+)
+def test_the_bypass_detector_separates_its_two_classes(form: str, is_bypass: bool) -> None:
+    """Verify the instrument on BOTH classes before reading it anywhere else.
 
-    assert _bypassing_writers(bypass) == [1], "detector is blind to a real bypass"
-    assert _bypassing_writers(sanctioned) == []
-    assert _bypassing_writers(other_artifact) == []
+    The first version of this detector matched only the bare-name ``write_parquet`` form
+    and was blind to ``pq.write_table(t, canonical_path)`` — a gate that cannot see the
+    most natural way to commit the very bypass it forbids. A detector that cannot separate
+    the two classes it exists to separate is not producing a measurement.
+    """
+    assert bool(_bypassing_writers(form)) is is_bypass
 
 
 # The ONE sanctioned site: write_canonical's own write_parquet call, which mints the

--- a/tests/test_resolve/test_run_record.py
+++ b/tests/test_resolve/test_run_record.py
@@ -1,0 +1,422 @@
+"""The resolve run record — the producer half of the prune completeness binding (da#428).
+
+Every test here defends one property: **the declared count is a tally of the rows the
+writer held in memory, and NOT a read-back of the file it wrote.** A read-back agrees
+perfectly with a truncated parquet, and da#426 measured that shape deleting 83.9% of the
+production graph with ``missing == 0`` and every derived gate green.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.graph.prune import read_canonical_ids
+from src.parse.schemas import NARRATOR_BIO_SCHEMA
+from src.resolve import _run_record
+from src.resolve._run_record import (
+    RESOLVE_RUN_FILENAME,
+    RunStatus,
+    canonical_id_tally,
+    current_run_id,
+    file_md5,
+    finalize_run,
+    read_run_record,
+    write_canonical,
+)
+from src.resolve.bio_promote import promote_bios_to_canonical
+from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+
+CANONICAL = "narrators_canonical.parquet"
+
+
+def _canonical_table(canonical_ids: list[str | None], *, death_year: int | None = None) -> pa.Table:
+    """A canonical table carrying exactly ``canonical_ids`` (dups/empties allowed).
+
+    ``death_year`` models what the date stages actually do: ``reconcile`` and
+    ``tabaqa_dates`` rewrite the file with the SAME row set but different date columns.
+    Without it a fixture for those two stages would be byte-identical to the previous
+    write, and any md5-changed assertion over them would be inert.
+    """
+    rows: list[dict[str, Any]] = []
+    for i, cid in enumerate(canonical_ids):
+        base: dict[str, Any] = {f.name: None for f in NARRATORS_CANONICAL_SCHEMA}
+        base["canonical_id"] = cid
+        base["name_ar"] = f"اسم {i}"
+        base["name_ar_normalized"] = f"اسم {i}"
+        base["mention_count"] = 0
+        base["death_year_ah"] = death_year
+        rows.append(base)
+    arrays = {f.name: [r[f.name] for r in rows] for f in NARRATORS_CANONICAL_SCHEMA}
+    return pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
+
+
+def _write_bio(staging: Path, bio_id: str, name: str) -> None:
+    base: dict[str, Any] = {f.name: None for f in NARRATOR_BIO_SCHEMA}
+    base.update(
+        {
+            "bio_id": bio_id,
+            "source": "itqan",
+            "name_ar": name,
+            "name_ar_normalized": normalize_arabic(name),
+        }
+    )
+    arrays = {f.name: [base[f.name]] for f in NARRATOR_BIO_SCHEMA}
+    pq.write_table(
+        pa.table(arrays, schema=NARRATOR_BIO_SCHEMA),
+        staging / f"narrators_bio_{bio_id.replace(':', '_')}.parquet",
+    )
+
+
+# --- The definition: distinct, non-empty — NOT a row count -------------------
+def test_tally_is_distinct_non_empty_not_a_row_count() -> None:
+    """A duplicate and a falsy id must make ``canonical_ids < rows``, red-first.
+
+    If the producer declared ``len(df)`` the consumer's equality would false-FAIL on
+    any dup/empty — and a false-FAIL on a destructive op sends an operator to "restore
+    from backup" after a prune that did exactly the right thing.
+
+    The ``None`` here is defensive-only and cannot reach a written parquet:
+    ``canonical_id`` is NON-NULLABLE in ``NARRATORS_CANONICAL_SCHEMA``, so the cast in
+    ``write_parquet`` rejects it. The consumer filters falsy anyway, and this tally
+    matches that behaviour exactly, so the two agree on inputs neither can receive.
+    The *representable* hazards — a duplicate and an empty string — are exercised on
+    the real write path in ``test_producer_tally_equals_consumer_read_canonical_ids``.
+    """
+    table = _canonical_table(["nar:a", "nar:b", "nar:b", None, ""])
+
+    assert table.num_rows == 5
+    assert canonical_id_tally(table) == 2  # {nar:a, nar:b}
+    assert canonical_id_tally(table) < table.num_rows
+
+
+def test_producer_tally_equals_consumer_read_canonical_ids(tmp_path: Path) -> None:
+    """Producer and consumer provably count the SAME thing on the same fixture.
+
+    Same definition, different derivation: the tally comes from the in-memory rows,
+    ``read_canonical_ids`` from the written file. This is the equality the whole prune
+    gate hangs on, so it is pinned against the real consumer, not a restatement of it.
+
+    A duplicate and an empty-string id are both present and both survive the write, so
+    ``canonical_ids < rows`` here on a real artifact — the two are NOT interchangeable.
+    """
+    table = _canonical_table(["nar:a", "nar:b", "nar:b", "", "nar:c"])
+    path = tmp_path / CANONICAL
+
+    write_canonical(table, path, stage="disambiguate")
+
+    record = read_run_record(tmp_path)
+    assert record is not None
+    assert record.canonical_ids == len(read_canonical_ids(path)) == 3
+    assert record.canonical_ids < pq.read_table(path).num_rows == 5
+
+
+# --- THE FALSIFIER ----------------------------------------------------------
+def test_tally_is_the_in_memory_count_not_a_read_back_of_a_short_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The writer is handed 100 rows; the disk receives 20. The record must say **100**.
+
+    This is the acceptance criterion of da#428 — *if this test cannot be written, the
+    implementation is a read-back and the issue is not done* — and getting it right took
+    two attempts, which is the whole lesson.
+
+    **A truncation applied AFTER the write does not falsify anything.** A read-back taken
+    at write time has already read the complete file by then, so it reports 100 too, and
+    the test passes under BOTH implementations while appearing to prove the point. That
+    version of this test was written first and a read-back mutant sailed straight through
+    it (``feedback_passing_repro_masks_bug``: a green repro proves nothing if it exercises
+    a different shape than the real failure).
+
+    The shape that actually separates them is the **partial write** — the mode the issue's
+    own table lists as "NOT caught" by a read-back manifest. So ``write_parquet`` is made
+    lossy here: ``write_canonical`` intends 100 rows and the file ends up with 20. An
+    in-memory tally declares what the writer INTENDED (100) and therefore disagrees with
+    the short file — and that disagreement is the entire completeness signal. A read-back
+    declares 20 and agrees with it perfectly, which is precisely how a truncated parquet
+    sails through every gate and deletes 83.9% of the graph (da#426).
+    """
+    full = _canonical_table([f"nar:{i}" for i in range(100)])
+    path = tmp_path / CANONICAL
+
+    real_write_parquet = _run_record.write_parquet
+
+    def _partial_write(table: pa.Table, p: Path, schema: pa.Schema | None = None) -> Path:
+        """The disk gets a fifth of what the writer handed it. Valid parquet, short."""
+        return real_write_parquet(table.slice(0, 20), p, schema=schema)
+
+    monkeypatch.setattr(_run_record, "write_parquet", _partial_write)
+
+    write_canonical(full, path, stage="cluster")
+
+    # The mutation is EFFECTIVE: the file really is short, and really is still a valid,
+    # readable parquet — the dangerous shape, not a corrupt one any reader would reject.
+    assert pq.read_table(path).num_rows == 20
+    assert len(read_canonical_ids(path)) == 20
+
+    # KNOWN-POSITIVE CONTROL: a read-back implementation would declare 20 — it agrees
+    # with the short file by construction. If the record below also said 20, this test
+    # could not tell the two implementations apart and would be worthless.
+    assert canonical_id_tally(pq.read_table(path)) == 20
+
+    # THE PROPERTY: the record declares what the writer INTENDED to write.
+    record = read_run_record(tmp_path)
+    assert record is not None
+    assert record.canonical_ids == 100, "the tally came from the FILE, not from memory"
+    assert record.canonical_ids != len(read_canonical_ids(path))
+
+
+def test_record_is_not_re_derived_when_the_parquet_changes_underneath_it(
+    tmp_path: Path,
+) -> None:
+    """Truncating the file after the fact must not retroactively change the declaration,
+    and must break the md5 binding so the publish refuses the bytes.
+
+    This is NOT the falsifier (see above — a read-back survives it). It pins the weaker
+    but still necessary property that the record is a stored declaration rather than
+    something recomputed on read, and that the tally is bound to the bytes it was taken
+    over.
+    """
+    full = _canonical_table([f"nar:{i}" for i in range(100)])
+    path = tmp_path / CANONICAL
+
+    write_canonical(full, path, stage="cluster")
+    pq.write_table(full.slice(0, 20), path)  # valid, short
+
+    assert len(read_canonical_ids(path)) == 20
+
+    record = read_run_record(tmp_path)
+    assert record is not None
+    assert record.canonical_ids == 100
+    assert record.parquet_md5 != file_md5(path), "the md5 binding did not notice the rewrite"
+
+
+# --- The four-(really six-)writer composition -------------------------------
+def test_bio_promote_after_disambiguate_declares_the_post_bio_promote_count(
+    tmp_path: Path,
+) -> None:
+    """The declared count is the LAST writer's, not the first writer's.
+
+    ``narrators_canonical.parquet`` has six writers. ``disambiguate`` OVERWRITES it;
+    ``bio_promote`` MERGEs into it — and that is not marginal: 43,109 of 129,234
+    canonical ids are bio-only ``mention_count=0`` entries (da#352 ruled these real
+    narrators). A tally taken at ``disambiguate`` would declare ~86k while the file
+    holds ~129k, and the consumer's equality would false-FAIL on every healthy run.
+
+    This drives the REAL ``promote_bios_to_canonical`` stage over a canonical file the
+    disambiguate writer already produced — a test exercising only ``disambiguate`` would
+    pass while being wrong ([[feedback_fixture_makes_guard_assertion_inert]]).
+    """
+    staging = tmp_path / "staging"
+    curated = tmp_path / "curated"
+    staging.mkdir()
+    curated.mkdir()
+    path = curated / CANONICAL
+
+    # Writer 1 — disambiguate OVERWRITES with 2 mention-derived ids.
+    write_canonical(_canonical_table(["nar:a", "nar:b"]), path, stage="disambiguate")
+    assert read_run_record(curated).canonical_ids == 2  # type: ignore[union-attr]
+
+    # Writer 2 — bio_promote MERGEs 2 bio-only narrators in, for real.
+    _write_bio(staging, "itqan:1", "سعيد بن سماك")
+    _write_bio(staging, "itqan:2", "فاطمة بنت محمد")
+    promote_bios_to_canonical(staging, curated)
+
+    # The mutation is effective: bio_promote genuinely ADDED rows.
+    after = read_canonical_ids(path)
+    assert len(after) == 4, "fixture inert — bio_promote added no ids, so it proves nothing"
+
+    record = read_run_record(curated)
+    assert record is not None
+    assert record.last_writer == "bio_promote"
+    assert record.canonical_ids == 4, "declared the disambiguate count, not the merged one"
+    assert record.canonical_ids == len(read_canonical_ids(path))
+
+
+def test_every_writer_re_mints_the_tally_so_the_last_one_wins(tmp_path: Path) -> None:
+    """Each of the six writers re-mints; whichever runs LAST is the one that stands.
+
+    ``reconcile`` and ``tabaqa_dates`` run AFTER ``narrator_split`` and preserve the row
+    set while rewriting the BYTES — so a tally pinned to a named "last" stage would keep
+    a stale md5 even when the count happened to be right. Binding the tally to the write
+    rather than to a stage name is what makes that impossible.
+    """
+    path = tmp_path / CANONICAL
+    seen: list[tuple[str, int, str]] = []
+
+    # death_year models the date stages genuinely rewriting the file with the same rows.
+    for stage, ids, death_year in [
+        ("disambiguate", ["nar:a", "nar:b", "nar:c"], None),
+        ("bio_promote", ["nar:a", "nar:b", "nar:c", "nar:d"], None),
+        ("cluster", ["nar:a", "nar:b", "nar:d"], None),  # fuzzy merge DROPS an id
+        ("narrator_split", ["nar:a", "nar:b", "nar:d", "nar:e"], None),  # peeled row APPENDED
+        ("reconcile", ["nar:a", "nar:b", "nar:d", "nar:e"], 110),  # rows same, BYTES change
+        ("tabaqa_dates", ["nar:a", "nar:b", "nar:d", "nar:e"], 120),  # rows same, BYTES change
+    ]:
+        write_canonical(_canonical_table(ids, death_year=death_year), path, stage=stage)
+        record = read_run_record(tmp_path)
+        assert record is not None
+        assert record.last_writer == stage
+        assert record.canonical_ids == len(set(ids))
+        assert record.parquet_md5 == file_md5(path), f"{stage} left a stale md5"
+        seen.append((stage, record.canonical_ids, record.parquet_md5))
+
+    # The count really does move around across writers (drops AND appends), so the
+    # "last writer wins" assertion above is not vacuously true of a constant.
+    assert [c for _, c, _ in seen] == [3, 4, 3, 4, 4, 4]
+
+    # And the last two writers — which PRESERVE the row set — still changed the BYTES.
+    # This is why the tally cannot be pinned to a stage chosen by name: `narrator_split`
+    # is the last writer to change the COUNT, but `tabaqa_dates` is the last to change
+    # the FILE, and a record naming the former would carry a stale md5 for the latter.
+    split_md5 = next(m for s, _, m in seen if s == "narrator_split")
+    reconcile_md5 = next(m for s, _, m in seen if s == "reconcile")
+    tabaqa_md5 = next(m for s, _, m in seen if s == "tabaqa_dates")
+    assert split_md5 != reconcile_md5 != tabaqa_md5
+    assert tabaqa_md5 == file_md5(path)
+
+
+# --- Fail-closed run status --------------------------------------------------
+def test_write_stamps_incomplete_and_only_finalize_upgrades(tmp_path: Path) -> None:
+    """A write can never declare the run finished; only the end of ``run_all`` can.
+
+    So a killed process, a raised stage or a ``--stop-after`` probe all leave
+    ``incomplete`` on disk. Nothing has to remember to mark failure.
+    """
+    path = tmp_path / CANONICAL
+    write_canonical(_canonical_table(["nar:a"]), path, stage="disambiguate")
+
+    assert read_run_record(tmp_path).run_status is RunStatus.INCOMPLETE  # type: ignore[union-attr]
+
+    finalize_run(tmp_path, ("step=ner outcome=ran files=1",), complete=True)
+    record = read_run_record(tmp_path)
+    assert record is not None
+    assert record.run_status is RunStatus.COMPLETE
+    assert record.canonical_ids == 1  # the tally is preserved, not recomputed
+    assert record.stages == ("step=ner outcome=ran files=1",)
+
+
+def test_finalize_with_errored_stage_leaves_incomplete(tmp_path: Path) -> None:
+    path = tmp_path / CANONICAL
+    write_canonical(_canonical_table(["nar:a"]), path, stage="disambiguate")
+
+    finalize_run(tmp_path, (), complete=False)
+
+    assert read_run_record(tmp_path).run_status is RunStatus.INCOMPLETE  # type: ignore[union-attr]
+
+
+def test_finalize_must_not_upgrade_a_record_it_did_not_mint(tmp_path: Path) -> None:
+    """A resumed run that touched no canonical writer must NOT promote a partial run's
+    tally to ``complete``.
+
+    ``--from-step dedup`` (da#268/da#272) starts past every canonical writer. If
+    ``finalize_run`` stamped ``complete`` on whatever record it found, an earlier run
+    that died half-way would have its short tally blessed by a later run that merely
+    finished — a false PASS reached by an entirely legitimate operation, on a
+    destructive op, with every other gate green.
+    """
+    path = tmp_path / CANONICAL
+    write_canonical(_canonical_table(["nar:a", "nar:b"]), path, stage="disambiguate")
+
+    # Forge the record so it looks like it was minted by a DIFFERENT (earlier) process.
+    record_path = tmp_path / RESOLVE_RUN_FILENAME
+    foreign = record_path.read_text().replace(f"run_id={current_run_id()}", "run_id=someone-else")
+    record_path.write_text(foreign)
+
+    # The mutation is effective: the record no longer claims this run.
+    assert read_run_record(tmp_path).run_id != current_run_id()  # type: ignore[union-attr]
+
+    finalize_run(tmp_path, (), complete=True)
+
+    record = read_run_record(tmp_path)
+    assert record is not None
+    assert record.run_status is RunStatus.INCOMPLETE, "a foreign partial run was blessed complete"
+
+
+def test_absent_record_reads_as_none_never_as_zero(tmp_path: Path) -> None:
+    """A missing instrument reading is a stop, never a silent zero."""
+    assert read_run_record(tmp_path) is None
+    (tmp_path / RESOLVE_RUN_FILENAME).write_text("GARBAGE not-a-record\n")
+    assert read_run_record(tmp_path) is None
+
+
+# --- The branch that calls it: no seventh writer may bypass write_canonical ---
+def _bypassing_writers(source: str) -> list[int]:
+    """Line numbers of ``write_parquet(...)`` calls that pass NARRATORS_CANONICAL_SCHEMA.
+
+    Such a call writes the canonical master WITHOUT minting a tally, leaving the record
+    describing bytes that no longer exist. A guard is pinned by the branch that calls it,
+    not by the existence of the function — so this walks the AST of every resolve module.
+    """
+    found: list[int] = []
+    for node in ast.walk(ast.parse(source)):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+            continue
+        if node.func.id != "write_parquet":
+            continue
+        refs = {
+            n.id for n in ast.walk(node) if isinstance(n, ast.Name)
+        }  # args + keywords, any depth
+        if "NARRATORS_CANONICAL_SCHEMA" in refs:
+            found.append(node.lineno)
+    return found
+
+
+def test_the_bypass_detector_separates_its_two_classes() -> None:
+    """Verify the instrument before reading it: it must FIRE on a bypass and stay silent
+    on the sanctioned writer. A detector that cannot separate the two classes it exists
+    to separate is not producing a measurement."""
+    bypass = "write_parquet(t, canonical_path, schema=NARRATORS_CANONICAL_SCHEMA)"
+    sanctioned = "write_canonical(t, canonical_path, stage='cluster')"
+    other_artifact = "write_parquet(t, audit_path, schema=NARRATOR_SPLITS_SCHEMA)"
+
+    assert _bypassing_writers(bypass) == [1], "detector is blind to a real bypass"
+    assert _bypassing_writers(sanctioned) == []
+    assert _bypassing_writers(other_artifact) == []
+
+
+# The ONE sanctioned site: write_canonical's own write_parquet call, which mints the
+# tally around it. Exempting it by name (rather than by "the detector happens not to see
+# it") keeps the detector able to fire on every other module — including any future one.
+_SANCTIONED_WRITER_MODULE = "_run_record.py"
+
+
+def test_the_sanctioned_writer_is_itself_the_only_exempted_site() -> None:
+    """The exemption is a real, load-bearing hole, so it is asserted rather than assumed.
+
+    If ``write_canonical`` ever stopped writing the canonical master, this fails — and
+    the test below would then be passing while guarding nothing.
+    """
+    source = Path(__file__).resolve().parents[2] / "src" / "resolve" / _SANCTIONED_WRITER_MODULE
+    assert _bypassing_writers(source.read_text(encoding="utf-8")), (
+        "write_canonical no longer writes narrators_canonical.parquet — the exemption "
+        "below is now covering nothing, and the bypass gate has quietly gone inert."
+    )
+
+
+def test_no_resolve_module_writes_the_canonical_master_directly() -> None:
+    """Every canonical write goes through :func:`write_canonical`. A seventh writer that
+    bypasses it fails HERE, rather than silently publishing a stale tally.
+
+    A guard is pinned by the BRANCH THAT CALLS IT, not by the existence of the function:
+    ``write_canonical`` could be perfect and the binding still be worthless if one stage
+    quietly kept calling ``write_parquet`` on the canonical path.
+    """
+    resolve_dir = Path(__file__).resolve().parents[2] / "src" / "resolve"
+    offenders = {
+        py.name: lines
+        for py in sorted(resolve_dir.glob("*.py"))
+        if py.name != _SANCTIONED_WRITER_MODULE
+        if (lines := _bypassing_writers(py.read_text(encoding="utf-8")))
+    }
+    assert offenders == {}, (
+        f"these write narrators_canonical.parquet without minting a tally: {offenders}. "
+        "Use write_canonical(table, path, stage=...) — the tally must be re-minted by "
+        "every writer, because whichever runs LAST is the one the consumer trusts."
+    )

--- a/tests/test_scripts/test_publish_parquet.py
+++ b/tests/test_scripts/test_publish_parquet.py
@@ -15,11 +15,16 @@ import pytest
 
 from scripts.publish_parquet import (
     BUCKET,
+    CANONICAL_PARQUET_NAME,
     CURATED_REQUIRED,
+    MANIFEST_FILENAME,
+    PROVENANCE_REQUIRED,
+    RESOLVE_RUN_FILENAME,
     PlannedUpload,
     PublishError,
     build_rclone_env,
     default_parquet_ref,
+    file_md5,
     main,
     plan_curated,
     plan_staging,
@@ -32,9 +37,25 @@ _FAKE_KEY = "K0ffeeBabeSecretAppKeyValue999"
 
 
 def _make_curated(curated_dir: Path) -> None:
+    """The three curated parquets PLUS the resolve run record they cannot publish without.
+
+    The record is what resolve writes (da#428): an in-memory tally, the run's terminal
+    status, and the md5 of the bytes the tally was taken over. Publish refuses without it.
+    """
     curated_dir.mkdir(parents=True, exist_ok=True)
     for name in CURATED_REQUIRED:
         (curated_dir / name).write_bytes(b"PAR1")
+    _write_run_record(curated_dir)
+
+
+def _write_run_record(
+    curated_dir: Path, *, canonical_ids: int = 129234, status: str = "complete"
+) -> None:
+    md5 = file_md5(curated_dir / CANONICAL_PARQUET_NAME)
+    (curated_dir / RESOLVE_RUN_FILENAME).write_text(
+        f"RESOLVE_RUN canonical_ids={canonical_ids} run_status={status} git_sha=abc1234 "
+        f"run_id=1-deadbeef last_writer=tabaqa_dates parquet_md5={md5} parquet_bytes=4\n"
+    )
 
 
 def _make_staging(staging_dir: Path, *, full: bool) -> None:
@@ -135,6 +156,7 @@ def test_verify_remote_passes_when_all_present() -> None:
     ]
     listing = {
         *(f"curated/{n}" for n in CURATED_REQUIRED),
+        *(f"curated/{n}" for n in PROVENANCE_REQUIRED),
         "staging/hadiths_bukhari.parquet",
     }
     verify_remote(listing, plan)  # no raise
@@ -151,6 +173,20 @@ def test_verify_remote_missing_curated_raises() -> None:
     plan: list[PlannedUpload] = []
     listing = {f"curated/{CURATED_REQUIRED[0]}"}  # only 1 of 3 curated present
     with pytest.raises(PublishError, match="required curated object"):
+        verify_remote(listing, plan)
+
+
+@pytest.mark.parametrize("absent", PROVENANCE_REQUIRED)
+def test_verify_remote_requires_both_provenance_objects(absent: str) -> None:
+    """A ref whose parquets landed but whose provenance did not is a ref the consumer
+    REFUSES to prune against. It must fail here, at publish, and not surface as a
+    mysterious refusal on the production box mid-destructive-op (da#428)."""
+    plan: list[PlannedUpload] = []
+    listing = {
+        *(f"curated/{n}" for n in CURATED_REQUIRED),
+        *(f"curated/{n}" for n in PROVENANCE_REQUIRED if n != absent),
+    }
+    with pytest.raises(PublishError, match=f"curated/{absent}"):
         verify_remote(listing, plan)
 
 
@@ -218,6 +254,7 @@ def test_publish_copy_only_and_no_secret_on_argv(
             listing = "\n".join(
                 [
                     *(f"curated/{n}" for n in CURATED_REQUIRED),
+                    *(f"curated/{n}" for n in PROVENANCE_REQUIRED),
                     "staging/hadiths_bukhari.parquet",
                     "staging/collections_all.parquet",
                     "staging/narrator_mentions_all.parquet",
@@ -243,9 +280,16 @@ def test_publish_copy_only_and_no_secret_on_argv(
     assert rc == 0
     assert capsys.readouterr().out.strip().splitlines()[-1] == ref
 
-    # 8 objects copied + 1 lsf verification.
+    # 8 data objects + the 2 provenance objects (da#428) copied, + 1 lsf verification.
     copy_calls = [c for c in calls if "copyto" in c]
-    assert len(copy_calls) == 8
+    assert len(copy_calls) == 10
+
+    # The manifest goes up LAST of all, so its mere presence in the bucket is itself the
+    # evidence that the publish ran to completion — a half-finished publish cannot leave
+    # a ref that looks complete to the consumer.
+    assert copy_calls[-1][-1].endswith(f"/curated/{MANIFEST_FILENAME}")
+    assert copy_calls[-2][-1].endswith(f"/curated/{RESOLVE_RUN_FILENAME}")
+
     # Copy-only: never a destructive rclone verb against the bucket.
     for cmd in calls:
         assert not ({"sync", "delete", "purge", "deletefile", "rmdir"} & set(cmd))

--- a/tests/test_scripts/test_publish_parquet.py
+++ b/tests/test_scripts/test_publish_parquet.py
@@ -207,6 +207,126 @@ def test_build_rclone_env_sets_native_vars(monkeypatch: pytest.MonkeyPatch) -> N
     assert env["RCLONE_CONFIG_PIPELINE_KEY"] == _FAKE_KEY
 
 
+# --- The gate is wired into main(), not merely defined (da#429 review) --------
+@pytest.mark.parametrize(
+    ("defect", "reason"),
+    [
+        ("incomplete", "did NOT complete"),
+        ("md5", "NOT the file resolve took its tally over"),
+        ("absent", "absent or malformed"),
+    ],
+)
+def test_main_refuses_a_bad_keep_set_and_uploads_NOTHING(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    defect: str,
+    reason: str,
+) -> None:
+    """``main()`` must actually CALL ``assert_run_publishable`` — and upload nothing.
+
+    Every other refusal test in this suite calls ``assert_run_publishable`` directly as a
+    unit, which pins the FUNCTION but not the BRANCH THAT CALLS IT. Oyunbileg Batbayar
+    deleted the call from ``_run()`` and all 38 publish tests still passed — while
+    ``rclone copyto ... narrators_canonical.parquet`` actually fired and an unbacked
+    keep-set reached the upload. That is the exact failure this PR names in
+    ``test_no_resolve_module_writes_the_canonical_master_directly`` and then committed
+    itself, one layer up.
+
+    The reason is asserted, not merely a non-zero exit: adding a guard EARLIER can
+    silently un-test every guard behind it, so "it refused" is not evidence that the door
+    under test is the one that fired.
+    """
+    curated = tmp_path / "curated"
+    _make_curated(curated)
+    _make_staging(tmp_path / "staging", full=True)
+    monkeypatch.setenv("PIPELINE_B2_KEY_ID", _FAKE_KEY_ID)
+    monkeypatch.setenv("PIPELINE_B2_KEY", _FAKE_KEY)
+    monkeypatch.setattr("scripts.publish_parquet.shutil.which", lambda _b: "/usr/bin/rclone")
+
+    if defect == "incomplete":
+        _write_run_record(curated, status="incomplete")
+    elif defect == "md5":
+        # The tally was taken over other bytes — a resume that skipped every canonical
+        # writer, or a scrub script that rewrote the parquet outside the sanctioned writer.
+        (curated / CANONICAL_PARQUET_NAME).write_bytes(b"PAR1-rewritten-after-the-tally")
+    elif defect == "absent":
+        (curated / RESOLVE_RUN_FILENAME).unlink()
+
+    calls: list[list[str]] = []
+
+    def _record(cmd: list[str], **_kwargs: object) -> object:
+        calls.append(cmd)
+        raise AssertionError(f"rclone must never be invoked for a refused keep-set: {cmd}")
+
+    monkeypatch.setattr("scripts.publish_parquet.subprocess.run", _record)
+
+    rc = main(
+        [
+            "--parquet-ref",
+            "staged/narrator-resolve/2026-07-11-abc1234",
+            "--curated-dir",
+            str(curated),
+            "--staging-dir",
+            str(tmp_path / "staging"),
+        ]
+    )
+
+    assert rc != 0, "publish ACCEPTED an artifact the consumer will refuse"
+    assert reason in capsys.readouterr().err, "refused — but NOT by the door under test"
+    assert calls == [], "an unbacked keep-set was uploaded to B2"
+
+
+def test_main_publishes_the_healthy_artifact(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The known-negative for the three refusals above.
+
+    Without it, deleting the gate's call site and replacing it with an unconditional
+    ``raise`` would satisfy every test above — a publisher that refuses EVERYTHING,
+    including the healthy artifact it exists to ship.
+    """
+    curated = tmp_path / "curated"
+    _make_curated(curated)
+    _make_staging(tmp_path / "staging", full=True)
+    monkeypatch.setenv("PIPELINE_B2_KEY_ID", _FAKE_KEY_ID)
+    monkeypatch.setenv("PIPELINE_B2_KEY", _FAKE_KEY)
+    monkeypatch.setattr("scripts.publish_parquet.shutil.which", lambda _b: "/usr/bin/rclone")
+
+    def _fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "lsf" in cmd:
+            listing = "\n".join(
+                [
+                    *(f"curated/{n}" for n in CURATED_REQUIRED),
+                    *(f"curated/{n}" for n in PROVENANCE_REQUIRED),
+                    "staging/hadiths_bukhari.parquet",
+                    "staging/collections_all.parquet",
+                    "staging/narrator_mentions_all.parquet",
+                    "staging/network_edges_studied.parquet",
+                    "staging/parallel_links.parquet",
+                ]
+            )
+            return subprocess.CompletedProcess(cmd, 0, stdout=listing, stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("scripts.publish_parquet.subprocess.run", _fake_run)
+
+    rc = main(
+        [
+            "--parquet-ref",
+            "staged/narrator-resolve/2026-07-11-abc1234",
+            "--curated-dir",
+            str(curated),
+            "--staging-dir",
+            str(tmp_path / "staging"),
+        ]
+    )
+
+    assert rc == 0, "the gate refused a HEALTHY artifact — a false-FAIL on the launch path"
+    # The tally is copied forward verbatim; the publisher declares no count of its own.
+    assert "canonical_ids=129234" in capsys.readouterr().err
+
+
 # --- CLI wiring -------------------------------------------------------------
 def test_dry_run_uploads_nothing_and_echoes_ref(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch

--- a/tests/test_scripts/test_publish_provenance.py
+++ b/tests/test_scripts/test_publish_provenance.py
@@ -1,0 +1,221 @@
+"""The publisher half of the prune completeness binding (da#428).
+
+``publish_parquet.py`` is a SEPARATE PROCESS that starts after resolve has exited. It
+holds no tally, so any count it emitted could only be a read-back of the parquet it is
+about to upload — which agrees perfectly with a truncated one. These tests pin the two
+properties that make that impossible rather than merely discouraged:
+
+1. it REFUSES to publish a keep-set whose tally is absent, partial, or describes
+   different bytes than the ones about to be shipped; and
+2. it is STRUCTURALLY incapable of counting — it never imports pyarrow.
+
+Each refusal asserts the REASON, not merely a non-zero exit: adding a guard earlier can
+silently un-test every guard behind it, so "it raised" is not evidence that the door
+under test is the one that fired.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.publish_parquet import (
+    CANONICAL_PARQUET_NAME,
+    CURATED_REQUIRED,
+    RESOLVE_RUN_FILENAME,
+    PlannedUpload,
+    PublishError,
+    assert_run_publishable,
+    file_md5,
+    manifest_line,
+    parse_resolve_run,
+    render_manifest,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _curated(tmp_path: Path, *, status: str = "complete", canonical_ids: int = 129234) -> Path:
+    curated = tmp_path / "curated"
+    curated.mkdir(parents=True, exist_ok=True)
+    for name in CURATED_REQUIRED:
+        (curated / name).write_bytes(b"PAR1" + name.encode())
+    md5 = file_md5(curated / CANONICAL_PARQUET_NAME)
+    (curated / RESOLVE_RUN_FILENAME).write_text(
+        f"RESOLVE_RUN canonical_ids={canonical_ids} run_status={status} git_sha=abc1234 "
+        f"run_id=1-dead last_writer=tabaqa_dates parquet_md5={md5} parquet_bytes=8\n"
+        "RESOLVE_STAGE step=ner outcome=ran files=1\n"
+    )
+    return curated
+
+
+def _decl(curated: Path):  # noqa: ANN202 — test helper
+    return parse_resolve_run((curated / RESOLVE_RUN_FILENAME).read_text())
+
+
+# --- The record parses exactly as the consumer parses it ---------------------
+def test_parses_the_consumer_contract_line(tmp_path: Path) -> None:
+    curated = _curated(tmp_path)
+    decl = _decl(curated)
+    assert decl is not None
+    assert decl.canonical_ids == 129234
+    assert decl.run_status == "complete"
+    assert decl.parquet_md5 == file_md5(curated / CANONICAL_PARQUET_NAME)
+
+
+def test_whole_token_extraction_cannot_be_hijacked_by_a_longer_key() -> None:
+    """``parquet_md5=`` must never answer for ``md5=`` (the da#419 whole-token rule)."""
+    decl = parse_resolve_run(
+        "RESOLVE_RUN canonical_ids=7 run_status=complete parquet_md5=deadbeef "
+        "extra_canonical_ids=9\n"
+    )
+    assert decl is not None
+    assert decl.canonical_ids == 7  # NOT 9
+    assert decl.parquet_md5 == "deadbeef"
+
+
+# --- The refusal doors. Each asserts its own REASON. -------------------------
+def test_refuses_when_the_record_is_absent(tmp_path: Path) -> None:
+    curated = _curated(tmp_path)
+    (curated / RESOLVE_RUN_FILENAME).unlink()
+
+    with pytest.raises(PublishError, match="absent or malformed"):
+        assert_run_publishable(None, file_md5(curated / CANONICAL_PARQUET_NAME))
+
+
+def test_refuses_when_the_run_did_not_complete(tmp_path: Path) -> None:
+    """The 'resolve stopped early' mode. No count equality of any kind can see it: the
+    tally and the file are both short and perfectly consistent."""
+    curated = _curated(tmp_path, status="incomplete")
+
+    with pytest.raises(PublishError, match="did NOT complete"):
+        assert_run_publishable(_decl(curated), file_md5(curated / CANONICAL_PARQUET_NAME))
+
+
+def test_refuses_a_zero_id_keep_set(tmp_path: Path) -> None:
+    curated = _curated(tmp_path, canonical_ids=0)
+
+    with pytest.raises(PublishError, match="delete every narrator"):
+        assert_run_publishable(_decl(curated), file_md5(curated / CANONICAL_PARQUET_NAME))
+
+
+def test_refuses_when_the_tally_describes_different_bytes(tmp_path: Path) -> None:
+    """The skipped-tally-stage door, and the scrub-script door, are the same door.
+
+    ``--from-step`` (da#268/da#272) can start past every canonical writer, so no tally is
+    minted this run; a scrub script can rewrite the parquet outside the sanctioned writer.
+    Both leave a record describing bytes that are no longer on disk. A skipped tally is
+    not a smaller number — it is NO number — and the publisher must never fall back to
+    counting the file itself.
+    """
+    curated = _curated(tmp_path)
+
+    # The mutation is EFFECTIVE: the parquet really changed after the tally was taken.
+    before = file_md5(curated / CANONICAL_PARQUET_NAME)
+    (curated / CANONICAL_PARQUET_NAME).write_bytes(b"PAR1-rewritten-by-a-scrub-script")
+    after = file_md5(curated / CANONICAL_PARQUET_NAME)
+    assert before != after, "mutation disarmed — the file did not actually change"
+
+    with pytest.raises(PublishError, match="NOT the file resolve took its tally over"):
+        assert_run_publishable(_decl(curated), after)
+
+
+def test_accepts_a_complete_run_whose_tally_matches(tmp_path: Path) -> None:
+    """The known-negative. Without this, every refusal above could be a guard that
+    refuses everything — including the honest artifact the gate exists to let through."""
+    curated = _curated(tmp_path)
+
+    assert_run_publishable(_decl(curated), file_md5(curated / CANONICAL_PARQUET_NAME))  # no raise
+
+
+# --- The manifest declares md5 + bytes, and NEVER a count --------------------
+def test_manifest_carries_no_count_at_all(tmp_path: Path) -> None:
+    """The consumer REFUSES a manifest that declares ``canonical_ids`` — a publisher that
+    thinks it knows the count has read the file back. This asserts the exact grep the
+    consumer runs (``^CANONICAL_MANIFEST .*canonical_ids=``) finds nothing."""
+    curated = _curated(tmp_path)
+    uploads = [PlannedUpload(curated / n, f"curated/{n}") for n in CURATED_REQUIRED]
+
+    body = render_manifest(uploads)
+
+    assert "canonical_ids" not in body
+    assert "rows=" not in body
+    for line in body.splitlines():
+        assert line.startswith("CANONICAL_MANIFEST ")
+        assert "canonical_ids=" not in line
+
+
+def test_manifest_line_binds_each_curated_object_to_its_bytes(tmp_path: Path) -> None:
+    curated = _curated(tmp_path)
+    uploads = [PlannedUpload(curated / n, f"curated/{n}") for n in CURATED_REQUIRED]
+
+    lines = render_manifest(uploads).strip().splitlines()
+
+    assert len(lines) == len(CURATED_REQUIRED)
+    canonical = next(ln for ln in lines if f"file={CANONICAL_PARQUET_NAME} " in ln + " ")
+    assert f"md5={file_md5(curated / CANONICAL_PARQUET_NAME)}" in canonical
+    assert f"bytes={(curated / CANONICAL_PARQUET_NAME).stat().st_size}" in canonical
+
+
+def test_manifest_excludes_staging_objects(tmp_path: Path) -> None:
+    curated = _curated(tmp_path)
+    uploads = [
+        PlannedUpload(curated / CANONICAL_PARQUET_NAME, f"curated/{CANONICAL_PARQUET_NAME}"),
+        PlannedUpload(curated / CANONICAL_PARQUET_NAME, "staging/hadiths_bukhari.parquet"),
+    ]
+    assert len(render_manifest(uploads).strip().splitlines()) == 1
+
+
+def test_manifest_line_format_is_the_consumer_token_shape() -> None:
+    line = manifest_line("narrators_canonical.parquet", "0" * 32, 4096)
+    assert line == (
+        f"CANONICAL_MANIFEST file=narrators_canonical.parquet md5={'0' * 32} bytes=4096"
+    )
+    # Whole-token parseable: every token is exactly one `key=value`, no spaces in values.
+    assert all(tok.count("=") == 1 for tok in line.split(" ")[1:])
+
+
+# --- The structural property: the publisher CANNOT count ---------------------
+def _imports_pyarrow(module: str) -> bool:
+    """Import ``module`` in a FRESH interpreter and report whether pyarrow got pulled in.
+
+    A subprocess is mandatory: inside the pytest process pyarrow is already in
+    ``sys.modules`` (the producer tests import it), so an in-process check would report
+    True for everything and be a detector that cannot separate its two classes.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", f"import {module}, sys; print('pyarrow' in sys.modules)"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+    return proc.stdout.strip() == "True"
+
+
+def test_the_pyarrow_detector_separates_its_two_classes() -> None:
+    """Verify the instrument before reading it: a module that DOES import pyarrow must
+    come back True, or the assertion below proves nothing (a silent False for every
+    input would 'pass' while measuring nothing)."""
+    assert _imports_pyarrow("src.resolve._run_record") is True, (
+        "detector is blind — it cannot see pyarrow even when present"
+    )
+    assert _imports_pyarrow("json") is False
+
+
+def test_publish_parquet_cannot_count_because_it_never_imports_pyarrow() -> None:
+    """The read-back is STRUCTURALLY impossible, not merely discouraged.
+
+    If this module ever imports pyarrow — directly, or transitively by importing
+    ``src.resolve`` — it acquires the ability to read the parquet back and declare a
+    count, and the circularity is silently relocated from the operator to the publisher,
+    wearing the words "producer-signed provenance" and a green md5. That is the exact
+    failure da#428 exists to prevent, so it is asserted at the import graph, not in prose.
+    """
+    assert _imports_pyarrow("scripts.publish_parquet") is False, (
+        "publish_parquet imports pyarrow — it can now read the parquet back and count it. "
+        "The publisher must copy resolve's tally forward, never recompute it."
+    )


### PR DESCRIPTION
## What

The **producer half** of the prune completeness binding. deploy#574 is merged and **inert until this lands** — it requires provenance objects in B2 and refuses every ref published today.

`prune-narrators` can delete **83.9% of the production graph** against a *valid but truncated* parquet, with `missing == 0` and every derived gate green (da#426). There are no backups yet. Every gate in the prune path is derived from the keep-set it validates, so all of them prove the prune obeyed the parquet and **none can ask whether it was the WHOLE parquet**. Only the process that *wrote* the file can supply that.

Two artifacts, each declaring only what its author can honestly attest:

| artifact | written by | declares |
|---|---|---|
| `curated/_resolve_run.txt` | **resolve** (`src/resolve/_run_record.py`) | `canonical_ids` (in-memory tally, **before** the write), `run_status`, git sha, per-stage outcomes |
| `curated/_manifest.txt` | `publish_parquet.py` | **md5 + bytes ONLY** — forbidden from declaring a count |

Publish **copies the tally forward and never recomputes it.**

## Three things in the issue were wrong. Verified at the artifact.

**1. There are SIX writers of `narrators_canonical.parquet`, not four.** The issue names `disambiguate`, `bio_promote`, `cluster`, `narrator_split`. It misses **`reconcile`** (`date_reconcile.py:527`) and **`tabaqa_dates`** (`tabaqa_dates.py:227`) — both of which run *after* `narrator_split` in `RESOLVE_STEP_ORDER` and rewrite the file (row set preserved, **bytes changed**). So the issue's own prescription — "the tally is taken by the LAST writer" — names the wrong stage, and a tally pinned there would ship a **stale md5**.

The cure is to stop naming stages. `write_canonical()` is the single sanctioned writer; it re-mints the tally on every call, so whichever writer runs last is automatically the one that stands. A seventh writer inherits the guarantee, and an AST gate fails CI if one ever bypasses it (a guard is pinned by the branch that calls it).

**2. A null `canonical_id` is unrepresentable.** The issue asks for a red-first test with "a duplicate and a null". `canonical_id` is **non-nullable** in `NARRATORS_CANONICAL_SCHEMA` — the cast in `write_parquet` rejects it. The representable hazards are a **duplicate and an empty string**, and those are what the write-path test uses. The count is DISTINCT NON-EMPTY either way, matching `read_canonical_ids()` exactly.

**3. "Refuse if the tally-minting stage was skipped" is a proxy for the real property**, and a leaky one — it does not catch `scripts/scrub_matn_canonical.py` / `scrub_relational_pollution.py`, which rewrite the canonical parquet *outside resolve entirely*. What publish actually enforces is the property itself: **is this file the one the tally was taken over, from a run that finished?** The record carries the md5 of the bytes the tally was minted against; publish refuses if it does not match. That is strictly stronger and catches the scrub-script hole too. The md5 binds tally to bytes — it cannot *produce* a count, so it introduces no circularity.

## Fail-closed by construction

Every `write_canonical` stamps `run_status=incomplete` — at the moment of a write the run has not finished. Only the successful end of `run_all` upgrades it. A killed process, a raised stage, a `--stop-after` probe all leave `incomplete` on disk and publish refuses; **nothing has to remember to mark failure**. And `finalize_run` refuses to upgrade a record it did not mint, so a `--from-step dedup` resume cannot bless an earlier *partial* run's tally as `complete` — a false PASS reachable by an entirely legitimate operation.

## The falsifier, and why the obvious version of it is worthless

The acceptance criterion is: truncate the parquet after the tally is taken and the record must still declare the original count. **I wrote that test first and a read-back mutant sailed straight through it.** A read-back taken at write time has already read the *complete* file by then, so it reports 100 too — the test passes under both implementations while appearing to prove the point.

The shape that actually separates them is the **partial write**: `write_parquet` is made lossy, the writer intends 100 rows, the disk receives 20. An in-memory tally declares 100 and disagrees with the file — that disagreement *is* the completeness signal. A read-back declares 20 and agrees with it perfectly.

Every guard here was mutation-tested: each mutant was verified to actually reach the forbidden state, and each was killed **by its own guard, naming its own reason** (a non-zero exit is not evidence the check under test fired).

## Verified against the real merged consumer

Ran deploy's actual `scripts/verify_prune_provenance.sh` against artifacts this producer generates:

- **accepts** the healthy artifact -> `PRUNE_PROVENANCE canonical_ids=129234 run_status=complete md5=e00466d1...`
- the completeness equality **holds on a healthy run** (129,234 declared == 129,234 read) — no false-FAIL, which was the whole hazard of correction 2
- **refuses** each defect naming the right reason: no record; `run_status=incomplete`; a manifest declaring a count; changed bytes; wrong operator expectation

(My first run of this was **vacuous** — rc=127, the gate script was not in the local deploy checkout, so every "refusal" was just bash failing to find the file. The known-positive control is what caught it.)

## Also structural

`publish_parquet.py` **provably never imports pyarrow** — asserted by executing it in a subprocess and checking `sys.modules`, with the detector verified on a known-positive first. It therefore *cannot* read the parquet back and count it. The read-back is impossible, not discouraged.

## Testing

- `mypy src/` clean (CI's exact command). The 8 pre-existing `scripts/` mypy errors are identical on `origin/main` and outside CI's scope.
- ruff format + lint clean.
- CI unit job green: 2,230 passed, 10 skipped.
- Integration job needs Docker (down on this box; runs in CI). No test asserts exact curated-dir contents, so the new sidecar cannot break one.

Closes #428.

Technical debt introduced by this change: none.
