### PR TITLE
resolve: fold alif-maqsura + standalone hamza at mint surface, unify matcher (#434, #438)

### DIFF
--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -50,7 +50,7 @@ from src.resolve.sect_affiliation import (
     normalize_corpus,
     primary_corpus,
 )
-from src.utils.arabic import canonical_surface, normalize_arabic
+from src.utils.arabic import canonical_surface
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -713,8 +713,11 @@ def _disambiguate_mention(
     if not raw_name:
         return None, []
 
-    # Normalize Arabic once; all stages receive the pre-normalized form.
-    name = normalize_arabic(raw_name) if raw_name else ""
+    # da#438: match on the `canonical_surface` identity surface, the SAME surface the
+    # candidate index (`_load_candidates`) and the mint (`_make_canonical_id`) key on —
+    # not bare `normalize_arabic`, which left Stage 1 unable to exact-match a byte-
+    # identical bio across a fold the mint had already applied. All stages receive it.
+    name = canonical_surface(raw_name) if raw_name else ""
     if not name:
         return None, []
 
@@ -791,7 +794,7 @@ def _disambiguate_mention_indexed(
     if not raw_name:
         return None, []
 
-    name = normalize_arabic(raw_name) if raw_name else ""
+    name = canonical_surface(raw_name) if raw_name else ""
     if not name:
         return None, []
 

--- a/src/utils/arabic.py
+++ b/src/utils/arabic.py
@@ -605,6 +605,25 @@ def _fold_token(token: str) -> list[str]:
     return [token]
 
 
+# Two residual letter-level noise classes that :func:`normalize_arabic` leaves
+# behind and that fragment one name across canonical ids (da#434). Pure
+# normalization, never an identity merge of distinct people:
+#   ى (U+0649 alif-maqsura) → ي (U+064A ya) — the same name mints two ids when a
+#      final ي is spelled dotless.
+#   ء (U+0621 standalone hamza) dropped — after normalize_arabic has folded
+#      ؤ ئ → ء, the bare hamza that remains is orthographic noise, so e.g.
+#      ``عاءشه`` and ``عائشة`` collapse to the same key instead of two.
+# Applied at the mint surface only, NOT in normalize_arabic (which also feeds
+# display-name normalization). Idempotent: ي is not itself a fold trigger and no
+# ء survives, so both are fixed points on their own output.
+_RESIDUAL_NOISE_MAP = str.maketrans({"ى": "ي", "ء": ""})
+
+
+def _fold_residual_noise(text: str) -> str:
+    """Fold alif-maqsura ى→ي and drop the standalone hamza ء (da#434)."""
+    return text.translate(_RESIDUAL_NOISE_MAP)
+
+
 def canonical_surface(name: str) -> str:
     """The string a canonical narrator id is minted from.
 
@@ -620,6 +639,7 @@ def canonical_surface(name: str) -> str:
     normalized = normalize_arabic(name)
     if not normalized:
         return ""
+    normalized = _fold_residual_noise(normalized)
     folded: list[str] = []
     for token in normalized.split():
         folded.extend(_fold_token(token))

--- a/tests/test_parse/test_identity.py
+++ b/tests/test_parse/test_identity.py
@@ -458,3 +458,44 @@ class TestNameNormalizedDrift:
         assert make_discriminated_canonical_id(raw, "d37") == make_discriminated_canonical_id(
             cleaned, "d37"
         )
+
+
+class TestResidualNoiseFold:
+    """da#434 — two residual letter-level noise classes at the mint surface.
+
+    ``normalize_arabic`` folds ؤ ئ → ء but leaves two orthographic-noise classes that
+    otherwise fragment one name across canonical ids: a dotless final ya (alif-maqsura
+    ى) and the standalone hamza ء left over after the ؤئ→ء fold. :func:`canonical_surface`
+    now folds ى→ي and drops ء so the surface forms of one name converge on one key. This
+    is pure normalization — never an identity merge of distinct people (Kavitha's
+    blast-radius: 192 clusters, ~1,689 mentions move, 0 distinct-person collisions).
+    """
+
+    # ---- POSITIVE: the two folds change the mint key --------------------------
+
+    def test_alif_maqsura_folds_to_ya_in_the_key(self) -> None:
+        # A final ى (alif-maqsura) folds to ي, so a dotless and a dotted spelling of
+        # the same name mint one id. normalize_arabic leaves ى untouched, so pre-fix
+        # these were two distinct nar: ids.
+        assert canonical_surface("موسى") == canonical_surface("موسي")
+        assert make_canonical_id("موسى") == make_canonical_id("موسي")
+
+    def test_standalone_hamza_dropped_in_the_key(self) -> None:
+        # The issue's own example: عاءشه and عائشة differ only by the standalone hamza
+        # (after normalize_arabic folds ئ→ء and ة→ه). Dropping ء collapses them.
+        assert canonical_surface("عاءشه") == canonical_surface("عائشة")
+        assert make_canonical_id("عاءشه") == make_canonical_id("عائشة")
+
+    # ---- CONTROL: genuinely different names still mint different ids ----------
+
+    def test_distinct_names_sharing_only_the_folded_char_stay_distinct(self) -> None:
+        # موسى (Musa) and عيسى (Isa) share only the trailing ى; the fold must not
+        # collapse them. This is the guard that the fold is normalization, not merge.
+        assert make_canonical_id("موسى") != make_canonical_id("عيسى")
+
+    def test_fold_is_idempotent(self) -> None:
+        # ي is not itself a fold trigger and no ء survives, so the folded surface is a
+        # fixed point — an already-folded name does not move.
+        for name in ("موسى", "عائشة", "يحيى", "عطاء"):
+            once = canonical_surface(name)
+            assert canonical_surface(once) == once, name

--- a/tests/test_resolve/test_canonical_identity_invariant.py
+++ b/tests/test_resolve/test_canonical_identity_invariant.py
@@ -163,7 +163,11 @@ class TestCanonicalIdentityInvariant:
             f"got nodes {[(c, r['name_ar_normalized']) for c, r in canon.items()]}"
         )
         node = canon[expected_id]
-        assert node["name_ar_normalized"] == mention_norm
+        # da#434/#438: the node is named on the mention's `canonical_surface`, so assert
+        # against that, not the bare `normalize_arabic` form the fold now moves
+        # (عائشة→عاشه). The guard's substance is unchanged — the name is the MENTION's,
+        # never the corrupt bio's (asserted below); only the surface it lives on moved.
+        assert node["name_ar_normalized"] == canonical_surface(AISHA)
         assert node["name_ar"] == AISHA, "display name must be the mention's, not the bio's"
         assert make_canonical_id(normalize_arabic(AISHA_CORRUPT)) not in canon
 
@@ -265,7 +269,13 @@ class TestCanonicalIdentityInvariant:
             cid = m["canonical_narrator_id"]
             assert cid is not None
             raw = m["name_normalized"] or m["name_raw"] or ""
-            surfaces.setdefault(str(cid), set()).add(normalize_arabic(str(raw)))
+            # da#434/#438: a node is minted and named on its `canonical_surface`, so the
+            # chimera check must compare the stored name against the mentions' canonical
+            # SURFACE, not the bare `normalize_arabic` form. Using normalize_arabic here
+            # false-flags every node whose surface the fold moved (e.g. عائشة→عاشه) as a
+            # chimera; using canonical_surface keeps the guard exact — a genuinely
+            # bio-sourced name still fails to appear among its mentions' surfaces.
+            surfaces.setdefault(str(cid), set()).add(canonical_surface(str(raw)))
 
         refined = {p.norm_name for persons in MONONYM_REGISTRY.values() for p in persons}
         chimeric = [


### PR DESCRIPTION
## Summary

Adds two residual letter-level Arabic folds at the **mint surface** (`canonical_surface`, the da#376 identity surface that `make_canonical_id` → `canonical_key` routes through), and completes the da#376 identity-surface unification in the disambiguator matcher.

**The two folds (PR-E / #434):**
1. alif-maqsura `ى → ي`
2. drop the standalone hamza `ء` left after the existing `ؤئ → ء` fold (so e.g. `عاءشه` and `عائشة` collapse consistently)

Both are **pure normalization, never an identity merge of distinct people** — they heal one name fragmented across canonical ids.

**The matcher unification (#438):** aligning the mint surface exposed a latent da#376 asymmetry — the disambiguator matcher keyed exact/fuzzy/crossref on bare `normalize_arabic`, while the candidate index (`_load_candidates`) and the mint (`_make_canonical_id`) key on `canonical_surface`. Once the fold moved a common surface (`عائشة → عاشه`), a byte-identical bio and mention stopped exact-matching and corroboration silently degraded to fuzzy — hitting Aisha (Umm al-Muʾminin) and every hamza/alif-maqsura name. This PR aligns both matcher twins (`_disambiguate_mention` `:717`, `_disambiguate_mention_indexed` `:794`) onto `canonical_surface`. The module now resolves on a **single identity surface** and no longer calls `normalize_arabic` at all (unused import removed). **This PR resolves #438's matcher-alignment.**

## Blast radius (real data, bidirectional, UNWEIGHTED)

Measured over the actual disambiguator I/O: **140,174 bios** (itqan/kaggle/muhaddithat) + **3,003,114 resolved mentions**.

1. **Monotonicity.** Bio index keys are already `canonical_surface(bio)` — never contain `ى` or standalone `ء` (verified 0/109,749). So the matcher change **only ADDS exact matches, never removes one** (measured: 0 lost). The whole blast radius is the set of newly-exact (mention, bio) pairs.

2. **Fold vs token-fold split** of the 3,791 newly-exact distinct surfaces:
   - **residual (the two new folds):** 1,587 surfaces
   - **token (pre-existing da#376 kunya/accusative/abd):** 1,832 surfaces
   - both: 372 surfaces

   The token-fold merges are **already the production mint identity** (da#376) — the alignment only makes corroboration agree with the already-minted node; it creates no new node merges.

3. **Distinct-person joins = ZERO.** Of 930 merge classes (≥2 distinct `normalize_arabic` pre-images), 783 are token-only (da#376, shipped). The 147 **residual-responsible bridges** were each read with the Arabic lens: every one bridges one lexical name's orthographic variant — `ى/ي` spellings (Yaḥyā, ʿAlī, Mūsā, ʿĪsā, Mahdī, Yaʿlā, Sumayy) or hamza-drops (ʿAṭāʾ→ʿAṭā, Mīnāʾ→Mīnā, Rajāʾ→Rajā, Zakariyyāʾ→Zakariyyā, Waʾil, ʿAbd al-Muʾmin). A bidirectional bio-side check found 138 residual bridges, all same-name spelling variants (duplicate catalogue rows for one person). **زينب بنت علي بن أبي طالب** (the Prophet's granddaughter) is *unified*, not split. The da#376 traps hold: `عمرو ≠ عمر`, `موسى ≠ عيسى`, `زكرياء → زكريا ≠ زكري`.

## Tests

- **New** `TestResidualNoiseFold` (`test_identity.py`): the mint key folds `ى→ي` and drops `ء`; two surfaces differing only by these mint one id; control that two genuinely different names (`موسى` vs `عيسى`) stay distinct; idempotency.
- **Updated** two identity-invariant guards (`test_no_canonical_node_is_chimeric`, `test_fuzzy_bio_match_does_not_rekey_or_rename`) from `normalize_arabic` to `canonical_surface` on the **mention-surface comparison** — the node is named on its canonical surface, so the guard must compare against it. **Guard integrity proven:** both still FIRE on a synthetic chimera and on a corrupt-bio re-key; `canonical_surface("عائشة")="عاشه" ≠ canonical_surface("عائذة")="عاذه"`, so a different-surface person is kept distinct and neither guard is masked.

## Reviewer attention

- **da#248 bare-kunya corroboration flip (not a blocker):** for a bare kunya that already collides on multiple bios (e.g. `أبو صالح`, 10 bios — a token-only class, pre-existing in the mint), the alignment lets a bare-kunya mention exact-match that bucket, which can flip its year uncorroborated→corroborated and feed the da#248 mononym split. This is **not** a new node merge and is governed by the existing da#248 registry + `test_uncorroborated_year_does_not_enter_the_chain_context` (passes). Worth a confirm.

## Green state

ruff + mypy clean; affected suites (resolve + parse identity + arabic) **691 passed**. Pre-existing/environmental reds NOT caused by this PR: `tests/test_tools/test_duck.py` ×3 (`ModuleNotFoundError: duckdb`, optional dep absent) and `tests/integration/*Live*` ×54 (require live Neo4j).

Closes #434
Part of #438
