### PR TITLE
fix(loader): guard save_manifest cleanup unlink on read-only FS (da#432)

### DIFF
--- a/src/pipeline/manifest.py
+++ b/src/pipeline/manifest.py
@@ -134,7 +134,14 @@ def save_manifest(manifest: dict[str, dict[str, Any]], path: Path) -> Path | Non
         tmp.replace(path)
     except OSError:
         logger.warning("manifest_write_failed", path=str(path))
-        tmp.unlink(missing_ok=True)
+        # The cleanup unlink is itself a write op: on a read-only filesystem (the
+        # graph-load `/app/data:ro` mount) it raises OSError(EROFS), which
+        # missing_ok= does NOT swallow (that catches only FileNotFoundError). Guard
+        # it so save_manifest stays truly best-effort and never aborts the load (da#432).
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
         return None
 
     return path

--- a/tests/test_pipeline/test_manifest_integrity.py
+++ b/tests/test_pipeline/test_manifest_integrity.py
@@ -14,6 +14,7 @@ Every choice below is biased toward re-loading.
 
 from __future__ import annotations
 
+import errno
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -182,6 +183,31 @@ class TestManifestWriteIsAtomic:
         # The previous manifest survives intact and no debris is left in the dir.
         assert json.loads(target.read_text()) == {"staging/a.parquet": {"md5": "old"}}
         assert list(tmp_path.iterdir()) == [target]
+
+    def test_save_manifest_is_best_effort_on_read_only_filesystem(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A read-only /app/data must degrade to a warning, never crash the load (da#432).
+
+        On the ``:ro`` graph-load mount the tmp write raises ``OSError(EROFS)``.
+        da#349 caught that, but its cleanup ``tmp.unlink(missing_ok=True)`` is itself
+        a write op that *also* raises ``EROFS`` on a read-only FS -- and ``missing_ok``
+        only swallows ``FileNotFoundError``, not ``EROFS`` -- so the cleanup re-raised
+        and aborted the whole ``load``. Model both failures and assert ``save_manifest``
+        returns ``None`` without propagating.
+        """
+        target = tmp_path / LAST_LOADED_MANIFEST_FILENAME
+
+        def _erofs(*_args: Any, **_kwargs: Any) -> None:
+            raise OSError(errno.EROFS, "Read-only file system")
+
+        # Both the write AND the cleanup unlink fail with EROFS, exactly as a
+        # read-only filesystem behaves (unlink of any name raises EROFS before ENOENT).
+        monkeypatch.setattr(Path, "write_text", _erofs)
+        monkeypatch.setattr(Path, "unlink", _erofs)
+
+        # Must not raise; best-effort write returns None.
+        assert save_manifest({"staging/b.parquet": {"md5": "new"}}, target) is None
 
 
 class TestCorruptManifestFailsSafe:


### PR DESCRIPTION
## What

Complete da#349's best-effort guard in `save_manifest`: wrap the cleanup `tmp.unlink(missing_ok=True)` so it cannot re-raise on a **read-only filesystem**.

## Why

The stg narrator reload (deploy-data-load run 29197974643, 2026-07-12) failed with loader `rc=1`, nothing committed:

```
OSError: [Errno 30] Read-only file system: 'data/.manifest.json.tmp'
  manifest.py:133 tmp.write_text(...)          # caught by da#349's except
During handling of the above exception, another exception occurred:
  manifest.py:137 tmp.unlink(missing_ok=True)  # UNCAUGHT -> crashes load
  cli.py:235 save_manifest(current_manifest, data_dir / MANIFEST_FILENAME)
```

`graph-load` mounts `/app/data:ro` **by intent** (deploy `compose/docker-compose.prod.yml`, citing da#348). da#349 made the *write* best-effort, but its own cleanup `unlink` is a write op too and raises `EROFS` on a read-only FS — and `missing_ok=` swallows only `FileNotFoundError`, not `EROFS`. da#374 then put `save_manifest()` on the load path, so every load now trips it. (#723's 07-05 prod load predates both PRs, which is why it worked.)

## Fix

3-line guard around the cleanup unlink — loader-side only. The `:ro` mount is correct and unchanged.

## Test

New regression test `test_save_manifest_is_best_effort_on_read_only_filesystem` models a read-only FS (both `write_text` and `unlink` raise `OSError(EROFS)`) and asserts `save_manifest` returns `None` without propagating. **Verified RED against the unfixed code** (raised at `manifest.py:137`) before the fix; green after. Full manifest + load-exit-code suites (35 tests) pass; mypy + ruff clean.

Closes #432
