### PR TITLE
Tag & keep bio-only narrators: attestation property (#370)

### DIFF
--- a/queries/validation/orphan_narrators.cypher
+++ b/queries/validation/orphan_narrators.cypher
@@ -1,6 +1,12 @@
-// Find narrator nodes with no relationships
+// Find narrator nodes with no relationships, EXCLUDING biography-only narrators.
 // Expected: 0 orphans in a healthy graph
+// A `biographical_only` narrator (da#370) is a real person carried by a rijal /
+// biographical source with no surviving isnad mention. Such narrators are kept on
+// purpose ("tag & keep") and are zero-degree BY DESIGN, so they are not orphans —
+// excluding them keeps this contract meaningful for a genuine orphan regression.
+// coalesce guards a legacy node loaded before the attestation property existed.
 MATCH (n:Narrator)
 WHERE NOT (n)--()
+  AND coalesce(n.attestation, '') <> 'biographical_only'
 RETURN n.id AS narrator_id, n.name_en AS name
 ORDER BY n.id

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -34,6 +34,7 @@ from typing import Any
 import pyarrow.parquet as pq
 import yaml
 
+from src.models.enums import Attestation
 from src.parse.composition import (
     canonical_matn_identity,
     is_canonical_hadith,
@@ -226,6 +227,7 @@ SET n.name_ar           = row.name_ar,
     n.external_id       = row.external_id,
     n.source_ids        = row.source_ids,
     n.mention_count     = row.mention_count,
+    n.attestation       = row.attestation,
     n.source_corpus     = row.source_corpus,
     n.source_corpora    = row.source_corpora,
     n.sect_affiliation  = row.sect_affiliation
@@ -287,6 +289,11 @@ def _load_narrators(
                 # ``MATCH (n:Narrator) WHERE any(s IN n.source_ids WHERE s STARTS WITH 'itqan:')``.
                 "source_ids": _val(row, "source_ids", []),
                 "mention_count": _val(row, "mention_count"),
+                # Attestation tag (da#370). Defaults to "unknown" for a legacy
+                # canonical file written before this column existed, so the property
+                # is always present on the node (mirrors source_corpus/sect_affiliation).
+                # Every current producer populates it as isnad_attested/biographical_only.
+                "attestation": _val(row, "attestation", Attestation.UNKNOWN.value),
                 # Sect/corpus provenance (da#103). ``source_corpus`` defaults to ""
                 # so the property is always present even for legacy canonical files
                 # written before these columns existed; ``sect_affiliation`` defaults

--- a/src/models/enums.py
+++ b/src/models/enums.py
@@ -83,6 +83,30 @@ class SectAffiliation(StrEnum):
     UNKNOWN = "unknown"
 
 
+class Attestation(StrEnum):
+    """How a canonical narrator is attested in the corpus (da#370).
+
+    Distinguishes a narrator we have an isnad transmission for from a
+    ``biographical_only`` record — a real historical person carried by a rijal /
+    biographical source (itqan / kaggle / muhaddithat) with **no** surviving isnad
+    mention. Bio-only narrators are deliberately kept ("tag & keep", owner ruling on
+    da#370): they are real, searchable people whose absence of an isnad is our
+    corpus's incompleteness, not theirs. The tag lets the UI present them as
+    biography-only entries and lets ``orphan_narrators.cypher`` exclude them so the
+    zero-degree contract stays meaningful for genuine orphans.
+
+    Derived from ``mention_count`` (see :func:`src.resolve.attestation.derive_attestation`):
+    a bio is provenance, not a chain hit, so a bio-promoted record carries
+    ``mention_count == 0``. ``UNKNOWN`` is not a derived value — every canonical
+    narrator has a known ``mention_count`` — it exists only as the loader's default
+    for a legacy canonical parquet written before this column existed.
+    """
+
+    ISNAD_ATTESTED = "isnad_attested"
+    BIOGRAPHICAL_ONLY = "biographical_only"
+    UNKNOWN = "unknown"
+
+
 class TrustworthinessGrade(StrEnum):
     """Narrator trustworthiness grade from classical rijal criticism."""
 

--- a/src/resolve/attestation.py
+++ b/src/resolve/attestation.py
@@ -1,0 +1,50 @@
+"""Derive a narrator-level :class:`Attestation` tag from its isnad mention count (da#370).
+
+A canonical narrator is ``biographical_only`` when it carries **no** isnad
+transmission mention — a record promoted from a rijal / biographical source
+(itqan / kaggle / muhaddithat) rather than seen transmitting in a chain. The signal
+is already present on the canonical record: ``bio_promote`` stamps ``mention_count = 0``
+on a bio-promoted narrator ("a bio is provenance, not a chain hit"), while a narrator
+disambiguated from real chain mentions carries ``mention_count >= 1``.
+
+Why this is derived at every canonical-table build site, not once
+----------------------------------------------------------------
+``narrators_canonical.parquet`` has more than one producer that (re)computes
+``mention_count``: ``disambiguate`` mints rows from mentions, ``bio_promote`` MERGEs
+bio rows in (``mention_count = 0``), and ``fuzzy_cluster`` collapses ids and **sums**
+the survivors' ``mention_count``. A tag computed once and carried across those steps
+would go stale exactly when a merge changes ``mention_count`` (a bio-only record
+folded into an attested one). So — mirroring :func:`derive_sect_affiliation`, which
+is likewise re-derived from the merged ``source_corpora`` at each of those sites — the
+attestation is re-derived from the row's **final** ``mention_count`` wherever the
+canonical table is built. It is a pure function of that one field, so re-deriving is
+always consistent and never depends on producer ordering.
+
+Note the tag is about *isnad* attestation, not graph degree: a ``biographical_only``
+narrator whose name later resolves to a ``STUDIED_UNDER`` network endpoint at load
+time still has no isnad transmission, so the tag stands. It is not the same predicate
+as "zero-degree" — that is why ``orphan_narrators.cypher`` excludes bio-only nodes
+explicitly rather than inferring bio-only from degree.
+"""
+
+from __future__ import annotations
+
+from src.models.enums import Attestation
+
+
+def derive_attestation(mention_count: object) -> str:
+    """Return the :class:`Attestation` value for a canonical narrator.
+
+    ``isnad_attested`` when the narrator carries a positive isnad ``mention_count``,
+    else ``biographical_only`` (a bio-promoted record with ``mention_count`` 0 or
+    ``None``). Never returns ``unknown``: a canonical narrator always has a known
+    ``mention_count``. Returns the enum *value* (a ``str``) so it drops straight into
+    the ``NARRATORS_CANONICAL_SCHEMA`` string column.
+
+    Accepts ``object`` because the canonical-row dicts in the resolve layer type this
+    field loosely; only a positive ``int`` counts as attested (mirrors the
+    ``mc if isinstance(mc, int)`` guard the fuzzy-cluster merge already uses).
+    """
+    if isinstance(mention_count, int) and mention_count > 0:
+        return Attestation.ISNAD_ATTESTED.value
+    return Attestation.BIOGRAPHICAL_ONLY.value

--- a/src/resolve/attestation.py
+++ b/src/resolve/attestation.py
@@ -11,14 +11,22 @@ Why this is derived at every canonical-table build site, not once
 ----------------------------------------------------------------
 ``narrators_canonical.parquet`` has more than one producer that (re)computes
 ``mention_count``: ``disambiguate`` mints rows from mentions, ``bio_promote`` MERGEs
-bio rows in (``mention_count = 0``), and ``fuzzy_cluster`` collapses ids and **sums**
-the survivors' ``mention_count``. A tag computed once and carried across those steps
-would go stale exactly when a merge changes ``mention_count`` (a bio-only record
-folded into an attested one). So — mirroring :func:`derive_sect_affiliation`, which
-is likewise re-derived from the merged ``source_corpora`` at each of those sites — the
-attestation is re-derived from the row's **final** ``mention_count`` wherever the
-canonical table is built. It is a pure function of that one field, so re-deriving is
-always consistent and never depends on producer ordering.
+bio rows in (``mention_count = 0``), ``fuzzy_cluster`` collapses ids and **sums** the
+survivors' ``mention_count``, and ``narrator_split`` (da#337) reduces a generic
+primary's count and mints peeled band rows. A tag computed once and carried across
+those steps would go stale exactly when one of them changes ``mention_count`` (a
+bio-only record folded into an attested one; a primary peeled down to zero). So —
+mirroring :func:`derive_sect_affiliation`, which is likewise re-derived from the
+merged ``source_corpora`` at each of those sites — the attestation is re-derived from
+the row's **final** ``mention_count`` at every one of those four sites. It is a pure
+function of that one field, so re-deriving is always consistent and never depends on
+producer ordering.
+
+The remaining canonical writers in ``RESOLVE_STEP_ORDER`` — ``date_reconcile`` and
+``tabaqa_dates`` — carry the tag through untouched, and that is safe **only because
+they never recompute ``mention_count``**: they round-trip the schema and edit date
+columns, so a value an earlier site derived stays valid. A future step that mutates
+``mention_count`` MUST add a re-derivation, exactly like the four above.
 
 Note the tag is about *isnad* attestation, not graph degree: a ``biographical_only``
 narrator whose name later resolves to a ``STUDIED_UNDER`` network endpoint at load

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -35,6 +35,7 @@ from src.parse.name_quality import (
 )
 from src.resolve._inputs import require_input
 from src.resolve._run_record import write_canonical
+from src.resolve.attestation import derive_attestation
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
 from src.resolve.sect_affiliation import (
     derive_sect_affiliation,
@@ -369,6 +370,11 @@ def promote_bios_to_canonical(
         rec["source_corpora"] = corpora
         rec["source_corpus"] = primary_corpus(corpora)
         rec["sect_affiliation"] = derive_sect_affiliation(corpora)
+        # Attestation from the row's FINAL mention_count (da#370): re-derived for
+        # every row — new bio records (mention_count 0 -> biographical_only) AND
+        # existing rows merged in from disambiguate — so a value the prior producer
+        # wrote can never go stale here. See src.resolve.attestation.
+        rec["attestation"] = derive_attestation(rec.get("mention_count"))
 
     # Attach name-variant aliases onto the canonical records the bios produced.
     alias_stats = _merge_aliases(staging_dir, canonical_map, promoted_cids, sources=sources)

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -38,6 +38,7 @@ from src.resolve._checkpoint import (
 )
 from src.resolve._inputs import require_input
 from src.resolve._run_record import write_canonical
+from src.resolve.attestation import derive_attestation
 from src.resolve.geography import regions_plausible, resolve_region
 from src.resolve.mononym_split import refine_mononym_name
 from src.resolve.schemas import (
@@ -917,6 +918,13 @@ def _build_canonical_table(
             [r.get("death_year_provenance") for r in rows], type=pa.string()
         ),
         "mention_count": pa.array([r.get("mention_count", 0) for r in rows], type=pa.int32()),
+        # Attestation tag derived from the row's final mention_count (da#370). A
+        # disambiguated narrator comes from real chain mentions, so this is
+        # "isnad_attested" for every row here; derived (not hard-coded) so the one
+        # helper stays the single source of truth across all producers.
+        "attestation": pa.array(
+            [derive_attestation(r.get("mention_count", 0)) for r in rows], type=pa.string()
+        ),
         # Sect/corpus provenance finalized from the accumulated corpora set (da#103).
         "source_corpus": pa.array([primary_corpus(_corpora(r)) for r in rows], type=pa.string()),
         "source_corpora": pa.array(

--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -92,6 +92,7 @@ from src.resolve._checkpoint import (
     save_checkpoint,
 )
 from src.resolve._run_record import write_canonical
+from src.resolve.attestation import derive_attestation
 from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
 from src.resolve.sect_affiliation import derive_sect_affiliation, normalize_corpus, primary_corpus
 from src.utils.logging import get_logger
@@ -1170,6 +1171,10 @@ def _merge_cluster(members: list[dict[str, Any]]) -> dict[str, Any]:
     merged["source_corpora"] = sorted(set(corpora))
     merged["source_corpus"] = primary_corpus(corpora)
     merged["sect_affiliation"] = derive_sect_affiliation(corpora)
+    # Re-derive attestation from the SUMMED mention_count (da#370): folding a
+    # bio-only survivor (mention_count 0) into an attested one lifts the total above
+    # 0, so a carried-over "biographical_only" would go stale. See src.resolve.attestation.
+    merged["attestation"] = derive_attestation(mention_count)
     return merged
 
 

--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -132,6 +132,7 @@ from src.parse.base import safe_str, write_parquet
 from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
 from src.resolve._inputs import require_input
 from src.resolve._run_record import write_canonical
+from src.resolve.attestation import derive_attestation
 from src.resolve.generic_name import is_generic_name
 from src.resolve.mononym_split import _MAX_GAP, _MIN_GAP, is_registered_mononym
 from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
@@ -620,6 +621,11 @@ def _peeled_record(primary_rec: dict[str, Any], band: PeeledBand, name_norm: str
     rec["birth_date_precision"] = DatePrecision.UNKNOWN.value
     rec["generation"] = _generation_for_year(band.midpoint_ah).value
     rec["mention_count"] = band.mention_count
+    # da#370: a peeled band carries real isnad mentions, so re-derive rather than
+    # inherit — the fixed column tuple above deliberately omits attestation, so
+    # without this the band would load as the loader's "unknown" default despite
+    # being isnad-attested. Derive from the FINAL mention_count (the shared helper).
+    rec["attestation"] = derive_attestation(band.mention_count)
     return rec
 
 
@@ -724,6 +730,10 @@ def split_generic_narrators(output_dir: Path, *, staging_dir: Path | None = None
         primary_rec = record_by_id[plan.primary_id]
         primary_count = _as_int(primary_rec.get("mention_count")) or 0
         primary_rec["mention_count"] = max(0, primary_count - plan.peeled_mention_count)
+        # da#370: peeling mutates mention_count AFTER the last derivation site
+        # (fuzzy_cluster), so re-derive the attestation on the reduced count — a
+        # primary peeled down to 0 mentions is now biographical_only, not stale.
+        primary_rec["attestation"] = derive_attestation(primary_rec["mention_count"])
         for band in plan.peeled:
             new_rows.append(_peeled_record(primary_rec, band, plan.name_ar_normalized))
             audit_rows.append(

--- a/src/resolve/schemas.py
+++ b/src/resolve/schemas.py
@@ -93,6 +93,13 @@ NARRATORS_CANONICAL_SCHEMA = pa.schema(
         # makes that guard *permit* a merge. One of {corroborated, uncorroborated, NULL}.
         pa.field("death_year_provenance", pa.string(), nullable=True),
         pa.field("mention_count", pa.int32(), nullable=True),
+        # Attestation tag (da#370): "biographical_only" when mention_count == 0 (a
+        # bio-promoted record with no isnad transmission), else "isnad_attested".
+        # Derived from mention_count at each canonical-table build site via
+        # src.resolve.attestation.derive_attestation. Nullable so a legacy canonical
+        # file written before this column loads without it (loader defaults to
+        # "unknown"); every current producer populates it.
+        pa.field("attestation", pa.string(), nullable=True),
         # Sect/corpus provenance on the canonical narrator (da#103, epic #81).
         # ``source_corpus`` is the scalar primary corpus (mirrors the Hadith /
         # Collection node property); ``source_corpora`` is the full multi-source

--- a/tests/integration/test_graph_loading.py
+++ b/tests/integration/test_graph_loading.py
@@ -258,6 +258,7 @@ def _write_narrators_parquet(curated: Path, rows: list[dict[str, Any]]) -> Path:
             [r.get("death_year_provenance") for r in rows], type=pa.string()
         ),
         "mention_count": pa.array([r.get("mention_count") for r in rows], type=pa.int32()),
+        "attestation": pa.array([r.get("attestation") for r in rows], type=pa.string()),
         "source_corpus": pa.array([r.get("source_corpus") for r in rows], type=pa.string()),
         "source_corpora": pa.array(
             [r.get("source_corpora", []) for r in rows], type=pa.list_(pa.string())

--- a/tests/test_graph/conftest.py
+++ b/tests/test_graph/conftest.py
@@ -122,6 +122,7 @@ def write_narrators_canonical(curated: Path, rows: list[dict[str, Any]]) -> Path
             [r.get("death_year_provenance") for r in rows], type=pa.string()
         ),
         "mention_count": pa.array([r.get("mention_count") for r in rows], type=pa.int32()),
+        "attestation": pa.array([r.get("attestation") for r in rows], type=pa.string()),
         "source_corpus": pa.array([r.get("source_corpus") for r in rows], type=pa.string()),
         "source_corpora": pa.array(
             [r.get("source_corpora", []) for r in rows], type=pa.list_(pa.string())

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -97,6 +97,40 @@ class TestLoadNarrators:
         assert row["source_corpora"] == []
         assert row["sect_affiliation"] == "unknown"
 
+    def test_narrator_carries_attestation(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """da#370: the attestation tag is SET on the Narrator node from the canonical row."""
+        write_narrators_canonical(
+            curated_dir,
+            [
+                {
+                    "canonical_id": "nar:bio-only",
+                    "name_en": "Bio Only",
+                    "mention_count": 0,
+                    "attestation": "biographical_only",
+                },
+            ],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        query, batch = next((q, b) for q, b in mock_client.calls if "MERGE (n:Narrator" in q)
+        assert "n.attestation" in query
+        assert isinstance(batch, list)
+        assert batch[0]["attestation"] == "biographical_only"
+
+    def test_narrator_attestation_defaults_to_unknown_when_absent(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """A legacy canonical row without the attestation column loads as 'unknown'."""
+        write_narrators_canonical(
+            curated_dir,
+            [{"canonical_id": "nar:legacy-attest", "name_en": "Legacy"}],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        _, batch = next((q, b) for q, b in mock_client.calls if "MERGE (n:Narrator" in q)
+        assert isinstance(batch, list)
+        assert batch[0]["attestation"] == "unknown"
+
     def test_invalid_canonical_id_skipped(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
     ) -> None:

--- a/tests/test_graph/test_validate.py
+++ b/tests/test_graph/test_validate.py
@@ -28,6 +28,13 @@ class TestValidationQueryFiles:
         path = QUERIES_DIR / "orphan_narrators.cypher"
         assert path.exists(), f"Missing {path}"
 
+    def test_orphan_query_excludes_biographical_only(self) -> None:
+        """da#370: kept bio-only narrators are zero-degree by design and must NOT be
+        flagged as orphans, or the contract stays uninformatively red."""
+        text = (QUERIES_DIR / "orphan_narrators.cypher").read_text()
+        assert "biographical_only" in text
+        assert "attestation" in text
+
     def test_chain_integrity_exists(self) -> None:
         path = QUERIES_DIR / "chain_integrity.cypher"
         assert path.exists(), f"Missing {path}"

--- a/tests/test_resolve/test_attestation.py
+++ b/tests/test_resolve/test_attestation.py
@@ -1,0 +1,28 @@
+"""Tests for src.resolve.attestation.derive_attestation (da#370)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models.enums import Attestation
+from src.resolve.attestation import derive_attestation
+
+
+@pytest.mark.parametrize("mention_count", [0, None])
+def test_no_isnad_mention_is_biographical_only(mention_count: int | None) -> None:
+    """A record with no isnad mention (bio-promoted, mention_count 0 or null) is bio-only."""
+    assert derive_attestation(mention_count) == Attestation.BIOGRAPHICAL_ONLY.value
+    assert derive_attestation(mention_count) == "biographical_only"
+
+
+@pytest.mark.parametrize("mention_count", [1, 2, 1695])
+def test_any_isnad_mention_is_attested(mention_count: int) -> None:
+    """A single real chain mention is enough to make a narrator isnad-attested."""
+    assert derive_attestation(mention_count) == Attestation.ISNAD_ATTESTED.value
+    assert derive_attestation(mention_count) == "isnad_attested"
+
+
+def test_never_derives_unknown() -> None:
+    """UNKNOWN is only the loader's legacy default, never a derived value."""
+    assert derive_attestation(0) != Attestation.UNKNOWN.value
+    assert derive_attestation(5) != Attestation.UNKNOWN.value

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -78,6 +78,8 @@ def test_promotes_bios_to_canonical_with_nar_ids(tmp_path: Path) -> None:
     assert rec["external_id"] == "320"
     assert rec["source_ids"] == ["itqan:320"]
     assert rec["mention_count"] == 0
+    # da#370: a bio-promoted record (no isnad mention) is tagged biographical_only.
+    assert rec["attestation"] == "biographical_only"
 
 
 def test_bio_promote_tags_sect_and_corpus(tmp_path: Path) -> None:

--- a/tests/test_resolve/test_fuzzy_cluster.py
+++ b/tests/test_resolve/test_fuzzy_cluster.py
@@ -218,6 +218,35 @@ def test_merged_record_routes_through_make_canonical_id(tmp_path: Path) -> None:
     assert merged["external_id"] == "320"
 
 
+def test_merge_retags_bio_only_survivor_as_attested(tmp_path: Path) -> None:
+    """da#370: folding a bio-only (mention_count 0) variant into an attested narrator
+    lifts the summed mention_count above 0, so the survivor must RE-DERIVE to
+    isnad_attested — a carried-over biographical_only would be stale."""
+    attested = _rec(
+        "محمد بن اسماعيل البخاري",
+        mention_count=5,
+        attestation="isnad_attested",
+        death_year_ah=256,
+    )
+    bio_only = _rec(
+        "محمد بن اسماعيل",
+        mention_count=0,
+        attestation="biographical_only",
+        death_year_ah=256,
+    )
+    canonical = tmp_path / "narrators_canonical.parquet"
+    _write_canonical(canonical, [attested, bio_only])
+
+    metrics = cluster_canonical_narrators(canonical)
+    assert metrics.merged_records == 1
+
+    rows = pq.read_table(canonical).to_pylist()
+    assert len(rows) == 1
+    merged = rows[0]
+    assert merged["mention_count"] == 5
+    assert merged["attestation"] == "isnad_attested"
+
+
 def test_merge_cluster_drops_bare_relational_alias() -> None:
     """da#391: the cluster alias-union never carries a bare relational-pronoun.
 

--- a/tests/test_resolve/test_narrator_split.py
+++ b/tests/test_resolve/test_narrator_split.py
@@ -324,6 +324,51 @@ def test_stage_splits_two_bands_and_peels(tmp_path: Path) -> None:
     assert audit[0]["new_id"] == peeled[0]["canonical_id"]
 
 
+def test_stage_peel_re_derives_attestation(tmp_path: Path) -> None:
+    """da#370: narrator_split mutates mention_count AFTER the last derivation site
+    (fuzzy_cluster), so it must re-derive attestation on BOTH the reduced primary and
+    each peeled band. Without the two re-derivations the primary keeps a stale tag and
+    every peeled band loads as the loader's "unknown" default.
+
+    The peeled band carries real isnad mentions -> isnad_attested. The primary's
+    recorded count is set equal to the peeled total, so the ``max(0, ...)`` reduction
+    lands it at 0 -> biographical_only — the branch a primary hits when peeling consumes
+    its whole recorded count. The assertion is that each tag follows the FINAL count.
+
+    Two equal bands of GENERIC_MIN_MENTIONS: the recorded count (50) both screens the
+    name in as generic AND equals the single peeled band, so the residual clamps to 0."""
+    out = tmp_path / "curated"
+    cand = make_canonical_id(_ABU_ABDALLAH)
+    early_death = 150 - MID_GAP
+    late_death = 250 - MID_GAP
+    canonical = [
+        # Recorded count == the peeled (late) band, so the reduction clamps to 0.
+        _canonical_row(cand, _ABU_ABDALLAH, 50),
+        _anchor_row("nar:early", early_death),
+        _anchor_row("nar:late", late_death),
+    ]
+    mentions = _hadiths_against_anchor(cand, "nar:early", 50, 0, "e")
+    mentions += _hadiths_against_anchor(cand, "nar:late", 50, 0, "l")
+    _write(out, canonical, mentions)
+
+    assert split_generic_narrators(out) is not None
+
+    by_id = _read_canonical(out)
+    peeled = [
+        r
+        for r in by_id.values()
+        if r["name_ar_normalized"] == _ABU_ABDALLAH and r["canonical_id"] != cand
+    ]
+    assert len(peeled) == 1
+    # Site 1 — _peeled_record: a band with real isnad mentions is isnad_attested.
+    assert peeled[0]["mention_count"] == 50
+    assert peeled[0]["attestation"] == "isnad_attested"
+    # Site 2 — apply loop: the primary reduced to 0 re-tags to biographical_only
+    # (a stale carried-over "isnad_attested" would be wrong).
+    assert by_id[cand]["mention_count"] == 0
+    assert by_id[cand]["attestation"] == "biographical_only"
+
+
 def test_stage_undatable_remainder_stays_on_primary(tmp_path: Path) -> None:
     out = tmp_path / "curated"
     cand = make_canonical_id(_ABU_ABDALLAH)

--- a/tests/test_resolve/test_schemas.py
+++ b/tests/test_resolve/test_schemas.py
@@ -70,13 +70,14 @@ class TestSampleData:
             "external_id": pa.array([None], type=pa.string()),
             "death_year_provenance": pa.array(["corroborated"], type=pa.string()),
             "mention_count": pa.array([5], type=pa.int32()),
+            "attestation": pa.array(["isnad_attested"], type=pa.string()),
             "source_corpus": pa.array(["sunnah"], type=pa.string()),
             "source_corpora": pa.array([["sunnah", "thaqalayn"]], type=pa.list_(pa.string())),
             "sect_affiliation": pa.array(["neutral"], type=pa.string()),
         }
         table = pa.table(data, schema=NARRATORS_CANONICAL_SCHEMA)
         assert table.num_rows == 1
-        assert {"source_corpus", "source_corpora", "sect_affiliation"} <= set(
+        assert {"source_corpus", "source_corpora", "sect_affiliation", "attestation"} <= set(
             NARRATORS_CANONICAL_SCHEMA.names
         )
 


### PR DESCRIPTION
## What

Implements the owner's **"tag & keep"** ruling on #370: a narrator attested only by a biographical source, with no surviving isnad transmission, is a real member of the graph and is kept — now **marked** so it's distinguishable from a genuine orphan and presentable by the UI as a biography-only entry.

Adds an `attestation` tag to the canonical narrator:
- `biographical_only` when `mention_count == 0` (a bio-promoted record — `bio_promote` already stamps `mention_count = 0`, "a bio is provenance, not a chain hit")
- `isnad_attested` otherwise

## Design — one shared helper, re-derived at every build site

`derive_attestation` (new `src/resolve/attestation.py`) is a pure function of `mention_count`, re-derived from each row's **final** `mention_count` at all three canonical-table build sites: `disambiguate` (mint), `bio_promote` (merge), and `fuzzy_cluster._merge_records` (id-collapse, which **sums** `mention_count`). This mirrors exactly how `derive_sect_affiliation` is already re-derived at those same three sites, so a value one producer writes can never go stale when a later merge changes `mention_count` (e.g. a bio-only record folded into an attested one → survivor re-derives to `isnad_attested`). Every other stage that rewrites `narrators_canonical.parquet` (date_reconcile / geography / …) preserves the column automatically via the schema-driven read-all/write-all idiom.

The loader maps it onto the Narrator node with an explicit `SET` (a legacy parquet lacking the column defaults to `unknown`). `orphan_narrators.cypher` now excludes `attestation = 'biographical_only'`, so its `// Expected: 0` contract is meaningful again — it catches a real orphan regression without flagging the kept bio-only nodes.

## No deploy change (confirmed)

The narrator prune (`prune-narrators` / deploy `graph-prune-narrators.yml`) keeps by **canonical-set membership**, not degree — its docstring explicitly rejects a degree predicate *because* it would wrongly delete these legitimate zero-degree canonical narrators. Bio-only narrators are canonical rows, so they already survive the prune regardless of degree. This PR does not touch that path, and no deploy edit is needed. (Scoping detail from the #370 investigation.)

## Files

- `src/models/enums.py` — `Attestation` StrEnum (`isnad_attested` / `biographical_only` / `unknown`)
- `src/resolve/attestation.py` — **new** `derive_attestation` helper
- `src/resolve/schemas.py` — `attestation` column on `NARRATORS_CANONICAL_SCHEMA`
- `src/resolve/{disambiguate,bio_promote,fuzzy_cluster}.py` — derive at each build site
- `src/graph/load_nodes.py` — map onto the Narrator node
- `queries/validation/orphan_narrators.cypher` — exclude bio-only

## Tests

`test_attestation.py` (helper), plus assertions that a bio-promoted narrator is tagged `biographical_only`, a disambiguated one `isnad_attested`, a fuzzy merge **re-tags** a folded bio-only survivor as `isnad_attested`, the property lands on the Narrator node (with the `unknown` legacy default), and the orphan query excludes bio-only. Full non-integration suite green (2256 passed); ruff + mypy-strict green.

## Notes

- **Count is not asserted in code.** The tag derives per-row from `mention_count`, so it's population-size-agnostic. The #370 analysis quoted ~42,770 P2 narrators from an earlier artifact; those counts move under da#356 re-key and should be verified at reload — nothing here depends on the number.
- **Not blocked on da#369.** The `mention_count == 0` signal cleanly excludes the P1 matn-fragment population (they carry `mention_count >= 1`), so the tag is correct with or without #369.
- The option-(3) **UI presentation** of bio-only entries is an isnad-graph concern, tracked separately.

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrsyDcQb1oGgFEVBacZzvs
