### PR TITLE
fix(validate): collection_coverage must FAIL on NULL expected_count (#382)

### DIFF
--- a/src/graph/validate.py
+++ b/src/graph/validate.py
@@ -301,13 +301,33 @@ def _classify_collection_coverage(
     rows: list[dict[str, object]],
     deviation_threshold: float,
 ) -> ValidationResult:
+    """Compare expected vs actual hadith counts per collection.
+
+    A collection fails the gate two ways:
+
+    * ``deviation_pct`` exceeds ``deviation_threshold`` — the loaded count
+      strayed too far from the collection's ``expected_count``.
+    * ``deviation_pct`` is NULL — the collection carries no ``expected_count``
+      (the cypher's ``CASE ... ELSE null`` arm), so coverage is **un-evaluable**.
+      The predecessor *skipped* those rows and then reported "all within
+      threshold", so a collection that loaded 0 of its 650,986 rows was rolled
+      into a green summary — a false PASS hiding a total load failure (da#382).
+      An un-evaluable collection is not a healthy one: it fails the gate. Only a
+      numeric deviation within threshold is a positive PASS.
+    """
     count = len(rows)
     failures: list[str] = []
     for row in rows:
+        cid = row.get("collection_id", "?")
         dev = row.get("deviation_pct")
-        if dev is not None and isinstance(dev, int | float) and dev > deviation_threshold:
-            cid = row.get("collection_id", "?")
-            failures.append(f"{cid}: {dev:.1f}% deviation")
+        if isinstance(dev, int | float):
+            if dev > deviation_threshold:
+                failures.append(f"{cid}: {dev:.1f}% deviation")
+        else:
+            actual = row.get("actual", "?")
+            failures.append(
+                f"{cid}: expected_count missing — coverage un-evaluable (actual={actual})"
+            )
     passed = len(failures) == 0
     details = "all within threshold" if passed else "; ".join(failures)
     return ValidationResult(query_name, passed, details, count)

--- a/tests/test_graph/test_validate.py
+++ b/tests/test_graph/test_validate.py
@@ -181,12 +181,39 @@ class TestCollectionCoverageClassification:
         result = _classify("collection_coverage", rows)
         assert result.passed is False
 
-    def test_null_expected_is_pass(self) -> None:
+    def test_null_expected_is_fail(self) -> None:
+        """da#382: a NULL/missing ``expected_count`` makes coverage un-evaluable.
+
+        The cypher returns ``deviation_pct = null`` for a collection whose
+        ``expected_count`` is NULL. The old classifier *skipped* that row and
+        reported "all within threshold" — so a collection that loaded 0 of its
+        650,986 rows was silently reported healthy. An un-evaluable collection
+        must FAIL the gate, not silently pass.
+        """
         rows: list[dict[str, object]] = [
-            {"collection_id": "col:unknown", "expected": None, "actual": 42, "deviation_pct": None},
+            {"collection_id": "col:unknown", "expected": None, "actual": 0, "deviation_pct": None},
         ]
         result = _classify("collection_coverage", rows)
-        assert result.passed is True
+        assert result.passed is False
+        assert result.is_fatal is True
+        assert "col:unknown" in result.details
+
+    def test_null_expected_not_masked_by_healthy_sibling(self) -> None:
+        """The un-evaluable collection must fail the whole run even when another
+        collection is genuinely within threshold — the failure cannot be rolled
+        into a green 'all within threshold' summary (da#382)."""
+        rows: list[dict[str, object]] = [
+            {
+                "collection_id": "col:bukhari",
+                "expected": 7563,
+                "actual": 7500,
+                "deviation_pct": 0.83,
+            },
+            {"collection_id": "col:empty", "expected": None, "actual": 0, "deviation_pct": None},
+        ]
+        result = _classify("collection_coverage", rows)
+        assert result.passed is False
+        assert "col:empty" in result.details
 
 
 class TestCypherFileLoading:


### PR DESCRIPTION
## Summary

`collection_coverage` validation reported a **false PASS** for a collection that loaded 0 of 650,986 rows. `_classify_collection_coverage` skipped every row whose `deviation_pct` was NULL — the cypher's `CASE WHEN c.expected_count IS NOT NULL ... ELSE null` arm — and then reported "all within threshold". So a collection with a missing `expected_count` that loaded nothing was silently rolled into a green summary, hiding a total load failure.

This is the exact blind spot already documented in `tests/test_graph/test_malformed_id_exit.py`: *"collection_coverage cannot measure a collection with a NULL expected_count, which is 67 of 68 (da#382)."*

## Fix

Switch to **positive classification**: only a numeric deviation within threshold PASSes. A NULL/missing `expected_count` is un-evaluable and now **fails the gate** with an explicit `expected_count missing — coverage un-evaluable (actual=N)` detail. A collection that DOES have a real `expected_count` within threshold still passes unchanged.

## Red → green evidence

QA red-first. Two tests were written to fail on current `main` and pass after the fix:

- `test_null_expected_is_fail` (replaces the old `test_null_expected_is_pass`, which asserted the buggy behavior) — NULL `expected_count` + 0 loaded rows → **FAIL**.
- `test_null_expected_not_masked_by_healthy_sibling` — control: a within-threshold collection alongside a NULL-expected one; the whole run must still FAIL and name the un-evaluable collection.

Before the fix (against `main` code):
```
FAILED ...::test_null_expected_is_fail
FAILED ...::test_null_expected_not_masked_by_healthy_sibling
2 failed
  -> ValidationResult(passed=True, details='all within threshold', ...)
```
After the fix: full `tests/test_graph/` suite **285 passed**; ruff format/lint, mypy strict all clean (pre-commit + pre-push green).

## Files changed
- `src/graph/validate.py` — `_classify_collection_coverage`: NULL/non-numeric `deviation_pct` now contributes a failure instead of being skipped.
- `tests/test_graph/test_validate.py` — red-first tests.

Closes #382
