### PR TITLE
Fix false mis-loader comments: mis edges are produced, not loaded (#364)

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -295,9 +295,13 @@ def _load_transmitted_to(
                 # (``load_nodes._load_hadiths``). Without this gate the edge orphans
                 # against a Hadith node that was never loaded (the ~196k
                 # ``fawaz:<book>:<n>`` dangling chains that duplicate lk). ``mis`` is
-                # unaffected: its transmission edges are produced as
-                # ``network_edges_mis.parquet``, never as narrator mentions, so they
-                # never reach this narrator-mention path.
+                # unaffected here for a different reason: it produces no narrator
+                # mentions at all (absent from NER routing), so it never reaches this
+                # narrator-mention path. Its transmission pairs are staged as
+                # ``network_edges_mis.parquet`` but are consumed by NO loader —
+                # produced, not loaded — pending a name-reconciliation crosswalk (mis
+                # Latin-transliteration ids ↔ Arabic-normalized canonical keys);
+                # tracked as a separate follow-up to da#364.
                 dropped_noncanonical += 1
                 continue
             if row.get("provenance"):
@@ -431,7 +435,10 @@ def _load_narrated(
                 # edge. Such an edge would otherwise be a guaranteed missing-endpoint
                 # (no Hadith node exists for it); dropping it at the source keeps the
                 # edge path consistent with the node loader. ``mis`` never reaches
-                # here (its edges come from ``network_edges_mis.parquet``).
+                # here because it produces no narrator mentions; its transmission
+                # pairs are staged as ``network_edges_mis.parquet`` but are loaded by
+                # no loader (produced, not loaded), pending a name-reconciliation
+                # crosswalk; tracked as a separate follow-up to da#364.
                 dropped_noncanonical += 1
                 continue
             key = (hid, _chain_index(row))

--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -298,10 +298,13 @@ def _load_transmitted_to(
                 # unaffected here for a different reason: it produces no narrator
                 # mentions at all (absent from NER routing), so it never reaches this
                 # narrator-mention path. Its transmission pairs are staged as
-                # ``network_edges_mis.parquet`` but are consumed by NO loader —
-                # produced, not loaded — pending a name-reconciliation crosswalk (mis
-                # Latin-transliteration ids ↔ Arabic-normalized canonical keys);
-                # tracked as a separate follow-up to da#364.
+                # ``network_edges_mis.parquet`` and ARE read by the STUDIED_UNDER glob
+                # (:func:`_load_studied_under`), but skipped row-by-row because they
+                # declare TRANSMITTED_TO, not STUDIED_UNDER — so no mis edge is
+                # persisted (produced, not loaded as a graph edge), pending a
+                # name-reconciliation crosswalk (mis Latin-transliteration ids ↔
+                # Arabic-normalized canonical keys); tracked as a separate follow-up
+                # to da#364.
                 dropped_noncanonical += 1
                 continue
             if row.get("provenance"):
@@ -436,9 +439,12 @@ def _load_narrated(
                 # (no Hadith node exists for it); dropping it at the source keeps the
                 # edge path consistent with the node loader. ``mis`` never reaches
                 # here because it produces no narrator mentions; its transmission
-                # pairs are staged as ``network_edges_mis.parquet`` but are loaded by
-                # no loader (produced, not loaded), pending a name-reconciliation
-                # crosswalk; tracked as a separate follow-up to da#364.
+                # pairs are staged as ``network_edges_mis.parquet`` and read by the
+                # STUDIED_UNDER glob but skipped row-by-row (they declare
+                # TRANSMITTED_TO, not STUDIED_UNDER), so no mis edge is persisted
+                # (produced, not loaded as a graph edge), pending a
+                # name-reconciliation crosswalk; tracked as a separate follow-up to
+                # da#364.
                 dropped_noncanonical += 1
                 continue
             key = (hid, _chain_index(row))

--- a/src/parse/composition.py
+++ b/src/parse/composition.py
@@ -17,10 +17,11 @@ composition (relayed via the Program Director) keeps each book once:
 * ``fawaz`` — its UNIQUE collections only (Nawawi, Dehlawi, Qudsi).
 * ``mis`` — its multi-isnad CHAINS only. Its Sahih Muslim matn duplicates ``lk``,
   so NO ``mis`` Hadith nodes are loaded. Its transmission edges are staged as
-  ``network_edges_mis.parquet`` but are currently consumed by no loader (produced,
-  not loaded), pending a name-reconciliation crosswalk (mis Latin-transliteration
-  ids ↔ Arabic-normalized canonical keys); tracked as a separate follow-up to
-  da#364.
+  ``network_edges_mis.parquet`` and read by the STUDIED_UNDER glob but skipped
+  row-by-row (they declare TRANSMITTED_TO, not STUDIED_UNDER), so no mis edge is
+  persisted (produced, not loaded as a graph edge), pending a name-reconciliation
+  crosswalk (mis Latin-transliteration ids ↔ Arabic-normalized canonical keys);
+  tracked as a separate follow-up to da#364.
 * every other source — all collections (value ``None``).
 
 This is the **per-source** half of the dedup and is the deterministic part that
@@ -70,8 +71,10 @@ from src.utils.arabic import is_arabic, normalize_arabic
 #   frozenset(...) = load only these collections.
 #   frozenset()    = load NO Hadith nodes for this source (e.g. ``mis``: its
 #                    transmission edges are staged as ``network_edges_mis.parquet``
-#                    but are currently loaded by no loader — produced, not loaded —
-#                    pending a name-reconciliation crosswalk; da#364).
+#                    and read by the STUDIED_UNDER glob but skipped (they declare
+#                    TRANSMITTED_TO), so no mis edge is persisted — produced, not
+#                    loaded as a graph edge — pending a name-reconciliation
+#                    crosswalk; da#364).
 HADITH_COMPOSITION: dict[str, frozenset[str] | None] = {
     "halimbahae": frozenset({"musnad_ahmad_ibn-hanbal", "sunan_al-darimi", "maliks_muwataa"}),
     "fawaz": frozenset({"nawawi", "dehlawi", "qudsi"}),

--- a/src/parse/composition.py
+++ b/src/parse/composition.py
@@ -16,8 +16,11 @@ composition (relayed via the Program Director) keeps each book once:
 * ``halimbahae`` — its UNIQUE books only (Musnad Ahmad, Darimi, Malik).
 * ``fawaz`` — its UNIQUE collections only (Nawawi, Dehlawi, Qudsi).
 * ``mis`` — its multi-isnad CHAINS only. Its Sahih Muslim matn duplicates ``lk``,
-  so NO ``mis`` Hadith nodes are loaded (``network_edges_mis`` still loads as
-  narrator-transmission edges).
+  so NO ``mis`` Hadith nodes are loaded. Its transmission edges are staged as
+  ``network_edges_mis.parquet`` but are currently consumed by no loader (produced,
+  not loaded), pending a name-reconciliation crosswalk (mis Latin-transliteration
+  ids ↔ Arabic-normalized canonical keys); tracked as a separate follow-up to
+  da#364.
 * every other source — all collections (value ``None``).
 
 This is the **per-source** half of the dedup and is the deterministic part that
@@ -66,7 +69,9 @@ from src.utils.arabic import is_arabic, normalize_arabic
 #                    ``"x": None`` entry and an absent key behave identically.
 #   frozenset(...) = load only these collections.
 #   frozenset()    = load NO Hadith nodes for this source (e.g. ``mis``: its
-#                    chains/edges still load via the edge loader).
+#                    transmission edges are staged as ``network_edges_mis.parquet``
+#                    but are currently loaded by no loader — produced, not loaded —
+#                    pending a name-reconciliation crosswalk; da#364).
 HADITH_COMPOSITION: dict[str, frozenset[str] | None] = {
     "halimbahae": frozenset({"musnad_ahmad_ibn-hanbal", "sunan_al-darimi", "maliks_muwataa"}),
     "fawaz": frozenset({"nawawi", "dehlawi", "qudsi"}),

--- a/src/resolve/ner.py
+++ b/src/resolve/ner.py
@@ -87,9 +87,10 @@ _SPLITTER_DEFERRED_SOURCES: dict[str, str] = {
 #   muhaddithat: bio/network data only, no raw isnads.
 #   mis (da#365): its ``hadiths_mis.parquet`` rows carry a null ``isnad_raw_ar`` and
 #     no ``full_text_ar``; mis's transmission chains are staged separately as
-#     ``network_edges_mis.parquet`` and loaded on their own path (da#364), never
-#     mined from raw isnad text here. Routed to skip (not unrouted) so the da#369
-#     hard-fail does not fire; it contributes 0 NER mentions by construction.
+#     ``network_edges_mis.parquet`` but are consumed by no loader (produced, not
+#     loaded), pending a name-reconciliation crosswalk (da#364), never mined from raw
+#     isnad text here. Routed to skip (not unrouted) so the da#369 hard-fail does not
+#     fire; it contributes 0 NER mentions by construction.
 _SKIP_SOURCES: set[str] = {"muhaddithat", "mis"}
 
 # The union of every corpus with an explicit NER route. A staged corpus outside

--- a/src/resolve/ner.py
+++ b/src/resolve/ner.py
@@ -87,10 +87,11 @@ _SPLITTER_DEFERRED_SOURCES: dict[str, str] = {
 #   muhaddithat: bio/network data only, no raw isnads.
 #   mis (da#365): its ``hadiths_mis.parquet`` rows carry a null ``isnad_raw_ar`` and
 #     no ``full_text_ar``; mis's transmission chains are staged separately as
-#     ``network_edges_mis.parquet`` but are consumed by no loader (produced, not
-#     loaded), pending a name-reconciliation crosswalk (da#364), never mined from raw
-#     isnad text here. Routed to skip (not unrouted) so the da#369 hard-fail does not
-#     fire; it contributes 0 NER mentions by construction.
+#     ``network_edges_mis.parquet`` and read by the STUDIED_UNDER glob but skipped
+#     (they declare TRANSMITTED_TO), so no mis edge is persisted — produced, not
+#     loaded as a graph edge — pending a name-reconciliation crosswalk (da#364),
+#     never mined from raw isnad text here. Routed to skip (not unrouted) so the
+#     da#369 hard-fail does not fire; it contributes 0 NER mentions by construction.
 _SKIP_SOURCES: set[str] = {"muhaddithat", "mis"}
 
 # The union of every corpus with an explicit NER route. A staged corpus outside


### PR DESCRIPTION
## What

Corrects four **false comments** that claim the `mis` corpus's transmission edges are loaded into the graph. They are not: `network_edges_mis.parquet` (63,642 `TRANSMITTED_TO` rows) is produced, staged, and then consumed by **no loader**.

**Comment-only. No behavior change, no load, no crosswalk** — wiring a loader is a separate deferred follow-up (issue #364's "Suggested fix" item 1).

## Why the comments are wrong (verified at HEAD)

- `_load_transmitted_to` reads only `narrator_mentions_resolved.parquet` (`_resolved_mentions_files`) — it never opens `network_edges_*`.
- `_load_studied_under` globs `network_edges_*` but `continue`s on every row whose declared relation is not `STUDIED_UNDER`; `mis` rows declare `TRANSMITTED_TO`, so they are skipped.
- `mis` also contributes 0 narrator mentions (absent from NER routing; `_SKIP_SOURCES`).

So `mis` is acquired → parsed → staged → silently discarded. `HADITH_COMPOSITION["mis"] = frozenset()` (line 73) is correct and left untouched.

## Comment sites corrected

| File | Site | Was |
|------|------|-----|
| `src/graph/load_edges.py` | TRANSMITTED_TO path (~:295) | "transmission edges are produced as `network_edges_mis.parquet`" (implied handled) |
| `src/graph/load_edges.py` | NARRATED path (~:435) | "its edges come from `network_edges_mis.parquet`" |
| `src/parse/composition.py` | module docstring (~:18) | "`network_edges_mis` still loads as narrator-transmission edges" |
| `src/parse/composition.py` | `HADITH_COMPOSITION` legend (~:69) | "its chains/edges still load via the edge loader" |
| `src/resolve/ner.py` | `_SKIP_SOURCES` note (~:88) | "loaded on their own path (da#364)" |

Each now states: mis edges are produced but loaded by **no** loader (produced, not loaded), pending a name-reconciliation crosswalk (mis Latin-transliteration ids ↔ Arabic-normalized canonical keys); tracked as a separate follow-up.

## Verification

- `git diff` is comment/docstring lines only — no executable-code change.
- ruff format --check, ruff check, mypy (strict), pytest (109 tests in the 3 touched modules' suites) — all green locally and via pre-commit/pre-push hooks.

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrsyDcQb1oGgFEVBacZzvs
