### PR TITLE
resolve: key narrator-split chain index on (hadith_id, chain_index) (#411)

### DIFF
--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -32,7 +32,9 @@ Algorithm (per eligible canonical id ``C``, name ``N``)
 -------------------------------------------------------
 1. Gather every mention with ``canonical_narrator_id == C``.
 2. **Isnad-adjacency evidence** — for each such mention, look at the chain neighbours
-   at ``position_in_chain`` ±1 in the same ``hadith_id`` and map them to their
+   at ``position_in_chain`` ±1 in the same ``(hadith_id, chain_index)`` chain (da#411 —
+   the composite key the graph loaders use; NOT ``hadith_id`` alone, which would
+   fabricate cross-chain neighbours in a multi-isnad hadith) and map them to their
    *attested* ``death_year_ah`` (precision ≠ ``tabaqa_estimate`` — an *estimated*
    window is never used as evidence, which also keeps the pass cascade-free on
    re-run). A teacher (neighbour at position−1) dies a transmission gap *earlier*;
@@ -448,87 +450,123 @@ def _remap_split_mentions(mentions_path: Path, remap: dict[str, str]) -> int:
     return remapped
 
 
+def _coalesce_chain_index(value: Any) -> int:
+    """Per-hadith isnad-chain ordinal, coalescing a missing/None value to 0.
+
+    Mirrors :func:`src.graph.load_edges._chain_index` (da#282) so this splitter groups
+    chains on the SAME ``(hadith_id, chain_index)`` key the edge/chain loaders use. A
+    ``None`` ``chain_index`` (a single-isnad producer that left it unset, or a legacy
+    pre-da#282 file) coalesces to 0, so single-chain hadiths are unaffected.
+    """
+    return int(value) if value is not None else 0
+
+
 def _build_chain_index(
     mentions_path: Path,
     candidate_ids: set[str],
-) -> tuple[dict[str, list[tuple[int, str]]], dict[str, list[tuple[str, int, str]]]]:
+) -> tuple[
+    dict[tuple[str, int], list[tuple[int, str]]],
+    dict[str, list[tuple[str, int, int, str]]],
+]:
     """Stream the mentions (two bounded passes) → (chains, candidate_mentions).
 
-    ``chains``: ``hadith_id -> [(position, canonical_id), ...]`` for neighbour lookup.
-    ``candidate_mentions``: ``candidate_id -> [(hadith_id, position, mention_id), ...]``.
+    ``chains``: ``(hadith_id, chain_index) -> [(position, canonical_id), ...]`` for
+    neighbour lookup — keyed on the composite ``(hadith_id, chain_index)`` the graph
+    loaders use (:func:`src.graph.load_edges._chain_index`, da#282), NOT ``hadith_id``
+    alone. A multi-isnad hadith (one ``hadith_id``, several ``chain_index`` values —
+    today lk's Arabic + English isnads, each numbered from position 0) therefore keeps
+    its isnads separate. Keying on ``hadith_id`` alone would flatten them into one
+    position-sorted list and fabricate cross-chain ±1 neighbours that exist in no real
+    chain, corrupting the death-band evidence (da#411).
+    ``candidate_mentions``:
+    ``candidate_id -> [(hadith_id, chain_index, position, mention_id), ...]`` — the
+    ``chain_index`` is carried through so :func:`_collect_datable` can confine each
+    mention's ±1 lookup to its own chain.
 
     Memory (da#337 PR-3a — OOM audit, cf. #723). ``chains`` is deliberately restricted
-    to *only* the hadiths that contain ≥1 candidate mention. A candidate's per-mention
-    death estimate is derived solely from its ±1 neighbours **within the same hadith**,
-    so a hadith with no candidate mention can never contribute a neighbour lookup and is
-    pure dead weight in ``chains``. The earlier one-pass build kept every hadith's full
-    chain resident — i.e. the *entire* mentions table — which is exactly the class of
-    full-table-resident structure that OOM'd resolve in #723. Restricting to
-    candidate-touching hadiths bounds the resident footprint to O(mentions in hadiths
-    that name a generic-name candidate) + O(candidate mentions), both a small fraction
-    of the multi-million-row corpus (generic-name candidates are a curated minority),
-    instead of O(all mentions).
+    to *only* the chains that contain ≥1 candidate mention. A candidate's per-mention
+    death estimate is derived solely from its ±1 neighbours **within the same
+    ``(hadith_id, chain_index)`` chain**, so a chain with no candidate mention can never
+    contribute a neighbour lookup and is pure dead weight in ``chains``. The earlier
+    one-pass build kept every hadith's full chain resident — i.e. the *entire* mentions
+    table — which is exactly the class of full-table-resident structure that OOM'd
+    resolve in #723. Restricting to candidate-touching chains bounds the resident
+    footprint to O(mentions in chains that name a generic-name candidate) + O(candidate
+    mentions), both a small fraction of the multi-million-row corpus (generic-name
+    candidates are a curated minority), instead of O(all mentions).
 
     The cost is two streaming passes (2× sequential read) instead of one, each with a
     one-row-group working set — the standard time-for-memory trade, mirroring
     ``fuzzy_cluster``'s multi-pass streaming IO shell. Pass 1 collects the candidate
-    mentions and the set of hadiths they occur in; pass 2 fills ``chains`` for only
-    those hadiths (retaining every position in them, so non-candidate neighbours are
-    still present for the ±1 lookup).
+    mentions and the set of ``(hadith_id, chain_index)`` chains they occur in; pass 2
+    fills ``chains`` for only those chains (retaining every position in them, so
+    non-candidate neighbours are still present for the ±1 lookup).
     """
