### PR TITLE
fix(resolve): reconcile narrator_split adjacency with loader TRANSMITTED_TO (da#439)

### DIFF
--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -31,15 +31,22 @@ not by the name shape.
 Algorithm (per eligible canonical id ``C``, name ``N``)
 -------------------------------------------------------
 1. Gather every mention with ``canonical_narrator_id == C``.
-2. **Isnad-adjacency evidence** — for each such mention, look at the chain neighbours
-   at ``position_in_chain`` ±1 in the same ``(hadith_id, chain_index)`` chain (da#411 —
-   the composite key the graph loaders use; NOT ``hadith_id`` alone, which would
-   fabricate cross-chain neighbours in a multi-isnad hadith) and map them to their
-   *attested* ``death_year_ah`` (precision ≠ ``tabaqa_estimate`` — an *estimated*
-   window is never used as evidence, which also keeps the pass cascade-free on
-   re-run). A teacher (neighbour at position−1) dies a transmission gap *earlier*;
-   a student (position+1) a gap *later* — so ``C``'s per-mention death estimate is
-   ``neighbour_death ± MID_GAP`` (``MID_GAP`` the midpoint of
+2. **Isnad-adjacency evidence** — for each such mention, look at its immediately
+   preceding / following **resolved** chain neighbours in the same
+   ``(hadith_id, chain_index)`` chain (da#411 — the composite key the graph loaders
+   use; NOT ``hadith_id`` alone, which would fabricate cross-chain neighbours in a
+   multi-isnad hadith) and map them to their *attested* ``death_year_ah``
+   (precision ≠ ``tabaqa_estimate`` — an *estimated* window is never used as
+   evidence, which also keeps the pass cascade-free on re-run). "Adjacent" is the
+   **consecutive-resolved** notion the loader pairs into ``TRANSMITTED_TO`` edges
+   (:func:`src.graph.load_edges._build_chain_pairs`, da#439), NOT an exact
+   ``position ± 1`` test: an intermediate position left unresolved (null
+   ``canonical_narrator_id``) opens a position gap that the loader bridges and that
+   an exact-±1 window would silently skip — erasing the adjacency of any narrator
+   seen only in gappy chains (the drop-gate erasure class, main#928 / da#423). A
+   teacher (the earlier-position neighbour) dies a transmission gap *earlier*; a
+   student (the later-position neighbour) a gap *later* — so ``C``'s per-mention
+   death estimate is ``neighbour_death ± MID_GAP`` (``MID_GAP`` the midpoint of
    :data:`~src.resolve.mononym_split._MIN_GAP`/``_MAX_GAP``), averaged over the
    mention's attested neighbours. A mention with no attested neighbour is *undatable*.
 3. **Cluster** the per-mention estimates 1-D, gap-based: sort and cut wherever a
@@ -548,6 +555,13 @@ def _build_chain_index(
             key = (hid, _coalesce_chain_index(cidx))
             if key in candidate_chain_keys:
                 chains.setdefault(key, []).append((int(pos), cid))
+    # Position-sort each chain once so :func:`_collect_datable` can read a mention's
+    # immediately-preceding / -following resolved neighbour by list index — the SAME
+    # position-sorted, consecutive-resolved adjacency the loader pairs into
+    # TRANSMITTED_TO edges (load_edges._build_chain_pairs, da#439). Tie-break on the
+    # canonical id so two resolved mentions sharing a position order deterministically.
+    for chain in chains.values():
+        chain.sort(key=lambda pc: (pc[0], pc[1]))
     return chains, candidate_mentions
 
 
@@ -559,21 +573,48 @@ def _collect_datable(
 ) -> list[DatableMention]:
     """Per-mention death estimates from attested chain neighbours (undatable dropped).
 
-    A neighbour is only ever the mention's ±1 position **within the same
-    ``(hadith_id, chain_index)`` chain** — never another isnad of the same hadith
-    (da#411) — mirroring the graph loaders' composite chain key.
+    A neighbour is the mention's immediately-preceding / -following **resolved**
+    mention in its position-sorted ``(hadith_id, chain_index)`` chain — never another
+    isnad of the same hadith (da#411). This is the **consecutive-resolved** adjacency
+    the graph loader pairs into ``TRANSMITTED_TO`` edges
+    (:func:`src.graph.load_edges._build_chain_pairs`), NOT an exact ``position ± 1``
+    test (da#439): when an intermediate position is unresolved (null
+    ``canonical_narrator_id``, dropped from ``chains`` in :func:`_build_chain_index`),
+    it opens a position gap. The loader still pairs across that gap (consecutive in the
+    resolved list), so an exact-±1 window here would diverge from the loaded graph —
+    systematically erasing the teacher/student adjacency of any narrator that appears
+    only in gappy chains (the drop-gate erasure class, main#928 / da#423). Reading the
+    immediate sorted-list neighbours instead keeps the split's evidence and the loaded
+    topology in agreement.
+
+    The loader's self-loop drop is mirrored too: a neighbour that resolves to the
+    mention's own canonical id forms no ``TRANSMITTED_TO`` edge (``from_id == to_id``),
+    so it contributes no adjacency here — and, as in the loader, is NOT bridged past to
+    the next resolved mention.
     """
     datable: list[DatableMention] = []
     for hadith_id, chain_index, position, mention_id in mentions:
+        chain = chains.get((hadith_id, chain_index), ())
+        # Locate this mention's slot in the position-sorted resolved chain
+        # (pre-sorted in _build_chain_index). Absent only if the chain was pruned —
+        # defensively skip rather than fabricate an adjacency.
+        idx = next((i for i, (p, _c) in enumerate(chain) if p == position), None)
+        if idx is None:
+            continue
+        own_id = chain[idx][1]
         estimates: list[int] = []
         anchors: list[str] = []
-        for npos, nid in chains.get((hadith_id, chain_index), ()):
-            if npos == position - 1:
-                sign = 1  # neighbour is the teacher (dies earlier) → C dies later
-            elif npos == position + 1:
-                sign = -1  # neighbour is the student (dies later) → C dies earlier
-            else:
+        # Teacher = the immediately-preceding resolved mention (lower position, dies
+        # earlier → C dies later, sign +1); student = the immediately-following
+        # (higher position, dies later → C dies earlier, sign −1). Consecutive in the
+        # resolved list, so a position gap from a dropped unresolved mention is
+        # bridged exactly as the loader bridges it.
+        for nidx, sign in ((idx - 1, 1), (idx + 1, -1)):
+            if nidx < 0 or nidx >= len(chain):
                 continue
+            nid = chain[nidx][1]
+            if nid == own_id:
+                continue  # self-loop: no edge in the graph, no adjacency here
             year = attested_by_id.get(nid)
             if year is None:
                 continue

--- a/tests/test_resolve/test_narrator_split.py
+++ b/tests/test_resolve/test_narrator_split.py
@@ -611,3 +611,103 @@ def test_multi_isnad_no_cross_chain_neighbour(tmp_path: Path) -> None:
     # …with no cross-chain leak in either direction (the load-bearing assertion).
     assert not (set(by_mention["m-c-0"].anchor_names) & chain1_anchors)
     assert not (set(by_mention["m-c-1"].anchor_names) & chain0_anchors)
+
+
+def test_gappy_chain_datable_across_dropped_position(tmp_path: Path) -> None:
+    """da#439: a position gap (from a dropped unresolved mention) must NOT hide a neighbour.
+
+    Chain positions 0..4, but positions 1 and 3 are **unresolved** (null
+    ``canonical_narrator_id``) and so are dropped from ``chains`` in
+    ``_build_chain_index``. The candidate sits at position 2; its only resolved
+    neighbours are the teacher at position 0 and the student at position 4 — each two
+    positions away.
+
+    The loader (``load_edges._build_chain_pairs``) pairs *consecutive resolved*
+    mentions, so it emits ``teacher -> candidate`` and ``candidate -> student`` across
+    those gaps. The old exact-``position ± 1`` window looked only at positions 1 and 3
+    (both dropped), found nothing, and left the candidate **undatable** — a systematic
+    under-count relative to the loaded graph (RED). Reading the immediate resolved
+    neighbours in the position-sorted chain recovers both adjacencies (GREEN).
+    """
+    from src.resolve.narrator_split import _build_chain_index, _collect_datable
+
+    cand = make_canonical_id(_ABU_ABDALLAH)
+    teacher = _anchor_row("nar:teacher", 100)  # pos 0 → dies earlier → sign +1
+    student = _anchor_row("nar:student", 180)  # pos 4 → dies later → sign −1
+    canonical = [_canonical_row(cand, _ABU_ABDALLAH, 1), teacher, student]
+    mentions = [
+        _mention_row("m-teacher", "h1", 0, "nar:teacher", chain_index=0),
+        _mention_row("m-gap1", "h1", 1, None, chain_index=0),  # unresolved → dropped
+        _mention_row("m-cand", "h1", 2, cand, chain_index=0),
+        _mention_row("m-gap3", "h1", 3, None, chain_index=0),  # unresolved → dropped
+        _mention_row("m-student", "h1", 4, "nar:student", chain_index=0),
+    ]
+    out = tmp_path / "curated"
+    _write(out, canonical, mentions)
+
+    attested_by_id = {r["canonical_id"]: r["death_year_ah"] for r in (teacher, student)}
+    name_by_id = {r["canonical_id"]: r["name_ar_normalized"] for r in canonical}
+
+    chains, candidate_mentions = _build_chain_index(
+        out / "narrator_mentions_resolved.parquet", {cand}
+    )
+    datable = _collect_datable(candidate_mentions[cand], chains, attested_by_id, name_by_id)
+
+    # The candidate is datable ACROSS the gaps — the exact-±1 window would have left
+    # `datable` empty (the divergence da#439 fixes).
+    assert len(datable) == 1
+    dm = datable[0]
+    assert set(dm.anchor_names) == {
+        name_by_id["nar:teacher"],
+        name_by_id["nar:student"],
+    }
+    # Estimate folds both neighbours with the loader-consistent sign convention:
+    # teacher (earlier position) + MID_GAP, student (later position) − MID_GAP.
+    assert dm.estimate == round(((100 + MID_GAP) + (180 - MID_GAP)) / 2)
+
+
+def test_split_adjacency_matches_loader_transmitted_to(tmp_path: Path) -> None:
+    """da#439: the split's neighbour set == the loader's TRANSMITTED_TO edges (same chain).
+
+    The reconciliation this issue asks for is *agreement* between two definitions of
+    "adjacent". This test runs BOTH on the same gappy fixture and asserts the candidate's
+    splitter neighbours are exactly the narrators the loader connects it to — the
+    cross-function invariant, not just a splitter-internal fixture.
+    """
+    from src.graph.load_edges import _build_chain_pairs
+    from src.resolve.narrator_split import _build_chain_index, _collect_datable
+
+    cand = make_canonical_id(_ABU_ABDALLAH)
+    teacher = _anchor_row("nar:teacher", 100)
+    student = _anchor_row("nar:student", 180)
+    canonical = [_canonical_row(cand, _ABU_ABDALLAH, 1), teacher, student]
+    # Same single (hadith_id, chain_index) chain with two interior gaps.
+    mention_rows = [
+        _mention_row("m-teacher", "hdt:bukhari:1", 0, "nar:teacher", chain_index=0),
+        _mention_row("m-gap1", "hdt:bukhari:1", 1, None, chain_index=0),
+        _mention_row("m-cand", "hdt:bukhari:1", 2, cand, chain_index=0),
+        _mention_row("m-gap3", "hdt:bukhari:1", 3, None, chain_index=0),
+        _mention_row("m-student", "hdt:bukhari:1", 4, "nar:student", chain_index=0),
+    ]
+    out = tmp_path / "curated"
+    _write(out, canonical, mention_rows)
+
+    # Loader side: TRANSMITTED_TO edges incident to the candidate → the other endpoints.
+    loader_pairs = _build_chain_pairs(mention_rows)
+    loader_neighbours = {p["to_id"] for p in loader_pairs if p["from_id"] == cand} | {
+        p["from_id"] for p in loader_pairs if p["to_id"] == cand
+    }
+    assert loader_neighbours == {"nar:teacher", "nar:student"}
+
+    # Splitter side: the anchors it derived for the candidate, mapped back to ids.
+    attested_by_id = {r["canonical_id"]: r["death_year_ah"] for r in (teacher, student)}
+    name_by_id = {r["canonical_id"]: r["name_ar_normalized"] for r in canonical}
+    id_by_name = {v: k for k, v in name_by_id.items()}
+    chains, candidate_mentions = _build_chain_index(
+        out / "narrator_mentions_resolved.parquet", {cand}
+    )
+    datable = _collect_datable(candidate_mentions[cand], chains, attested_by_id, name_by_id)
+    split_neighbours = {id_by_name[n] for d in datable for n in d.anchor_names}
+
+    # The two notions of adjacency AGREE (the da#439 invariant).
+    assert split_neighbours == loader_neighbours


### PR DESCRIPTION
## What & why

Closes #439.

`narrator_split`'s death-band evidence and the graph loader used two different notions of chain adjacency, diverging on **gappy chains**:

- **Loader** (`load_edges._build_chain_pairs`): sorts a chain by `position_in_chain`, filters to **resolved** mentions, and pairs **consecutive resolved** mentions — bridging any position gap.
- **Splitter** (`narrator_split._collect_datable`): matched neighbours at an **exact `position ± 1`**.

When an intermediate position is unresolved (null `canonical_narrator_id`, dropped from the split's chain index), the loader still emits a `TRANSMITTED_TO` edge across the gap, but the exact-±1 window found nothing and left the narrator **undatable**. A narrator appearing only in gappy chains was therefore systematically **erased** from the split's evidence relative to the loaded graph — the drop-gate erasure class (main#928 / da#423), and a PR-B (#337/#346) input concern since PR-B's isnad-neighbour discriminator clusters on that same adjacency.

## Change

- `_collect_datable` now reads a mention's **immediately-preceding / -following resolved** neighbour in its position-sorted `(hadith_id, chain_index)` chain — the loader's consecutive-resolved notion — instead of exact ±1. It mirrors the loader's **self-loop drop** (a neighbour resolving to the mention's own id forms no edge and is not bridged past).
- `_build_chain_index` position-sorts each chain once (deterministic `(position, cid)` order) so the lookup is by list index.
- The composite-key cross-chain confinement (da#411) and the sign convention (teacher = earlier position `+MID_GAP`, student = later position `−MID_GAP`) are unchanged.

## Tests (agreement, not just a fixture)

- `test_gappy_chain_datable_across_dropped_position` — chain with positions 0/2/4 resolved and 1/3 dropped; **RED** under exact-±1 (candidate undatable, verified), **GREEN** now (datable across both gaps).
- `test_split_adjacency_matches_loader_transmitted_to` — runs **both** `_build_chain_pairs` (loader) and the split path on one gappy fixture and asserts the candidate's split neighbours equal the loader's `TRANSMITTED_TO` edges incident to it. This exercises the reconciled adjacency against the real loader function, not a splitter-internal fixture — the da#439 invariant.

## Gates
- Full resolve + graph suites green (`857 passed, 6 skipped`); narrator_split file `20 passed`.
- ruff lint + format, mypy strict: clean. Pre-commit + pre-push hooks passed (cspell skipped — `.py` is out of cspell's `docs/**/*.md` scope; no workflow/secret changes).

Reviewers: @ requested Kavitha Sundaramurthy, Ivana Horvat.
