### PR TITLE
bio_promote: count accepted truncated-residue residual + correct guard docs (#385/#397/#398)

### DIFF
--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -1834,7 +1834,7 @@ def asserted_name_tokens(name_normalized: str | None) -> tuple[str, ...]:
 
 
 def cleaner_removed_content(name_normalized: str | None, cleaned: str | None) -> bool:
-    """True when :func:`clean_narrator_name` cut into the name the source asserted (da#379).
+    """True when :func:`clean_narrator_name` removed name-span material, not just an affix (da#379).
 
     ``clean_narrator_name`` does two categorically different things that its return
     value alone does not distinguish:
@@ -1842,18 +1842,32 @@ def cleaner_removed_content(name_normalized: str | None, cleaned: str | None) ->
     * **Normalization** — markup, honorifics, editorial connectives and a bracketed
       catalog entry number are affixes *around* a name. Stripping them leaves the
       name the source asserted, whole: ``"( 4875 ) عبد الله بن موسى"`` →
-      ``"عبد الله بن موسى"``, still that narrator's full name.
-    * **Truncation** — an isnad/matn tail or a colon-joined body is *part of the same
-      span* as the name, and cutting it keeps only a head. The residue is not a name
-      the source asserted, and it is frequently a bare ism:
-      ``"عبيدة مولى رسول الله ذكره بن شاهين …"`` (an obscure client of the Prophet)
-      reduces to ``"عبيده"`` — the name of a different, heavily-attested narrator.
+      ``"عبد الله بن موسى"``, still that narrator's full name. This returns ``False``.
+    * **Truncation** — an isnad/matn tail or a colon-joined body is cut off, keeping
+      only a head. This returns ``True``. Note it does NOT imply the cleaner "cut into
+      the name" (da#398): truncation splits into two sub-cases the return value again
+      does not separate —
 
-    A caller that keys identity on the cleaner's output must tell these apart. An
-    affix is not a tail. Comparing against :func:`asserted_name_tokens` — rather than
-    against a re-tokenization of the raw input — is what makes that distinction; a
-    re-tokenization sees the entry number, the connective and the honorific as
-    "content removed" and refuses a merge the source fully supports.
+        - *cut into the name*: the residue is a fragment, frequently a bare ism —
+          ``"عبيدة مولى رسول الله ذكره بن شاهين …"`` (an obscure client of the Prophet)
+          reduces to ``"عبيده"``, the name of a different, heavily-attested narrator.
+        - *tail after a complete name*: the asserted name is INTACT and only a chain
+          continuation after it was removed — ``"اسحاق بن مره عن انس"`` → ``"اسحاق بن
+          مره"`` (the full nasab; only the teacher-key ``عن انس`` cut). The name was
+          not cut *into*; a tail *after* it was removed. Roughly 40% of the corpus's
+          truncations are this class (da#397/da#398).
+
+    So a ``True`` means "removed more than an affix", NOT "the residue is not a name".
+    A caller keying identity on the cleaner's output must not over-read it (da#398):
+    it separates affix-normalization from name-material removal, and no finer. Deciding
+    whether a tail-after-complete-name residue is the SAME person as an existing record
+    is a homonymy question this function cannot answer — it needs biographical
+    disambiguation, not a token diff.
+
+    Comparing against :func:`asserted_name_tokens` — rather than a re-tokenization of
+    the raw input — is what draws the affix/removal line; a re-tokenization sees the
+    entry number, the connective and the honorific as "content removed" and refuses a
+    merge the source fully supports.
     """
     if not name_normalized or not cleaned:
         return False

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -242,6 +242,14 @@ def promote_bios_to_canonical(
     skipped_source = 0
     skipped_pollution = 0
     skipped_truncated_merge = 0
+    # The ACCEPTED truncated-residue residual (da#385). The guard only refuses a
+    # truncated residue that would claim an *attested* node (mention_count > 0);
+    # every other truncated residue is accepted — it either lands on a zero-mention
+    # catalog node or mints a new node keyed on the truncation. Both are deliberate
+    # (the guard's scope is narrow by design, da#379) but were previously uncounted,
+    # so "we accepted it" was indistinguishable from "it never happened". Count them.
+    truncated_residue_onto_unattested = 0
+    truncated_residue_minted = 0
     # Canonical ids a bio actually promoted into this run — the anchor set aliases
     # attach to (da#389). Excludes pollution-drops and truncation-skips, which mint
     # no node (or refuse the merge), so their aliases have nothing to anchor to.
@@ -283,14 +291,33 @@ def promote_bios_to_canonical(
             bio_id = safe_str(row.get("bio_id"))
             cid = make_canonical_id(norm)
 
-            # When the cleaner CUT INTO the name the source asserted, the residue is
-            # not a name — it is whatever survived a truncation, and it is routinely
-            # a bare ism (da#379). Such a residue may not claim an *attested*
-            # narrator: `عبيدة مولى رسول الله ذكره بن شاهين …` cleans to `عبيده` and
-            # would otherwise merge onto ʿAbīda al-Salmānī (1,695 mentions),
-            # back-filling an obscure client's jarḥ grade and death year onto him via
-            # _BACKFILL_FIELDS. A bare ism is not a person. Refusing the merge is
-            # always safe; asserting it is not.
+            # When `cleaner_removed_content` is True the cleaner removed name-span
+            # material beyond its affix normalizations. That covers TWO classes the
+            # guard treats alike, and a maintainer must not read this refusal as
+            # "the residue is not a name" — for most of these rows it is (da#397/da#398):
+            #
+            #   1. CUT INTO the name → a bare-ism residue that is genuinely not the
+            #      asserted name. `عبيدة مولى رسول الله ذكره بن شاهين …` cleans to
+            #      `عبيده` and would otherwise merge onto ʿAbīda al-Salmānī (1,695
+            #      mentions), back-filling an obscure client's jarḥ grade and death year
+            #      onto him via _BACKFILL_FIELDS. A bare ism is not a person; refusing is
+            #      the only safe call. This is what the guard exists for.
+            #   2. A COMPLETE name that merely lost an isnad/gloss TAIL → e.g.
+            #      `اسحاق بن مره عن انس` → `اسحاق بن مره`, the full nasab intact, only the
+            #      teacher-key `عن انس` cut. Roughly 40% of the mention-bearing refusals
+            #      are this class (full-nasab residues, not bare isms).
+            #
+            # For class 2 refusal is NON-CORRUPTING but it is NOT "always safe" in the
+            # symmetric sense — it withholds correct enrichment from real narrators. So
+            # why refuse it too? Because `make_canonical_id` folds Arabic inflection
+            # (da#376) but NOT homonymy, and full-nasab homonyms are pervasive here: a
+            # blast-radius measurement over the staging corpus found 45 of 240 accept-
+            # target names carry CONFLICTING jarḥ grades across their bio entries (one
+            # name-key graded both thiqa and kadhdhab — provably >1 person). Accepting a
+            # class-2 merge on the name alone back-fills a verdict onto a possibly-
+            # different bearer — the da#423 direction (feedback_drop_gate_bidirectional_ab).
+            # So the conservative refusal is the right DEFAULT for both classes; safely
+            # recovering class 2 needs biographical disambiguation, deferred to da#397/398.
             #
             # `cleaner_removed_content` compares against the cleaner's OWN
             # pre-truncation tokens, not a re-tokenization of `norm`. A bracketed
@@ -319,6 +346,10 @@ def promote_bios_to_canonical(
                 continue
 
             if cid not in canonical_map:
+                # da#385: a truncated residue that mints a brand-new node names that
+                # node after a truncation, not after an asserted name. Count it.
+                if truncated:
+                    truncated_residue_minted += 1
                 canonical_map[cid] = {
                     "canonical_id": cid,
                     "name_ar": name_ar,
@@ -339,6 +370,12 @@ def promote_bios_to_canonical(
                     "source_corpora": [corpus] if corpus else [],
                 }
             else:
+                # da#385: a truncated residue reaching this branch merges onto a node
+                # that is NOT attested — a mention_count > 0 target was already refused
+                # above, so this is a zero-mention catalog node (curated or minted this
+                # run). Two catalog entries fuse under a truncated key; count it.
+                if truncated:
+                    truncated_residue_onto_unattested += 1
                 rec = canonical_map[cid]
                 src_ids = rec.setdefault("source_ids", [])
                 if bio_id and bio_id not in src_ids:
@@ -393,6 +430,28 @@ def promote_bios_to_canonical(
             note="aliases whose cleaned canonical name matched no promoted bio",
         )
 
+    # da#385: surface the ACCEPTED truncated-residue residual once, loudly, and name
+    # the deferred name/prose extraction as its owner. These are not defects the guard
+    # should have caught — the da#379 guard is deliberately scoped to attested targets —
+    # but they DO name canonical nodes after a truncation (a bare ism or a residue that
+    # fused two catalog entries), so they must be observable rather than silent. The
+    # real cure is upstream: a name/prose extractor that never emits the truncated span
+    # (da#299, kaggle; the deferred itqan prose extraction). Until then, this is the
+    # measurement that keeps the residual honest (feedback_silent_zero_is_not_a_measurement).
+    truncated_residue_accepted = truncated_residue_onto_unattested + truncated_residue_minted
+    if truncated_residue_accepted:
+        logger.warning(
+            "bio_promote_truncated_residue_accepted",
+            onto_unattested=truncated_residue_onto_unattested,
+            minted_new=truncated_residue_minted,
+            total=truncated_residue_accepted,
+            note=(
+                "truncated bio residues accepted onto a zero-mention node or minting a "
+                "new node keyed on the truncation; owner = deferred name/prose extraction "
+                "(da#299 kaggle + itqan prose)"
+            ),
+        )
+
     logger.info(
         "bio_promote_complete",
         bio_files=len(bio_files),
@@ -403,6 +462,8 @@ def promote_bios_to_canonical(
         skipped_source=skipped_source,
         skipped_pollution=skipped_pollution,
         skipped_truncated_merge=skipped_truncated_merge,
+        truncated_residue_onto_unattested=truncated_residue_onto_unattested,
+        truncated_residue_minted=truncated_residue_minted,
         aliases_added=alias_stats.added,
         aliases_unmatched_pollution=alias_stats.unmatched_pollution,
         aliases_unmatched_no_bio=alias_stats.unmatched_no_bio,

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -1201,3 +1201,96 @@ def test_unmatched_no_bio_is_counted_and_warns(
         event == "bio_promote_aliases_unmatched_no_bio" and kw.get("unmatched_no_bio") == 1
         for event, kw in warnings_seen
     ), warnings_seen
+
+
+def test_truncated_residue_minting_a_new_node_is_counted_and_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """da#385: an ACCEPTED truncated residue that mints a new node must be counted + warned.
+
+    The da#379 guard only refuses a truncated residue that would claim an ATTESTED node;
+    a residue whose canonical id is absent is accepted and mints a node named after the
+    truncation. That outcome is deliberate but was previously silent — indistinguishable
+    from "it never happened" (feedback_silent_zero_is_not_a_measurement). Drive it POSITIVE
+    with the verbatim itqan prose fixture (cleans to the bare ism `عبيده`) against an empty
+    curated dir, and assert both the `bio_promote_complete` count and the aggregate WARN.
+    """
+    from src.resolve import bio_promote as bp
+
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+
+    assert cleaner_removed_content(
+        normalize_arabic(_ITQAN_60592_PROSE),
+        clean_narrator_name(normalize_arabic(_ITQAN_60592_PROSE)),
+    )
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:60592",
+                "source": "itqan",
+                "name_ar": _ITQAN_60592_PROSE,
+                "name_ar_normalized": normalize_arabic(_ITQAN_60592_PROSE),
+                "trustworthiness": "thiqa",
+            }
+        ],
+    )
+
+    events: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(bp.logger, "info", lambda event, **kw: events.append((event, kw)))
+    monkeypatch.setattr(bp.logger, "warning", lambda event, **kw: events.append((event, kw)))
+
+    assert bp.promote_bios_to_canonical(staging, out_dir) is not None
+    complete = next(kw for event, kw in events if event == "bio_promote_complete")
+    assert complete["truncated_residue_minted"] == 1
+    assert complete["truncated_residue_onto_unattested"] == 0
+    assert any(
+        event == "bio_promote_truncated_residue_accepted"
+        and kw.get("minted_new") == 1
+        and kw.get("total") == 1
+        for event, kw in events
+    ), events
+
+
+def test_truncated_residue_onto_zero_mention_node_is_counted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """da#385: a truncated residue merging onto a ZERO-mention node is the other counted class.
+
+    A mention_count == 0 target is not attested, so the guard does not refuse — the residue
+    fuses two catalog entries under a truncated key (deliberate; da#299 owns the real fix).
+    That path increments `truncated_residue_onto_unattested`, never `_minted`.
+    """
+    from src.resolve import bio_promote as bp
+
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+
+    _write_attested_narrator(out_dir, "عبيده", mentions=0)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:60592",
+                "source": "itqan",
+                "name_ar": _ITQAN_60592_PROSE,
+                "name_ar_normalized": normalize_arabic(_ITQAN_60592_PROSE),
+                "trustworthiness": "thiqa",
+            }
+        ],
+    )
+
+    events: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(bp.logger, "info", lambda event, **kw: events.append((event, kw)))
+
+    assert bp.promote_bios_to_canonical(staging, out_dir) is not None
+    complete = next(kw for event, kw in events if event == "bio_promote_complete")
+    assert complete["truncated_residue_onto_unattested"] == 1
+    assert complete["truncated_residue_minted"] == 0


### PR DESCRIPTION
## Summary

Observability + documentation only. The da#379 truncated-merge guard's **refuse-line is unchanged** — no behavioral loosening. A blast-radius measurement (below) showed the proposed loosening would join **distinct persons**, so the behavioral recovery stays deferred; this PR ships only the safe half of PR-CD.

## What changed

- **#385 — count the accepted truncated-residue residual.** Two counters on `bio_promote` (`truncated_residue_minted`, `truncated_residue_onto_unattested`) + one aggregate `logger.warning` naming the deferred name/prose extraction (da#299) as owner. The guard refuses only a truncated residue claiming an *attested* node; every other truncated residue is accepted (mints a new node, or fuses onto a zero-mention node) and was previously **silent** — "we accepted it" was indistinguishable from "it never happened" (`feedback_silent_zero_is_not_a_measurement`). Live-corpus residual: **~6,983 rows minted new nodes (4,199 distinct cids) + ~4,765 merged onto zero-mention nodes.**
- **#398 — correct `cleaner_removed_content`'s contract.** A `True` means "removed more than an affix", **not** "cut into the name". The docstring now separates a bare-ism *cut into the name* from a *tail-after-a-complete-name* removal (`اسحاق بن مره عن انس` → `اسحاق بن مره`), and states plainly that deciding whether such a residue is the same person is a homonymy question a token diff cannot answer.
- **#397 — correct the misleading inline guard comment.** It justified refusal as "always safe" over "bare ism" residues; in fact ~40% of the mention-bearing refusals are **full nasabs**, and refusal is non-corrupting-but-withholds-enrichment, not symmetrically "safe". The comment now documents the deliberate class-2 over-refusal pending disambiguation.

## Why the behavioral loosening is NOT in this PR (the measurement)

Measured with the branch's own cleaner against the live staging corpus (`narrators_bio_{itqan,kaggle,muhaddithat}`, 138,707 named rows) + `data/curated/narrators_canonical.parquet` (107,951 canonical):

- A refined guard would newly accept **460** merges onto attested narrators (240 distinct target names, Σ 41,997 mentions).
- **Bidirectional, unweighted, Arabic-reader lens:** the newly-accepted set joins distinct persons. **45 of 240 target name-keys carry conflicting jarḥ grades** across bio entries — `محمد بن الأزهر الجوزجاني` (mc=4) carries all of daif/kadhdhab/matruk/saduq/thiqa/unknown on one key; `جابر بن يزيد` (mc=53) daif+kadhdhab+unknown. One name-key graded both *thiqa* and *kadhdhab* is provably >1 person, keyword-independent. A further ≥106/460 rows carry an explicit disputed-identity marker (مجهول / لا يعرف / وقيل اسمه) or a death-year/generation conflict.
- Instrument verified on both classes: dispute-marker base rate 4.4% across all itqan bios vs 17.8% on the teacher-tail set (4× separation).

Loosening the guard would back-fill *forger*/*abandoned* verdicts onto attested narrators by bare name-match — the da#423 direction (`feedback_drop_gate_bidirectional_ab`). The behavioral recall recovery (class-A merge / same-person recovery) is **deferred** behind biographical homonym disambiguation (jarḥ-grade / death-year separation) + the full bidirectional-unweighted A/B + Arabic rijāl gate. #397 and #398 stay open as the deferred trackers.

## Tests

2 new positive-witnessed counter tests (`test_truncated_residue_minting_a_new_node_is_counted_and_warns`, `test_truncated_residue_onto_zero_mention_node_is_counted`). Full suite green; ruff format+lint, mypy strict, pytest all pass (pre-commit + pre-push).

Closes #385
Re #397
Re #398