-    chains: dict[str, list[tuple[int, str]]] = {}
-    candidate_mentions: dict[str, list[tuple[str, int, str]]] = {}
+    chains: dict[tuple[str, int], list[tuple[int, str]]] = {}
+    candidate_mentions: dict[str, list[tuple[str, int, int, str]]] = {}
     if not mentions_path.exists():
         return chains, candidate_mentions
 
     pf = pq.ParquetFile(mentions_path)
-    cols = ["mention_id", "hadith_id", "position_in_chain", "canonical_narrator_id"]
+    cols = ["mention_id", "hadith_id", "chain_index", "position_in_chain", "canonical_narrator_id"]
 
-    # Pass 1 — candidate mentions + the hadiths that contain them.
-    candidate_hadith_ids: set[str] = set()
+    # Pass 1 — candidate mentions + the (hadith_id, chain_index) chains that contain them.
+    candidate_chain_keys: set[tuple[str, int]] = set()
     for rg_idx in range(pf.metadata.num_row_groups):
         table = pf.read_row_group(rg_idx, columns=cols)
         mention_ids = table.column("mention_id").to_pylist()
         hadith_ids = table.column("hadith_id").to_pylist()
+        chain_indexes = table.column("chain_index").to_pylist()
         positions = table.column("position_in_chain").to_pylist()
         cids = table.column("canonical_narrator_id").to_pylist()
-        for mid, hid, pos, cid in zip(mention_ids, hadith_ids, positions, cids, strict=True):
+        for mid, hid, cidx, pos, cid in zip(
+            mention_ids, hadith_ids, chain_indexes, positions, cids, strict=True
+        ):
             if cid is None or hid is None or pos is None:
                 continue
             if cid in candidate_ids:
-                candidate_mentions.setdefault(cid, []).append((hid, int(pos), mid))
-                candidate_hadith_ids.add(hid)
+                ci = _coalesce_chain_index(cidx)
+                candidate_mentions.setdefault(cid, []).append((hid, ci, int(pos), mid))
+                candidate_chain_keys.add((hid, ci))
 
-    if not candidate_hadith_ids:
+    if not candidate_chain_keys:
         return chains, candidate_mentions
 
-    # Pass 2 — full chains, but only for candidate-touching hadiths (bounded footprint).
-    chain_cols = ["hadith_id", "position_in_chain", "canonical_narrator_id"]
+    # Pass 2 — full chains, but only for candidate-touching (hadith_id, chain_index)
+    # chains (bounded footprint).
+    chain_cols = ["hadith_id", "chain_index", "position_in_chain", "canonical_narrator_id"]
     for rg_idx in range(pf.metadata.num_row_groups):
         table = pf.read_row_group(rg_idx, columns=chain_cols)
         hadith_ids = table.column("hadith_id").to_pylist()
+        chain_indexes = table.column("chain_index").to_pylist()
         positions = table.column("position_in_chain").to_pylist()
         cids = table.column("canonical_narrator_id").to_pylist()
-        for hid, pos, cid in zip(hadith_ids, positions, cids, strict=True):
+        for hid, cidx, pos, cid in zip(hadith_ids, chain_indexes, positions, cids, strict=True):
             if cid is None or hid is None or pos is None:
                 continue
-            if hid in candidate_hadith_ids:
-                chains.setdefault(hid, []).append((int(pos), cid))
+            key = (hid, _coalesce_chain_index(cidx))
+            if key in candidate_chain_keys:
+                chains.setdefault(key, []).append((int(pos), cid))
     return chains, candidate_mentions
 
 
 def _collect_datable(
-    mentions: list[tuple[str, int, str]],
-    chains: dict[str, list[tuple[int, str]]],
+    mentions: list[tuple[str, int, int, str]],
+    chains: dict[tuple[str, int], list[tuple[int, str]]],
     attested_by_id: dict[str, int],
     name_by_id: dict[str, str],
 ) -> list[DatableMention]:
