### PR TITLE
resolve: over_merged bare-generic flag producer — schema + stage + curated seed + fixture (#445)

### DIFF
--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -230,7 +230,9 @@ SET n.name_ar           = row.name_ar,
     n.attestation       = row.attestation,
     n.source_corpus     = row.source_corpus,
     n.source_corpora    = row.source_corpora,
-    n.sect_affiliation  = row.sect_affiliation
+    n.sect_affiliation  = row.sect_affiliation,
+    n.over_merged       = row.over_merged,
+    n.over_merge_note   = row.over_merge_note
 """
 
 
@@ -301,6 +303,14 @@ def _load_narrators(
                 "source_corpus": _val(row, "source_corpus", ""),
                 "source_corpora": _val(row, "source_corpora", []),
                 "sect_affiliation": _val(row, "sect_affiliation", "unknown"),
+                # Over-merge flag (da#445 / #337 flag-now). Defaults to False so the
+                # property is always present on the node (mirrors attestation/
+                # sect_affiliation) — an unset/legacy value reads as "not flagged", and
+                # the honest-leaderboard consumer (ig#1183) can filter
+                # `WHERE n.over_merged = true`. The note is left None when unflagged (a
+                # null SET simply carries no note property on those nodes).
+                "over_merged": _val(row, "over_merged", False),
+                "over_merge_note": _val(row, "over_merge_note"),
             }
         )
 

--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -172,6 +172,7 @@ RESOLVE_STEP_ORDER = (
     "narrator_split",
     "reconcile",
     "tabaqa_dates",
+    "over_merged_flag",
     "muhaddithat_links",
     "dedup",
     "parallels",
@@ -472,6 +473,7 @@ def run_all(
         muhaddithat_links,
         narrator_split,
         ner,
+        over_merged_flag,
         parallels,
         tabaqa_dates,
     )
@@ -714,6 +716,38 @@ def run_all(
     else:
         outcomes["tabaqa_dates"] = StageSkipped("tabaqa_dates", "precomputed")
         logger.info("resolve_step_skipped_precomputed", step="tabaqa_dates")
+
+    # Step 3.67: Over-merged bare-generic flag (da#445 / #337 flag-now). The LAST writer
+    # of narrators_canonical.parquet: after every date stage has finalized the canonical
+    # table, set the ``over_merged`` boolean (+ note) on the curated bare-generic hubs
+    # (bare ʿAbd Allāh, Sufyān, …) so the honest leaderboard can disclose their inflated
+    # betweenness. PURE annotation — no node is split or minted; the flagged set is a
+    # hand-verified curated list under a bidirectional acceptance fixture (no
+    # corpus-internal threshold separates chimeras from genuine hubs). Goes through
+    # write_canonical like every canonical writer, so the da#428 completeness tally is
+    # re-minted; a no-op (None) when the seed matches no row.
+    if _do("over_merged_flag"):
+        try:
+            logger.info("resolve_step", step="over_merged_flag", status="running")
+            flagged = over_merged_flag.apply_over_merged_flags(output_dir)
+            flag_files = [flagged] if flagged is not None else []
+            outcomes["over_merged_flag"] = StageRan("over_merged_flag", flag_files)
+            logger.info(
+                "resolve_step",
+                step="over_merged_flag",
+                status="complete",
+                files=len(flag_files),
+            )
+        except Exception as exc:  # noqa: BLE001
+            outcomes["over_merged_flag"] = StageErrored(
+                "over_merged_flag", type(exc).__name__, traceback.format_exc()
+            )
+            logger.error(
+                "resolve_step_failed", step="over_merged_flag", traceback=traceback.format_exc()
+            )
+    else:
+        outcomes["over_merged_flag"] = StageSkipped("over_merged_flag", "precomputed")
+        logger.info("resolve_step_skipped_precomputed", step="over_merged_flag")
 
     # Step 3.7: Curated muhaddithat orphan mention-links (da#228 / ADR-004 item #3).
     # The 8 bio-only muhaddithat narrators promoted by bio_promote carry no chain

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -936,6 +936,11 @@ def _build_canonical_table(
         "sect_affiliation": pa.array(
             [derive_sect_affiliation(_corpora(r)) for r in rows], type=pa.string()
         ),
+        # Over-merge flag (da#445) is set later by the ``over_merged_flag`` stage from
+        # the curated seed, never here — a freshly-disambiguated node defaults to
+        # unflagged (None; the graph loader reads that as False).
+        "over_merged": pa.array([r.get("over_merged") for r in rows], type=pa.bool_()),
+        "over_merge_note": pa.array([r.get("over_merge_note") for r in rows], type=pa.string()),
     }
     return pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
 

--- a/src/resolve/over_merged_flag.py
+++ b/src/resolve/over_merged_flag.py
@@ -1,0 +1,193 @@
+"""Flag over-merged bare-generic narrator nodes for the honest leaderboard (da#445).
+
+Background (#337 / #346 flag-now)
+---------------------------------
+A bare-generic narrator name — a bare ism (``محمد``, ``سفيان``) or a bare kunya
+(``أبو عبد الله``) with no distinguishing nasab/nisba — collapses many
+historically-distinct people onto one ``nar:`` node (``make_canonical_id`` is a pure
+function of the normalized name). That fused node then reports a spuriously inflated
+betweenness centrality and pollutes the top of the choke-point leaderboard.
+
+**We do NOT split and do NOT mint nodes.** The #337 spike proved algorithmic
+context-splitting of these nodes both infeasible (the chimera does not separate — bare
+``عبد الله``'s largest community is an 850-year mega-blob welded by the collectors'
+shared late teachers) and unsafe (it false-splits genuine hubs — al-Zuhrī peeled into
+five fabricated nodes, one dated 594 AH for a man who died 124 AH). So the owner chose
+to *annotate* the leaderboard now and defer a real split to external rijāl evidence
+(da#443). This stage is that annotation: one boolean column, zero fabricated nodes.
+
+Why a curated list and not a threshold
+--------------------------------------
+There is **no corpus-internal threshold** that separates over-merged chimeras from
+genuine hubs (the #337 §0 negative result): the genuine hubs Shuʿba/Qatāda/Mālik/Ibn
+ʿAbbās span an attested-neighbour-death range as wide as the chimeras, and bare Sufyān
+is as neighbour-concentrated as a hub. A pure-threshold auto-flag would re-commit the
+silent-zero error at the detector — false-flagging a genuinely central transmitter of
+the Prophet's hadith. So the flagged set is a **hand-verified curated list**
+(:data:`_SEED_PATH`) under a **bidirectional acceptance fixture**
+(``tests/test_resolve/test_over_merged_flag.py``): every genuine-hub control name MUST
+be absent from the list and every seeded chimera MUST be present — the da#423
+silent-zero discipline, the exclude direction sacred.
+
+What this stage does
+--------------------
+Reads ``over_merged_narrators.yaml``, resolves each entry to a canonical id (by
+``canonical_id`` when given, else ``make_canonical_id(normalize_arabic(name_ar))`` — the
+same rule that minted the node), and sets ``over_merged = True`` + ``over_merge_note`` on
+the matching canonical rows (every other row is set ``over_merged = False``, note None).
+It fabricates nothing and remaps nothing. Placed after the canonical table is fully
+built (after ``tabaqa_dates``); it is the last writer of ``narrators_canonical.parquet``
+and, like every canonical writer, goes through :func:`write_canonical` so the da#428
+completeness tally is re-minted. Idempotent: a re-run reads the already-flagged table
+and re-applies the same booleans.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+from src.parse.identity import make_canonical_id
+from src.resolve._run_record import write_canonical
+from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+from src.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = get_logger(__name__)
+
+# The curated seed ships beside this module (imported wherever the package installs).
+_SEED_PATH = Path(__file__).with_name("over_merged_narrators.yaml")
+
+__all__ = [
+    "OverMergedEntry",
+    "load_over_merged_seed",
+    "over_merged_flags",
+    "apply_over_merged_flags",
+]
+
+
+@dataclass(frozen=True)
+class OverMergedEntry:
+    """One curated over-merged bare-generic narrator.
+
+    Keyed either by an explicit ``canonical_id`` or by ``name_ar`` (resolved to the id
+    ``make_canonical_id`` mints — the SAME rule that created the node, so the flag lands
+    on the very node the over-merge produced). ``note`` is the confirming spike/rijāl
+    evidence, required so a flagged node always carries its justification.
+    """
+
+    canonical_id: str | None
+    name_ar: str | None
+    name_en: str | None
+    note: str
+
+    def resolved_id(self) -> str:
+        """The canonical id this entry flags — explicit id, else minted from the name."""
+        if self.canonical_id:
+            return self.canonical_id
+        return make_canonical_id(normalize_arabic(self.name_ar or ""))
+
+
+def load_over_merged_seed(path: Path = _SEED_PATH) -> tuple[OverMergedEntry, ...]:
+    """Parse the curated ``over_merged_narrators.yaml`` seed.
+
+    Returns the entries in file order (empty when the file is absent). Raises
+    ``ValueError`` on a malformed entry — a seed with a missing key is a defect, not a
+    silently-dropped row (an unflagged chimera is exactly the silent zero this list
+    exists to prevent).
+    """
+    if not path.exists():
+        return ()
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    rows = raw.get("over_merged", []) if isinstance(raw, dict) else raw
+    entries: list[OverMergedEntry] = []
+    for row in rows:
+        cid = row.get("canonical_id")
+        name_ar = row.get("name_ar")
+        note = row.get("over_merge_note")
+        if not cid and not name_ar:
+            raise ValueError("over_merged seed entry needs a canonical_id or a name_ar")
+        if not note:
+            raise ValueError(
+                f"over_merged seed entry {cid or name_ar!r} is missing its over_merge_note"
+            )
+        entries.append(
+            OverMergedEntry(
+                canonical_id=cid,
+                name_ar=name_ar,
+                name_en=row.get("name_en"),
+                note=note,
+            )
+        )
+    return tuple(entries)
+
+
+def over_merged_flags(entries: Iterable[OverMergedEntry]) -> dict[str, str]:
+    """``canonical_id -> over_merge_note`` for every seeded entry."""
+    return {entry.resolved_id(): entry.note for entry in entries}
+
+
+def apply_over_merged_flags(output_dir: Path, *, seed_path: Path = _SEED_PATH) -> Path | None:
+    """Set ``over_merged`` (+ note) on curated canonical rows; pure annotation (da#445).
+
+    Reads ``narrators_canonical.parquet`` from ``output_dir`` (the curated dir), flags the
+    rows whose canonical id is in the curated seed, and rewrites the table via
+    :func:`write_canonical`. Returns the canonical path when at least one row was flagged,
+    or ``None`` on a no-op (no canonical table, empty table, or the seed matched no row).
+    Never fabricates a node — a seed id that matches no canonical row is logged (loudly),
+    never invented.
+    """
+    canonical_path = output_dir / "narrators_canonical.parquet"
+    if not canonical_path.exists():
+        logger.warning("over_merged_flag_no_canonical", path=str(canonical_path))
+        return None
+
+    flags = over_merged_flags(load_over_merged_seed(seed_path))
+    records: list[dict[str, Any]] = pq.read_table(canonical_path).to_pylist()
+    if not records:
+        return None
+
+    matched = 0
+    for rec in records:
+        cid = rec.get("canonical_id")
+        note = flags.get(cid) if cid else None
+        if note is not None:
+            rec["over_merged"] = True
+            rec["over_merge_note"] = note
+            matched += 1
+        else:
+            rec["over_merged"] = False
+            rec["over_merge_note"] = None
+
+    # A seed id matching no canonical row is a stale/typo'd entry, NOT a licence to mint a
+    # node — surface it so an unapplied flag is observable, never silent (da#428 spirit;
+    # feedback_silent_zero_is_not_a_measurement).
+    present = {rec.get("canonical_id") for rec in records}
+    unmatched = sorted(cid for cid in flags if cid not in present)
+    if unmatched:
+        logger.warning("over_merged_flag_seed_absent", unmatched=unmatched, count=len(unmatched))
+
+    if matched == 0:
+        logger.info("over_merged_flag_no_matches", seed=len(flags), canonical_total=len(records))
+        return None
+
+    arrays = {f.name: [rec.get(f.name) for rec in records] for f in NARRATORS_CANONICAL_SCHEMA}
+    table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
+    write_canonical(table, canonical_path, stage="over_merged_flag")
+
+    logger.info(
+        "over_merged_flag_complete",
+        flagged=matched,
+        seed=len(flags),
+        unmatched_seed=len(unmatched),
+        canonical_total=len(records),
+    )
+    return canonical_path

--- a/src/resolve/over_merged_narrators.yaml
+++ b/src/resolve/over_merged_narrators.yaml
@@ -1,0 +1,85 @@
+# Curated over-merged bare-generic narrator seed (da#445 / #337 flag-now spec).
+#
+# Each entry names a canonical Narrator node that is a BARE GENERIC name — a bare ism
+# (given name) or bare kunya with no distinguishing nasab/nisba — under which many
+# historically-distinct people collapse onto one `nar:` id. Such a node reports a
+# spuriously inflated betweenness centrality (a fake choke-point). We do NOT split or
+# mint any node (the #337 spike proved algorithmic context-splitting infeasible on
+# corpus-internal evidence and unsafe — it false-splits genuine hubs). We ANNOTATE:
+# the `over_merged_flag` resolve stage sets `over_merged = true` (+ this note) on the
+# matching canonical row so the leaderboard can disclose the inflation.
+#
+# This is a SEED (seed-now, grow-later — owner). Only provably-definitional bare
+# generics that are over-merged by construction are listed; the automated high-recall
+# queue + external/rijāl confirmation grows the list under da#443. There is NO
+# corpus-internal threshold that separates these chimeras from genuine hubs (the
+# genuine hubs al-Zuhrī / Shuʿba / Mālik span the same neighbour-death range and bare
+# Sufyān looks as concentrated as a hub — see the #337 §0 negative result), which is
+# exactly why this is a curated list under a bidirectional acceptance fixture
+# (tests/test_resolve/test_over_merged_flag.py): the genuine-hub control set MUST stay
+# absent from this list, and every entry here MUST be present.
+#
+# Matching: an entry is resolved to a canonical id by `canonical_id` when given, else
+# `make_canonical_id(normalize_arabic(name_ar))` — the SAME rule that mints the node
+# (mirrors bio_promote / muhaddithat_links). `over_merge_note` is required.
+
+over_merged:
+  - name_ar: "عبد الله"
+    name_en: "Abd Allah (bare ism)"
+    over_merge_note: >-
+      Bare theophoric ism; betweenness #1 on the stg leaderboard. The #337 spike ran
+      the context splitter on this node and it did NOT separate (51 communities >
+      SPLIT_MAX_PEEL=50 -> abstains; the largest community is a ~30% mega-blob of
+      attested dates spanning -44 -> 805 AH, welded by the collectors' shared late
+      teachers). Over-merged by construction: hundreds of distinct Abd Allahs collapse
+      on the bare name.
+
+  - name_ar: "سفيان"
+    name_en: "Sufyan (bare ism)"
+    over_merge_note: >-
+      Bare ism; betweenness #2. A known fusion of at least two major transmitters,
+      Sufyan al-Thawri (d.161) and Sufyan b. Uyayna (d.198) (da#248 mononym registry).
+      Self-contradictory bio metadata on the fused node (marked a Companion AND d.278
+      AH) is the signature of an over-merge, not one person.
+
+  - name_ar: "أبو عبد الله"
+    name_en: "Abu Abd Allah (bare kunya)"
+    over_merge_note: >-
+      Bare kunya ("father of Abd Allah"), among the most common kunyas, borne by many
+      distinct narrators across generations. Top-of-leaderboard betweenness; neighbour
+      diffuseness 0.40 (well above the genuine-hub band). Over-merged by construction.
+
+  - name_ar: "أبو جعفر"
+    name_en: "Abu Jafar (bare kunya)"
+    over_merge_note: >-
+      Bare kunya borne by many distinct narrators across generations. Neighbour
+      diffuseness 0.35. Over-merged by construction; annotation only, no split.
+
+  - name_ar: "محمد"
+    name_en: "Muhammad (bare ism)"
+    over_merge_note: >-
+      Bare ism; the single most common Arabic given name, under which thousands of
+      distinct narrators collapse. Neighbour diffuseness 0.50. Over-merged by
+      construction.
+
+  - name_ar: "أحمد"
+    name_en: "Ahmad (bare ism)"
+    over_merge_note: >-
+      Bare ism borne by very many distinct narrators. Neighbour diffuseness 0.55.
+      Over-merged by construction.
+
+  - name_ar: "عبد الرحمن"
+    name_en: "Abd al-Rahman (bare ism)"
+    over_merge_note: >-
+      Bare theophoric ism spanning generations. Neighbour diffuseness 0.31.
+      Over-merged by construction.
+
+  - name_ar: "أبو بكر"
+    name_en: "Abu Bakr (bare kunya)"
+    over_merge_note: >-
+      Bare kunya borne by many traditionists (e.g. Abu Bakr b. Abi Shayba, Abu Bakr b.
+      Ayyash) across generations; neighbour diffuseness 0.39; over-merged by
+      construction. COMPANION-ADJACENT NAME: the bare kunya is NOT the Companion Abu
+      Bakr al-Siddiq (who carries a nasab), so flagging the fused bare-kunya node does
+      not touch the Companion; routed to the Arabic/rijal reviewer for confirmation.
+      Annotation only, no split.

--- a/src/resolve/schemas.py
+++ b/src/resolve/schemas.py
@@ -109,6 +109,20 @@ NARRATORS_CANONICAL_SCHEMA = pa.schema(
         pa.field("source_corpus", pa.string(), nullable=True),
         pa.field("source_corpora", pa.list_(pa.string()), nullable=True),
         pa.field("sect_affiliation", pa.string(), nullable=True),
+        # Over-merge flag (da#445 / #337/#346 flag-now). An honest-leaderboard
+        # annotation that this canonical node is a bare-generic name (bare ism/kunya)
+        # fusing many historically-distinct people, so its betweenness/centrality is
+        # inflated and it is NOT a single person. PURE annotation — no node is split or
+        # minted (algorithmic split proved infeasible on corpus-internal evidence; see
+        # the #337 flag-now spec / the external-evidence split da#443). Set by the
+        # ``over_merged_flag`` resolve stage from the curated ``over_merged_narrators.yaml``
+        # (a hand-verified, bidirectionally-gated list — no corpus-internal threshold
+        # separates chimeras from genuine hubs). Nullable so every prior canonical
+        # producer leaves it None; the graph loader defaults an unset value to False so
+        # the node property is always present. ``over_merge_note`` carries the confirming
+        # spike/rijāl evidence for a flagged node (None when unflagged).
+        pa.field("over_merged", pa.bool_(), nullable=True),
+        pa.field("over_merge_note", pa.string(), nullable=True),
     ]
 )
 

--- a/tests/integration/test_graph_loading.py
+++ b/tests/integration/test_graph_loading.py
@@ -264,6 +264,8 @@ def _write_narrators_parquet(curated: Path, rows: list[dict[str, Any]]) -> Path:
             [r.get("source_corpora", []) for r in rows], type=pa.list_(pa.string())
         ),
         "sect_affiliation": pa.array([r.get("sect_affiliation") for r in rows], type=pa.string()),
+        "over_merged": pa.array([r.get("over_merged") for r in rows], type=pa.bool_()),
+        "over_merge_note": pa.array([r.get("over_merge_note") for r in rows], type=pa.string()),
     }
     table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
     path = curated / "narrators_canonical.parquet"

--- a/tests/test_graph/conftest.py
+++ b/tests/test_graph/conftest.py
@@ -128,6 +128,8 @@ def write_narrators_canonical(curated: Path, rows: list[dict[str, Any]]) -> Path
             [r.get("source_corpora", []) for r in rows], type=pa.list_(pa.string())
         ),
         "sect_affiliation": pa.array([r.get("sect_affiliation") for r in rows], type=pa.string()),
+        "over_merged": pa.array([r.get("over_merged") for r in rows], type=pa.bool_()),
+        "over_merge_note": pa.array([r.get("over_merge_note") for r in rows], type=pa.string()),
     }
     table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
     path = curated / "narrators_canonical.parquet"

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -131,6 +131,41 @@ class TestLoadNarrators:
         assert isinstance(batch, list)
         assert batch[0]["attestation"] == "unknown"
 
+    def test_narrator_carries_over_merged_flag(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """da#445: a flagged canonical row SETs over_merged + note on the Narrator node."""
+        write_narrators_canonical(
+            curated_dir,
+            [
+                {
+                    "canonical_id": "nar:over-merged",
+                    "name_en": "Over Merged",
+                    "over_merged": True,
+                    "over_merge_note": "bare generic; betweenness inflated",
+                },
+            ],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        query, batch = next((q, b) for q, b in mock_client.calls if "MERGE (n:Narrator" in q)
+        assert "n.over_merged" in query
+        assert "n.over_merge_note" in query
+        assert batch[0]["over_merged"] is True
+        assert batch[0]["over_merge_note"] == "bare generic; betweenness inflated"
+
+    def test_narrator_over_merged_defaults_false_when_absent(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """A legacy/unflagged canonical row loads as over_merged=False (property present)."""
+        write_narrators_canonical(
+            curated_dir,
+            [{"canonical_id": "nar:unflagged", "name_en": "Unflagged"}],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        _, batch = next((q, b) for q, b in mock_client.calls if "MERGE (n:Narrator" in q)
+        assert batch[0]["over_merged"] is False
+        assert batch[0]["over_merge_note"] is None
+
     def test_invalid_canonical_id_skipped(
         self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
     ) -> None:

--- a/tests/test_resolve/test_generic_name.py
+++ b/tests/test_resolve/test_generic_name.py
@@ -115,12 +115,18 @@ class TestOverMergeFlagCandidacy:
     """
 
     def test_bare_sufyan_screens_in_at_leaderboard_scale(self) -> None:
-        # The exact da#445 acceptance assertion — already true at HEAD.
+        # The exact da#445 acceptance assertion — already true at HEAD (bare ism).
         assert is_generic_name(normalize_arabic("سفيان"), 26876) is True
 
-    def test_full_ism_nasab_is_the_unaffected_specific_form(self) -> None:
-        # The genuinely-unaffected case is a full ism+nasab (≥3 significant tokens), which
-        # stays screened OUT. (A 2-token ism+nisba like سفيان الثوري still screens IN by
-        # design — see TestRecallFirstCandidacy — so "distinguishing nisba ⇒ False" is only
-        # true once the name is a full ism+nasab.)
-        assert is_generic_name(normalize_arabic("سفيان بن سعيد الثوري"), 26876) is False
+    def test_two_token_ism_nisba_screens_in_by_design(self) -> None:
+        # A 2-token ism+nisba (سفيان الثوري) is included BY DESIGN, NOT excluded: a naive
+        # "2nd token is ال-prefixed ⇒ nisba ⇒ safe" rule would wrongly protect عبد الله
+        # (الله is ال-prefixed too), so 2-token compounds are deliberately screened IN and
+        # the (non-)split is deferred to downstream evidence. Pinned so no future change
+        # mistakes "has a nisba" for "is specific".
+        assert is_generic_name(normalize_arabic("سفيان الثوري"), _MC) is True
+
+    def test_full_ism_nasab_is_the_specificity_cutoff(self) -> None:
+        # The real "stays False" control is a full ism+nasab with ≥3 significant tokens —
+        # NOT a 2-token nisba form. This is the only shape specific enough to screen out.
+        assert is_generic_name(normalize_arabic("محمد بن اسماعيل البخاري"), _MC) is False

--- a/tests/test_resolve/test_generic_name.py
+++ b/tests/test_resolve/test_generic_name.py
@@ -99,3 +99,28 @@ class TestDegenerateInput:
     @pytest.mark.parametrize("name", ["", "   ", "\t\n"])
     def test_empty_or_whitespace_is_false_without_crash(self, name: str) -> None:
         assert is_generic_name(name, _MC) is False
+
+
+class TestOverMergeFlagCandidacy:
+    """da#445 / #337 flag-now: pin that bare Sufyān screens IN (it already does).
+
+    The flag-now spec's aside (i) asked to ensure bare Sufyān is caught by the screen.
+    It ALREADY is: a bare single-token ism screens in via the existing thin/short-fragment
+    path, so ``is_generic_name`` needs no change (a redundant "bare-ism branch" would
+    alter no output). Pinned here against a regression, with the real caveat recorded: the
+    reason bare Sufyān is nonetheless skipped by ``narrator_split`` is a DIFFERENT screen,
+    ``is_registered_mononym`` (da#248 mononym registry) — not this function. And note this
+    screen is recall-first: it returns True for genuine hubs too (al-Zuhrī, Mālik), so it
+    never separates chimeras from hubs — the da#445 curated ``over_merged`` list does that.
+    """
+
+    def test_bare_sufyan_screens_in_at_leaderboard_scale(self) -> None:
+        # The exact da#445 acceptance assertion — already true at HEAD.
+        assert is_generic_name(normalize_arabic("سفيان"), 26876) is True
+
+    def test_full_ism_nasab_is_the_unaffected_specific_form(self) -> None:
+        # The genuinely-unaffected case is a full ism+nasab (≥3 significant tokens), which
+        # stays screened OUT. (A 2-token ism+nisba like سفيان الثوري still screens IN by
+        # design — see TestRecallFirstCandidacy — so "distinguishing nisba ⇒ False" is only
+        # true once the name is a full ism+nasab.)
+        assert is_generic_name(normalize_arabic("سفيان بن سعيد الثوري"), 26876) is False

--- a/tests/test_resolve/test_over_merged_flag.py
+++ b/tests/test_resolve/test_over_merged_flag.py
@@ -1,0 +1,228 @@
+"""Tests for src.resolve.over_merged_flag — the da#445 honest-leaderboard flag.
+
+The load-bearing test is the **bidirectional acceptance gate**
+(:class:`TestBidirectionalAcceptance`): the curated seed MUST flag every known
+over-merged chimera and MUST NOT flag any genuine hub. The exclude direction is
+sacred — flagging a genuinely-central transmitter (al-Zuhrī, Abū Hurayra, …) is the
+silent-zero error this whole flag-not-split design exists to avoid (#337 §0 / da#423),
+so a seed that ever named a hub fails CI here, exactly as a split that shattered him
+would have. There is deliberately NO corpus-internal threshold in scope: the seed is a
+hand-verified curated list and this fixture is its gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.parse.identity import make_canonical_id
+from src.resolve import over_merged_flag as omf
+from src.resolve._run_record import read_run_record
+from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+
+# The two control sets are the spec's locked lists (#337 §2). MUST_INCLUDE names are the
+# provably-definitional bare generics seeded this wave; MUST_EXCLUDE are genuinely-single
+# hubs that must never be flagged. Both are keyed by their raw Arabic name and resolved
+# to a canonical id the same way the node is minted.
+_MUST_INCLUDE = (
+    "عبد الله",  # ʿAbd Allāh — betweenness #1, spike-proven mega-blob
+    "سفيان",  # Sufyān — betweenness #2, al-Thawrī + ibn ʿUyayna fusion
+    "أبو عبد الله",  # Abū ʿAbd Allāh — most common bare kunya
+    "أبو جعفر",  # Abū Jaʿfar
+    "محمد",  # Muḥammad
+    "أحمد",  # Aḥmad
+    "عبد الرحمن",  # ʿAbd al-Raḥmān
+    "أبو بكر",  # Abū Bakr — Companion-adjacent bare kunya (rijāl-reviewed)
+)
+_MUST_EXCLUDE = (
+    "الزهري",  # al-Zuhrī
+    "أبو هريرة",  # Abū Hurayra
+    "مالك",  # Mālik
+    "ابن عباس",  # Ibn ʿAbbās
+    "شعبة",  # Shuʿba
+    "قتادة",  # Qatāda
+    "الأعمش",  # al-Aʿmash
+    "نافع",  # Nāfiʿ
+    "معمر",  # Maʿmar
+)
+
+
+def _cid(name: str) -> str:
+    return make_canonical_id(normalize_arabic(name))
+
+
+class TestBidirectionalAcceptance:
+    """CI-binding: the curated seed flags every chimera and no genuine hub."""
+
+    def test_every_seeded_chimera_is_present(self) -> None:
+        flagged = set(omf.over_merged_flags(omf.load_over_merged_seed()))
+        missing = [n for n in _MUST_INCLUDE if _cid(n) not in flagged]
+        assert not missing, f"seed is missing known over-merged chimeras: {missing}"
+
+    def test_no_genuine_hub_is_flagged(self) -> None:
+        # The SACRED direction: a flag list that names a genuine hub fails here, exactly
+        # as a split that shattered al-Zuhrī would have (#337 §0 / da#423).
+        flagged = set(omf.over_merged_flags(omf.load_over_merged_seed()))
+        offenders = [n for n in _MUST_EXCLUDE if _cid(n) in flagged]
+        assert not offenders, f"seed FLAGS a genuine hub — silent-zero violation: {offenders}"
+
+
+class TestSeedIntegrity:
+    def test_every_entry_carries_a_note(self) -> None:
+        for entry in omf.load_over_merged_seed():
+            assert entry.note.strip(), (
+                f"seed entry {entry.name_ar or entry.canonical_id} has no note"
+            )
+
+    def test_resolved_ids_are_distinct(self) -> None:
+        ids = [e.resolved_id() for e in omf.load_over_merged_seed()]
+        assert len(ids) == len(set(ids)), "duplicate canonical id in the seed"
+
+    def test_malformed_entry_raises(self, tmp_path: Path) -> None:
+        # A seed entry with neither a canonical_id nor a name_ar is a defect, not a
+        # silently-dropped row (a dropped chimera is the very silent zero we guard).
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(
+            "over_merged:\n  - name_en: nameless\n    over_merge_note: x\n", encoding="utf-8"
+        )
+        with pytest.raises(ValueError, match="canonical_id or a name_ar"):
+            omf.load_over_merged_seed(bad)
+
+    def test_entry_without_note_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yaml"
+        bad.write_text('over_merged:\n  - name_ar: "محمد"\n', encoding="utf-8")
+        with pytest.raises(ValueError, match="over_merge_note"):
+            omf.load_over_merged_seed(bad)
+
+
+# --------------------------------------------------------------------------- #
+# Stage — apply_over_merged_flags over a synthetic canonical table
+# --------------------------------------------------------------------------- #
+def _canonical_row(cid: str, name_norm: str, **over: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {f.name: None for f in NARRATORS_CANONICAL_SCHEMA}
+    base["canonical_id"] = cid
+    base["name_ar_normalized"] = name_norm
+    base["mention_count"] = 100
+    base.update(over)
+    return base
+
+
+def _write_canonical(curated: Path, rows: list[dict[str, Any]]) -> None:
+    curated.mkdir(parents=True, exist_ok=True)
+    arrays = {f.name: [r.get(f.name) for r in rows] for f in NARRATORS_CANONICAL_SCHEMA}
+    pq.write_table(
+        pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA),
+        curated / "narrators_canonical.parquet",
+    )
+
+
+def _read_by_id(curated: Path) -> dict[str, dict[str, Any]]:
+    return {
+        r["canonical_id"]: r
+        for r in pq.read_table(curated / "narrators_canonical.parquet").to_pylist()
+    }
+
+
+def test_stage_flags_curated_rows_and_leaves_others(tmp_path: Path) -> None:
+    curated = tmp_path / "curated"
+    abd_allah = _cid("عبد الله")
+    sufyan = _cid("سفيان")
+    zuhri = _cid("الزهري")
+    rows = [
+        _canonical_row(abd_allah, normalize_arabic("عبد الله")),
+        _canonical_row(sufyan, normalize_arabic("سفيان")),
+        _canonical_row(zuhri, normalize_arabic("الزهري")),
+        _canonical_row("nar:ordinary", normalize_arabic("محمد بن اسماعيل البخاري")),
+    ]
+    _write_canonical(curated, rows)
+
+    assert omf.apply_over_merged_flags(curated) is not None
+    by_id = _read_by_id(curated)
+    # Chimeras flagged True and carry a note.
+    for cid in (abd_allah, sufyan):
+        assert by_id[cid]["over_merged"] is True
+        assert by_id[cid]["over_merge_note"]
+    # Genuine hub + ordinary node explicitly False with no note.
+    for cid in (zuhri, "nar:ordinary"):
+        assert by_id[cid]["over_merged"] is False
+        assert by_id[cid]["over_merge_note"] is None
+    # No node minted / dropped — pure annotation.
+    assert len(by_id) == 4
+
+
+def test_stage_matches_real_production_node_ids() -> None:
+    # The seed resolves the two top contaminants to the exact stg leaderboard node ids
+    # (project memory): bare ʿAbd Allāh nar:9b79… and bare Sufyān nar:afc3…. Pins that
+    # the name-keyed resolution mints the SAME id the corpus does, so the seed will flag
+    # the real nodes on the re-run, not phantoms.
+    flags = omf.over_merged_flags(omf.load_over_merged_seed())
+    assert _cid("عبد الله").startswith("nar:9b793066")
+    assert _cid("سفيان").startswith("nar:afc30d02")
+    assert _cid("عبد الله") in flags
+    assert _cid("سفيان") in flags
+
+
+def test_stage_no_canonical_table_is_noop(tmp_path: Path) -> None:
+    assert omf.apply_over_merged_flags(tmp_path / "curated") is None
+
+
+def test_stage_empty_canonical_is_noop(tmp_path: Path) -> None:
+    curated = tmp_path / "curated"
+    _write_canonical(curated, [])
+    assert omf.apply_over_merged_flags(curated) is None
+
+
+def test_stage_seed_matching_no_row_is_noop_and_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A canonical table with none of the seeded ids: the stage flags nothing (no-op None)
+    # and NEVER fabricates a node for an absent seed id — it warns instead.
+    curated = tmp_path / "curated"
+    _write_canonical(curated, [_canonical_row("nar:someone-else", normalize_arabic("خالد"))])
+    events: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(omf.logger, "warning", lambda e, **kw: events.append((e, kw)))
+    monkeypatch.setattr(omf.logger, "info", lambda e, **kw: events.append((e, kw)))
+
+    assert omf.apply_over_merged_flags(curated) is None
+    # The one canonical row is untouched; no seed id was invented as a new row.
+    assert len(_read_by_id(curated)) == 1
+    assert any(e == "over_merged_flag_seed_absent" for e, _ in events)
+
+
+def test_stage_is_idempotent(tmp_path: Path) -> None:
+    curated = tmp_path / "curated"
+    _write_canonical(
+        curated,
+        [
+            _canonical_row(_cid("عبد الله"), normalize_arabic("عبد الله")),
+            _canonical_row("nar:ordinary", normalize_arabic("محمد بن اسماعيل البخاري")),
+        ],
+    )
+    assert omf.apply_over_merged_flags(curated) is not None
+    first = pq.read_table(curated / "narrators_canonical.parquet").to_pylist()
+    assert omf.apply_over_merged_flags(curated) is not None
+    second = pq.read_table(curated / "narrators_canonical.parquet").to_pylist()
+    assert first == second
+
+
+def test_stage_goes_through_write_canonical(tmp_path: Path) -> None:
+    # da#428: the canonical rewrite must re-mint the completeness tally through
+    # write_canonical (the AST bypass gate + this record are how a 7th writer is caught).
+    curated = tmp_path / "curated"
+    _write_canonical(
+        curated,
+        [
+            _canonical_row(_cid("عبد الله"), normalize_arabic("عبد الله")),
+            _canonical_row("nar:ordinary", normalize_arabic("محمد بن اسماعيل البخاري")),
+        ],
+    )
+    assert omf.apply_over_merged_flags(curated) is not None
+    record = read_run_record(curated)
+    assert record is not None
+    assert record.last_writer == "over_merged_flag"
+    assert record.canonical_ids == 2

--- a/tests/test_resolve/test_schemas.py
+++ b/tests/test_resolve/test_schemas.py
@@ -74,6 +74,8 @@ class TestSampleData:
             "source_corpus": pa.array(["sunnah"], type=pa.string()),
             "source_corpora": pa.array([["sunnah", "thaqalayn"]], type=pa.list_(pa.string())),
             "sect_affiliation": pa.array(["neutral"], type=pa.string()),
+            "over_merged": pa.array([None], type=pa.bool_()),
+            "over_merge_note": pa.array([None], type=pa.string()),
         }
         table = pa.table(data, schema=NARRATORS_CANONICAL_SCHEMA)
         assert table.num_rows == 1


### PR DESCRIPTION
## Summary

Producer leg (da#445) of the honest-leaderboard **flag-now** work (meta main#958; authoritative design = Jean-Claude's flag-now spec on #337). The #337 spike proved algorithmic splitting of over-merged bare-generic nodes both **infeasible** (bare ʿAbd Allāh's largest context community is an ~850-year mega-blob) and **unsafe** (it false-splits genuine hubs — al-Zuhrī into 5 fabricated nodes). So the owner chose to **annotate, not split**: one boolean per canonical row so the choke-point leaderboard can DISCLOSE the inflation. **Zero nodes split, zero minted.**

## Deliverables

1. **Schema** — `over_merged: bool` + `over_merge_note: str` on `NARRATORS_CANONICAL_SCHEMA` (nullable; loader defaults unset → False). Every *explicit* canonical-table builder kept schema-complete (`disambiguate.py` + test helpers/fixtures); the schema-driven writers pick the columns up automatically.
2. **Curated seed** — `src/resolve/over_merged_narrators.yaml`: 8 provably-definitional bare generics (bare ʿAbd Allāh, Sufyān, Abū ʿAbd Allāh, Abū Jaʿfar, Muḥammad, Aḥmad, ʿAbd al-Raḥmān, Abū Bakr), each with an `over_merge_note`. No genuine-hub name is listed.
3. **Resolve stage** — `src/resolve/over_merged_flag.py`, placed after `tabaqa_dates` (last canonical writer). Reads the seed, resolves each entry by `canonical_id` or `make_canonical_id(normalize_arabic(name_ar))`, SETs the flag+note on matching rows. Fabricates nothing (an absent seed id is warned, never invented), rewrites via `write_canonical` (da#428 tally re-minted), idempotent. **Verified the seed resolves bare ʿAbd Allāh → `nar:9b793066…` and bare Sufyān → `nar:afc30d02…`, the exact stg leaderboard node ids.**
4. **Bidirectional acceptance fixture (CI-binding)** — `tests/test_resolve/test_over_merged_flag.py`: the 9-hub control set (al-Zuhrī, Abū Hurayra, Mālik, Ibn ʿAbbās, Shuʿba, Qatāda, al-Aʿmash, Nāfiʿ, Maʿmar) MUST be absent and every seeded chimera MUST be present. Flagging a hub fails CI (the sacred exclude direction, da#423 discipline).
5. **load_nodes** — carries `over_merged` (+ note) as a Narrator node property (default False; deploy#603 transports/sets it live).

## ⚠️ Reviewer flag — Companion-adjacent seed entry

**`أبو بكر` (Abū Bakr)** is in the seed. It is a **bare kunya** borne by many traditionists (Abū Bakr b. Abī Shayba, b. ʿAyyāsh, …) and is over-merged by construction; the bare kunya is **NOT** the Companion Abū Bakr al-Ṣiddīq (who carries a nasab), so flagging the fused bare-kunya node does not touch the Companion. Per the brief, **routing this to the Arabic/rijāl reviewer** to confirm inclusion. If the reviewer prefers it held for grow-later (da#443), I'll remove that one line + its fixture entry.

## Note on deliverable 2 (`is_generic_name` Sufyān)

Verified at HEAD that `is_generic_name("سفيان", 26876)` **already returns True** (a bare ism screens in via the existing thin/short-fragment path), so the acceptance test passes on unmodified code and a "bare-ism branch" would be redundant dead code. The real reason bare Sufyān is skipped by `narrator_split` is a *different* screen — `is_registered_mononym` (da#248) — not `is_generic_name`; and the screen is recall-first (True for genuine hubs too), which is exactly why the curated list + fixture, not a threshold, is the gate. So deliverable 2 is implemented as a **regression test that pins** the already-true behavior (no code change to `generic_name.py`). Flagged to the team lead for Jean-Claude's ruling.

## Test evidence

- ruff + mypy(`src/`) clean; `pytest -m "not integration"` → **2280 passed**.
- New: bidirectional fixture, stage end-to-end (chimera→True+note, hub/ordinary→False+None, no node minted/dropped), no-op/empty/idempotent/write_canonical-tally cases, seed integrity (note-required, distinct ids, malformed→raise), load_nodes carry-through (True+note; default False), and the da#445 `is_generic_name` pins.
- Integration tests (live Neo4j) run in the separate CI `test-integration` job — not run locally (no Docker daemon in this env); the one integration helper touched is schema-completed.

Closes #445
Part of main#928 / main#958
