### PR TITLE
resolve: clean stale Abū Bakr over_merge_note (rijāl ruling landed) (#445)

### DIFF
--- a/src/resolve/over_merged_narrators.yaml
+++ b/src/resolve/over_merged_narrators.yaml
@@ -79,7 +79,6 @@ over_merged:
     over_merge_note: >-
       Bare kunya borne by many traditionists (e.g. Abu Bakr b. Abi Shayba, Abu Bakr b.
       Ayyash) across generations; neighbour diffuseness 0.39; over-merged by
-      construction. COMPANION-ADJACENT NAME: the bare kunya is NOT the Companion Abu
-      Bakr al-Siddiq (who carries a nasab), so flagging the fused bare-kunya node does
-      not touch the Companion; routed to the Arabic/rijal reviewer for confirmation.
-      Annotation only, no split.
+      construction. Companion-adjacent: this bare kunya is a DISTINCT canonical node
+      from the Companion Abu Bakr al-Siddiq (who carries a nasab), so the flag does not
+      touch the Companion. Annotation only, no split.


### PR DESCRIPTION
## Summary

Content-only follow-up to da#445 (merged #447). Ivana ruled **Abū Bakr IN** — the bare kunya is a distinct canonical node from the Companion Abū Bakr al-Ṣiddīq (who carries a nasab) — so the seed note's `"...routed to the Arabic/rijal reviewer for confirmation"` process clause is now stale. It's **user-facing**: `over_merge_note` becomes the ig#1183 badge tooltip AND ships to stg immediately via the deploy#603 live SET, so the stale clause would actually be visible. Fixed at source so live + durable stay byte-identical.

## Change

`src/resolve/over_merged_narrators.yaml` — the **Abū Bakr note only** (1 entry):

- before: `...COMPANION-ADJACENT NAME: the bare kunya is NOT the Companion Abu Bakr al-Siddiq (who carries a nasab), so flagging the fused bare-kunya node does not touch the Companion; routed to the Arabic/rijal reviewer for confirmation. Annotation only, no split.`
- after: `...Companion-adjacent: this bare kunya is a DISTINCT canonical node from the Companion Abu Bakr al-Siddiq (who carries a nasab), so the flag does not touch the Companion. Annotation only, no split.`

## Scope discipline

- Exactly **one** note edited; the other 7 are untouched (they render as expandable "why flagged" detail, per the team-lead call).
- The Abū Bakr **canonical id is unchanged** (`nar:cf44624b-1f1b-5c9e-b498-625d55191fd2`) — the note is not part of the id.
- The **bidirectional acceptance fixture asserts ids, not note text**, so it does not move.
- Note stays single-line / ASCII (YAML folded scalar).

## Verification

- yaml parses; seed still 8 entries; Abū Bakr id stable; note no longer contains "routed", now contains "DISTINCT canonical node".
- `pytest tests/test_resolve/test_over_merged_flag.py tests/test_resolve/test_generic_name.py` → 33 passed.
- ruff + full pre-push (mypy + pytest `-m "not integration"`) green.

After merge I'll re-emit the id→note map so the team lead can relay the final version to Aisha for the deploy#603 live dispatch.

Re #445
Part of main#928 / main#958