-    """Per-mention death estimates from attested chain neighbours (undatable dropped)."""
+    """Per-mention death estimates from attested chain neighbours (undatable dropped).
+
+    A neighbour is only ever the mention's ±1 position **within the same
+    ``(hadith_id, chain_index)`` chain** — never another isnad of the same hadith
+    (da#411) — mirroring the graph loaders' composite chain key.
+    """
     datable: list[DatableMention] = []
-    for hadith_id, position, mention_id in mentions:
+    for hadith_id, chain_index, position, mention_id in mentions:
         estimates: list[int] = []
         anchors: list[str] = []
-        for npos, nid in chains.get(hadith_id, ()):
+        for npos, nid in chains.get((hadith_id, chain_index), ()):
             if npos == position - 1:
                 sign = 1  # neighbour is the teacher (dies earlier) → C dies later
             elif npos == position + 1:

--- a/tests/test_resolve/test_narrator_split.py
+++ b/tests/test_resolve/test_narrator_split.py
@@ -164,13 +164,22 @@ def _anchor_row(cid: str, death: int) -> dict[str, Any]:
     )
 
 
-def _mention_row(mention_id: str, hadith_id: str, position: int, cid: str) -> dict[str, Any]:
+def _mention_row(
+    mention_id: str,
+    hadith_id: str,
+    position: int,
+    cid: str,
+    chain_index: int | None = None,
+) -> dict[str, Any]:
     base: dict[str, Any] = {f.name: None for f in NARRATOR_MENTIONS_RESOLVED_SCHEMA}
     base["mention_id"] = mention_id
     base["hadith_id"] = hadith_id
     base["source_corpus"] = "bukhari"
     base["position_in_chain"] = position
     base["canonical_narrator_id"] = cid
+    # None coalesces to chain 0 (single-isnad hadith / legacy file), so callers that
+    # do not care about multi-isnad grouping are unaffected.
+    base["chain_index"] = chain_index
     return base
 
 
@@ -493,3 +502,67 @@ def test_stage_hub_peels_small_spurious_band_keeps_ge_90pct(tmp_path: Path) -> N
     assert peeled[0]["mention_count"] == small
     assert peeled[0]["death_year_ah"] == 260
     assert peeled[0]["death_date_precision"] == DatePrecision.ISNAD_ESTIMATE.value
+
+
+# --------------------------------------------------------------------------- #
+# da#411 — multi-isnad chain keying (no cross-chain ±1 neighbours)
+# --------------------------------------------------------------------------- #
+def test_multi_isnad_no_cross_chain_neighbour(tmp_path: Path) -> None:
+    """da#411: a multi-isnad hadith must keep its isnads separate for the ±1 lookup.
+
+    One ``hadith_id`` carries two isnads (``chain_index`` 0 and 1), each numbered from
+    position 0 with distinct narrators; the split candidate sits at position 1 in BOTH.
+    Keying the splitter's chain index on ``hadith_id`` alone (the pre-da#411 bug)
+    flattens the two isnads into one position-sorted list, so the candidate's pos±1
+    neighbour lookup picks up the *other* isnad's narrators — teacher/student
+    adjacencies that exist in no real chain and that corrupt the death-band evidence.
+    Grouping on the composite ``(hadith_id, chain_index)`` key the graph loaders use
+    (``src.graph.load_edges._chain_index``, da#282) confines each mention's neighbours
+    to its own chain.
+
+    RED on the old hadith_id-only code (each mention's anchors leak across chains);
+    GREEN after the composite-key fix. Exercises ``_build_chain_index`` (the keying)
+    and ``_collect_datable`` (the neighbour window) directly.
+    """
+    from src.resolve.narrator_split import _build_chain_index, _collect_datable
+
+    cand = make_canonical_id(_ABU_ABDALLAH)
+    # Distinct attested anchors per isnad of the SAME hadith. Chain 0: teacher d.100
+    # (pos 0) + student d.170 (pos 2). Chain 1: teacher d.250 (pos 0) + student d.320
+    # (pos 2). Their death years are far apart so a cross-chain leak is unmistakable.
+    ta0 = _anchor_row("nar:t_a0", 100)
+    sa0 = _anchor_row("nar:s_a0", 170)
+    tb1 = _anchor_row("nar:t_b1", 250)
+    sb1 = _anchor_row("nar:s_b1", 320)
+    canonical = [_canonical_row(cand, _ABU_ABDALLAH, 2), ta0, sa0, tb1, sb1]
+    mentions = [
+        # isnad 0
+        _mention_row("m-t-a0", "h1", 0, "nar:t_a0", chain_index=0),
+        _mention_row("m-c-0", "h1", 1, cand, chain_index=0),
+        _mention_row("m-s-a0", "h1", 2, "nar:s_a0", chain_index=0),
+        # isnad 1 — same hadith_id, different chain_index
+        _mention_row("m-t-b1", "h1", 0, "nar:t_b1", chain_index=1),
+        _mention_row("m-c-1", "h1", 1, cand, chain_index=1),
+        _mention_row("m-s-b1", "h1", 2, "nar:s_b1", chain_index=1),
+    ]
+    out = tmp_path / "curated"
+    _write(out, canonical, mentions)
+
+    attested_by_id = {r["canonical_id"]: r["death_year_ah"] for r in (ta0, sa0, tb1, sb1)}
+    name_by_id = {r["canonical_id"]: r["name_ar_normalized"] for r in canonical}
+
+    chains, candidate_mentions = _build_chain_index(
+        out / "narrator_mentions_resolved.parquet", {cand}
+    )
+    datable = _collect_datable(candidate_mentions[cand], chains, attested_by_id, name_by_id)
+
+    by_mention = {d.mention_id: d for d in datable}
+    chain0_anchors = {name_by_id["nar:t_a0"], name_by_id["nar:s_a0"]}
+    chain1_anchors = {name_by_id["nar:t_b1"], name_by_id["nar:s_b1"]}
+
+    # Each mention draws its ±1 anchors ONLY from its own isnad…
+    assert set(by_mention["m-c-0"].anchor_names) == chain0_anchors
+    assert set(by_mention["m-c-1"].anchor_names) == chain1_anchors
+    # …with no cross-chain leak in either direction (the load-bearing assertion).
+    assert not (set(by_mention["m-c-0"].anchor_names) & chain1_anchors)
+    assert not (set(by_mention["m-c-1"].anchor_names) & chain0_anchors)


