### PR TITLE
resolve: remove unreachable Gate 3 (SPLIT_MIN_SEPARATION) dead code (da#444)

### DIFF
--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -47,8 +47,15 @@ Algorithm (per eligible canonical id ``C``, name ``N``)
 4. **ABSTAIN — leave ``C`` as ONE node — UNLESS ALL hold** (the over-split guard):
    * ≥2 clusters each with ≥ :data:`SPLIT_MIN_SUPPORT` mentions (*qualifying*);
    * ≤ :data:`SPLIT_MAX_CLUSTERS` qualifying clusters (more ⇒ the name is a generic
-     bucket we cannot cleanly resolve → abstain, logged for audit);
-   * adjacent qualifying-cluster midpoints separated by > :data:`SPLIT_MIN_SEPARATION`.
+     bucket we cannot cleanly resolve → abstain, logged for audit).
+
+   A separate "adjacent bands too close ⇒ abstain" separation guard is **not** needed:
+   :func:`_cut_bands` only ever starts a new band on a consecutive gap exceeding
+   :data:`SPLIT_BAND_GAP` (80 AH), so any two distinct bands — and therefore any two
+   qualifying bands — are already > 80 AH apart by construction, well beyond any
+   contemporaries-scatter threshold. (A ``SPLIT_MIN_SEPARATION = 50`` gate once sat here;
+   because ``SPLIT_BAND_GAP > 50`` it was structurally unreachable and was removed as
+   dead code — da#444.)
 5. **Peel-not-partition** — undatable mentions, and any mention in a below-support
    band, STAY on the primary node. Only confidently-dated distinct clusters peel off.
 6. **Id assignment** (deterministic — a pure function of the input, reproducible
@@ -147,7 +154,6 @@ logger = get_logger(__name__)
 __all__ = [
     "SPLIT_BAND_GAP",
     "SPLIT_MIN_SUPPORT",
-    "SPLIT_MIN_SEPARATION",
     "SPLIT_MAX_CLUSTERS",
     "MID_GAP",
     "NARRATOR_SPLITS_SCHEMA",
@@ -176,10 +182,6 @@ SPLIT_BAND_GAP = 80
 # Below it, a band is left on the primary (peel-not-partition) — a handful of
 # adjacency estimates is not enough to mint a distinct historical person.
 SPLIT_MIN_SUPPORT = 10
-
-# Two qualifying bands whose midpoints are closer than this are treated as one
-# referent's scatter, not two people — abstain. Secondary to SPLIT_BAND_GAP.
-SPLIT_MIN_SEPARATION = 50
 
 # More than this many *qualifying* bands means the name is a generic bucket we cannot
 # cleanly resolve into a few people — abstain and log for audit rather than shatter it.
@@ -341,11 +343,12 @@ def plan_split(name_ar_normalized: str, datable: list[DatableMention]) -> SplitP
             max_clusters=SPLIT_MAX_CLUSTERS,
         )
         return abstain
-    # Gate 3: adjacent qualifying midpoints must be well separated.
+    # Gate 1 (single band) + Gate 2 (too many) are the complete guard set. A third
+    # "adjacent midpoints too close ⇒ abstain" separation guard was removed as dead code
+    # (da#444): _cut_bands starts a new band only on a gap > SPLIT_BAND_GAP (80 AH), so
+    # any two qualifying bands are already > 80 AH apart — the removed SPLIT_MIN_SEPARATION
+    # (50) check could never fire.
     qsorted = sorted(qualifying, key=_band_midpoint)
-    mids = [_band_midpoint(b) for b in qsorted]
-    if any(b - a <= SPLIT_MIN_SEPARATION for a, b in zip(mids, mids[1:], strict=False)):
-        return abstain
 
     # The largest qualifying band (ties → lower midpoint) keeps the primary id; the
     # undatable/below-support remainder is already off the peel list by construction.

--- a/tests/test_resolve/test_narrator_split.py
+++ b/tests/test_resolve/test_narrator_split.py
@@ -6,7 +6,8 @@ the recall-first ``is_generic_name`` screen admits genuinely-single people
 evidence — ≥2 well-separated, well-supported bands — never on the screen alone. A
 single-band name abstains and its node is left whole. Coverage:
 
-* pure ``plan_split`` band logic (abstain vs peel, every gate);
+* pure ``plan_split`` band logic (abstain vs peel, both live gates — Gate 1 single-band
+  and Gate 2 too-many-bands; the old Gate 3 separation guard was dead code, removed da#444);
 * the ``سفيان الثوري`` case Ivana flagged — screens IN, death-band gate ABSTAINS;
 * end-to-end stage over parquet fixtures — peel-not-partition, undatable remainder
   stays, registered-mononym deferral, remap correctness, idempotence, and a
@@ -28,9 +29,12 @@ from src.resolve import MissingInputError
 from src.resolve.generic_name import is_generic_name
 from src.resolve.narrator_split import (
     MID_GAP,
+    SPLIT_BAND_GAP,
     SPLIT_MAX_CLUSTERS,
     SPLIT_MIN_SUPPORT,
     DatableMention,
+    _band_midpoint,
+    _cut_bands,
     plan_split,
     split_generic_narrators,
 )
@@ -111,6 +115,30 @@ def test_within_band_gap_estimates_stay_one_band() -> None:
     # ordinary within-person estimate scatter must not fragment a node.
     datable = _dm(200, 15) + _dm(240, 15, "b2")
     assert not plan_split(_ABU_ABDALLAH, datable).is_split
+
+
+def test_removed_gate3_separation_is_dead_code() -> None:
+    # da#444: the old Gate 3 (`SPLIT_MIN_SEPARATION = 50`, "adjacent qualifying midpoints
+    # too close ⇒ abstain") was structurally unreachable and is removed. `_cut_bands`
+    # starts a new band only on a consecutive gap > SPLIT_BAND_GAP (80 AH), so ANY two
+    # bands it emits are already > 80 AH apart — well beyond any <=50 contemporaries
+    # threshold. Sweep two well-supported bands across every separation 0..300 and assert:
+    #   * two bands ever form only when the requested separation > SPLIT_BAND_GAP, and when
+    #     they do their adjacent midpoints are always > SPLIT_BAND_GAP apart (never <=50);
+    #   * the only two outcomes are a single-band abstain (Gate 1) or a clean split —
+    #     a separation-based abstain never occurs.
+    n = SPLIT_MIN_SUPPORT + 5
+    for sep in range(0, 301):
+        datable = _dm(120, n, "early") + _dm(120 + sep, n, "late")
+        qual = [b for b in _cut_bands(datable) if len(b) >= SPLIT_MIN_SUPPORT]
+        plan = plan_split(_ABU_ABDALLAH, datable)
+        if len(qual) >= 2:
+            mids = sorted(_band_midpoint(b) for b in qual)
+            adj = min(b - a for a, b in zip(mids, mids[1:], strict=False))
+            assert adj > SPLIT_BAND_GAP  # never in the removed gate's <=50 range
+            assert plan.is_split  # two well-supported separated bands always peel
+        else:
+            assert not plan.is_split  # collapsed to one band → Gate 1 abstain
 
 
 def test_same_band_label_collision_tiebreak_by_anchor() -> None:


### PR DESCRIPTION
## Summary

Removes the date-axis `narrator_split` **Gate 3** (`SPLIT_MIN_SEPARATION = 50`) as
**unreachable dead code** (da#444). The guard — "adjacent qualifying-band midpoints too
close ⇒ abstain" in `plan_split` — can never fire given the current constant
relationship, so its abstain branch is never taken.

## Root cause

Two thresholds are in tension:

- `SPLIT_BAND_GAP = 80` — `_cut_bands` starts a new death-band whenever a consecutive
  estimate gap exceeds 80 AH, so any two distinct bands are separated by a > 80 AH gap.
- `SPLIT_MIN_SEPARATION = 50` — Gate 3 abstained when two adjacent qualifying-band
  **midpoints** were `<= 50` AH apart.

Because two bands only exist when separated by a > 80 gap, `min(next) > max(prev) + 80`
and each midpoint lies inside its band's range, so adjacent midpoints are always `> 80`
apart — never `<= 50`. Since `SPLIT_BAND_GAP (80) > SPLIT_MIN_SEPARATION (50)`, the
guard is structurally unreachable.

## Evidence

Swept two well-supported bands through the real `plan_split` across every separation
0..300. Outcomes were **only** a single-band Gate 1 abstain (separation <= 80) or a
clean split; the minimum adjacent qualifying-band midpoint separation ever observed was
**81**. `gate3` never determined an outcome. Verified the instrument separates the
classes (Gate 1 vs split) before reading the null result.

## Change (Option 1 — remove)

- Remove the Gate 3 block and the `SPLIT_MIN_SEPARATION` constant (+ its `__all__`
  entry). Documented that Gate 1 (single-band) + Gate 2 (too-many-bands) are the
  **complete** guard set, and why a separation gate is structurally unnecessary given
  `SPLIT_BAND_GAP > 50`.
- Chose Option 1 over Option 2 (re-enable by raising the threshold above
  `SPLIT_BAND_GAP`): that would change split behavior on adjacent-but-separated bands
  and needs its own evidence, which does not exist. No product reason to abstain there.

## Impact

Latent only — **no behavior change**. Gate 1 + Gate 2 carry the real over-split
protection; nothing that split before splits differently now.

## Tests

- New `test_removed_gate3_separation_is_dead_code`: sweeps 0..300 and asserts two
  qualifying bands are always `> SPLIT_BAND_GAP` apart and the only outcomes are Gate 1
  abstain or split — no separation-based abstain.
- `pytest tests/test_resolve/test_narrator_split.py` → 19 passed.
- ruff format + lint clean; mypy strict clean; full pre-push green.

## Reviewers

- Peer: **Nikolaos Papadopoulos**
- Secondary: **Oyunbileg Batbayar**

Closes #444
Part of main#928