### PR DESCRIPTION
## Summary

PR-A (issue #411) — the hard prerequisite for the batched narrator-split re-run.

`src/resolve/narrator_split.py::_build_chain_index` keyed its `chains` structure on **`hadith_id` alone**, while the graph loaders key chains on the composite **`(hadith_id, chain_index)`** (`src/graph/load_edges.py::_chain_index`, da#282). For a **multi-isnad hadith** (same `hadith_id`, multiple `chain_index` values — today lk's Arabic + English isnads, each numbered from position 0), dropping `chain_index` flattened both isnads into one position-sorted list. `_collect_datable`'s pos±1 neighbour lookup then fabricated cross-chain teacher/student neighbours that exist in no real chain, corrupting the death-date neighbour window the split decision (and the #337/#346 context signal built on top of it) rests on.

## Fix (mechanical key-alignment — not the #337/#346 discriminator, which is PR-B)

- `_build_chain_index` now reads `chain_index`, keys `chains` on `(hadith_id, chain_index)`, and carries the ordinal through `candidate_mentions`. New `_coalesce_chain_index` helper mirrors `load_edges._chain_index` (None → 0, so single-isnad hadiths and legacy pre-da#282 files are unaffected). The da#337-PR-3a OOM bound is preserved and slightly tightened — pass 2 restricts to candidate-touching `(hadith_id, chain_index)` chains instead of whole hadiths.
- `_collect_datable`'s ±1 neighbour lookup keys on `(hadith_id, chain_index)`, so a neighbour is only ever within the same chain.

## Test evidence (RED → GREEN)

New `tests/test_resolve/test_narrator_split.py::test_multi_isnad_no_cross_chain_neighbour`: one `hadith_id`, two `chain_index` values (0 and 1), distinct attested narrators per chain, candidate at position 1 in both. Asserts each candidate mention's ±1 anchors come **only** from its own chain.

- **RED** on the pre-fix (hadith_id-only) code — chain-0 mention's anchors leaked in chain-1's narrators (d.250, d.320):
  ```
  E  AssertionError: assert {...320'} == {...170'}
  E    Extra items in the left set: 'راو مءرخ رقم 320', 'راو مءرخ رقم 250'
  ```
- **GREEN** after the composite-key fix. Full module: 17 passed. Full `tests/test_resolve/`: 539 passed, 6 skipped.

## Files changed
- `src/resolve/narrator_split.py` — `_coalesce_chain_index` (new), `_build_chain_index` (composite key + 4-tuple candidate_mentions), `_collect_datable` (composite-key neighbour lookup), algorithm docstring line updated.
- `tests/test_resolve/test_narrator_split.py` — `_mention_row` gains an optional `chain_index`; new `test_multi_isnad_no_cross_chain_neighbour`.

## Scope
Exactly the key-alignment + its neighbour-window consequence + the test. The #337/#346 isnad-neighbour clustering (PR-B) depends on this landing first and is **not** implemented here.

Closes #411
