### PR TITLE
resolve: contextual (isnad-neighbour) disambiguation of over-merged bare names (da#346)

### DIFF
--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -170,6 +170,7 @@ RESOLVE_STEP_ORDER = (
     "bio_promote",
     "cluster",
     "narrator_split",
+    "contextual_disambiguation",
     "reconcile",
     "tabaqa_dates",
     "over_merged_flag",
@@ -466,6 +467,7 @@ def run_all(
 
     from src.resolve import (
         bio_promote,
+        contextual_disambiguation,
         date_reconcile,
         dedup,
         disambiguate,
@@ -657,6 +659,47 @@ def run_all(
     else:
         outcomes["narrator_split"] = StageSkipped("narrator_split", "precomputed")
         logger.info("resolve_step_skipped_precomputed", step="narrator_split")
+
+    # Step 3.57: Contextual (isnad-neighbour) disambiguation (da#346). The date-axis
+    # narrator_split abstains on a BARE name (no attested death-band to cut), but the
+    # isnad POSITION still identifies a referent: a bare ʿAbd Allāh narrating ⟵Prophet
+    # ⟶Nāfiʿ is Ibn ʿUmar. For each curated, hand-verified neighbour-pair signature,
+    # peel the matching mentions onto a distinct discriminated node; leave every unknown
+    # or ambiguous mention on the bare primary (which over_merged_flag keeps flagged) and
+    # to da#443's external-rijāl split. Runs AFTER narrator_split (operates on the settled
+    # canonical set) and BEFORE reconcile/tabaqa_dates/over_merged_flag so the peeled ids
+    # + remapped mentions flow through the date stages and the residual flag counts the
+    # reduced primary. Empty seed ⇒ pure no-op. Idempotent (peeled ids no longer carry the
+    # bare name; the residual still matches no signature). Emits contextual_splits.parquet
+    # (audit) + contextual_coverage.parquet (the da#346 blast-radius report).
+    if _do("contextual_disambiguation"):
+        try:
+            logger.info("resolve_step", step="contextual_disambiguation", status="running")
+            ctx_path = contextual_disambiguation.apply_contextual_disambiguation(
+                output_dir, staging_dir=staging_dir
+            )
+            ctx_files = [ctx_path] if ctx_path is not None else []
+            outcomes["contextual_disambiguation"] = StageRan("contextual_disambiguation", ctx_files)
+            logger.info(
+                "resolve_step",
+                step="contextual_disambiguation",
+                status="complete",
+                files=len(ctx_files),
+            )
+        except Exception as exc:  # noqa: BLE001
+            outcomes["contextual_disambiguation"] = StageErrored(
+                "contextual_disambiguation", type(exc).__name__, traceback.format_exc()
+            )
+            logger.error(
+                "resolve_step_failed",
+                step="contextual_disambiguation",
+                traceback=traceback.format_exc(),
+            )
+    else:
+        outcomes["contextual_disambiguation"] = StageSkipped(
+            "contextual_disambiguation", "precomputed"
+        )
+        logger.info("resolve_step_skipped_precomputed", step="contextual_disambiguation")
 
     # Step 3.6: Multi-source date reconciliation (da#165). After bio_promote and
     # cluster have built the final canonical set, fold each narrator's per-source

--- a/src/resolve/contextual_disambiguation.py
+++ b/src/resolve/contextual_disambiguation.py
@@ -51,10 +51,12 @@ Algorithm (per curated signature ``S`` on bare name ``N``)
 ----------------------------------------------------------
 1. Resolve ``N`` to its canonical id ``C = make_canonical_id(N)`` and gather every
    mention with ``canonical_narrator_id == C``.
-2. For each such mention, read its ±1 chain neighbours **within the same
-   ``(hadith_id, chain_index)`` chain** (:func:`src.resolve.narrator_split._build_chain_index`,
-   da#411 — never a cross-chain neighbour) and map them to their normalized names: the
-   set of teacher names (position −1) and student names (position +1).
+2. For each such mention, read its **consecutive-resolved** teacher/student neighbours
+   within the same ``(hadith_id, chain_index)`` chain — the SHARED adjacency helper
+   :func:`src.resolve.narrator_split.resolved_chain_neighbours` (da#439), identical to
+   the loader's ``TRANSMITTED_TO`` adjacency and the date-band splitter's, so a gappy
+   isnad cannot silently erase a discriminating pair (da#411 — never a cross-chain
+   neighbour) — and map them to their normalized names.
 3. A signature *matches* a mention iff every neighbour role it constrains is satisfied —
    its ``teacher_ar`` (if given) is among the mention's teacher names AND its
    ``student_ar`` (if given) among the student names. A mention matched by exactly one
@@ -100,7 +102,11 @@ import yaml
 from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
 from src.resolve._run_record import write_canonical
 from src.resolve.attestation import derive_attestation
-from src.resolve.narrator_split import _build_chain_index, _remap_split_mentions
+from src.resolve.narrator_split import (
+    _build_chain_index,
+    _remap_split_mentions,
+    resolved_chain_neighbours,
+)
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
@@ -280,26 +286,28 @@ def _neighbour_names_by_mention(
     chains: dict[tuple[str, int], list[tuple[int, str]]],
     name_by_id: dict[str, str],
 ) -> dict[str, tuple[frozenset[str], frozenset[str]]]:
-    """``mention_id -> (teacher_names, student_names)`` from ±1 in-chain neighbours.
+    """``mention_id -> (teacher_names, student_names)`` from the consecutive-resolved neighbours.
 
-    A neighbour is only ever the ±1 position **within the same ``(hadith_id, chain_index)``
-    chain** (da#411), mirroring the graph loaders' composite chain key. Names are the
-    normalized ``name_ar_normalized`` of the neighbour canonical ids.
+    Uses the **shared** isnad-adjacency helper
+    (:func:`src.resolve.narrator_split.resolved_chain_neighbours`, da#439) so this stage's
+    notion of teacher/student is byte-identical to the date-band splitter's and to the
+    loader's ``TRANSMITTED_TO`` adjacency — the immediately-preceding / -following
+    **resolved** mention in the position-sorted ``(hadith_id, chain_index)`` chain (a
+    dropped-position gap bridged as the loader bridges it; self-loop dropped, not bridged
+    past; never a cross-isnad neighbour, da#411). Reading exact ``position ± 1`` here (the
+    pre-da#439 form) would have silently erased a golden-chain teacher/student pair on any
+    gappy isnad — under-peeling a confident identity. Names are the neighbour ids'
+    ``name_ar_normalized``; each role is a singleton or empty set.
     """
     out: dict[str, tuple[frozenset[str], frozenset[str]]] = {}
     for hadith_id, chain_index, position, mention_id in mentions:
-        teachers: set[str] = set()
-        students: set[str] = set()
-        for npos, nid in chains.get((hadith_id, chain_index), ()):
-            if npos == position - 1:
-                name = name_by_id.get(nid)
-                if name:
-                    teachers.add(name)
-            elif npos == position + 1:
-                name = name_by_id.get(nid)
-                if name:
-                    students.add(name)
-        out[mention_id] = (frozenset(teachers), frozenset(students))
+        teacher_id, student_id = resolved_chain_neighbours(chains, hadith_id, chain_index, position)
+        teacher_name = name_by_id.get(teacher_id) if teacher_id else None
+        student_name = name_by_id.get(student_id) if student_id else None
+        out[mention_id] = (
+            frozenset({teacher_name} if teacher_name else ()),
+            frozenset({student_name} if student_name else ()),
+        )
     return out
 
 

--- a/src/resolve/contextual_disambiguation.py
+++ b/src/resolve/contextual_disambiguation.py
@@ -1,0 +1,548 @@
+"""Peel confidently-identifiable mentions off an over-merged bare name by isnad context (da#346).
+
+The problem this addresses (why ``narrator_split`` could not)
+-------------------------------------------------------------
+The bare ism ``عبد الله`` collapses ~19k mentions of *many* historically-distinct ʿAbd
+Allāhs (Ibn ʿUmar, Ibn ʿAbbās, Ibn Masʿūd, …) onto one ``nar:`` node — the classic
+over-merge that inflates betweenness (da#346). The date-axis splitter
+(:mod:`src.resolve.narrator_split`) **correctly abstains** here: a bare mention carries
+no *attested* death-year neighbour band to discriminate on, so there is nothing for the
+death-band evidence gate to cut (Gate 1, single band ⇒ abstain). The #337 spike proved
+that forcing a date-band split of such a node is both infeasible (the chimera does not
+separate) and unsafe (it false-splits genuine hubs — al-Zuhrī peeled into five fabricated
+impossible-date nodes). That negative result is why #337 was resolved *flag-now*
+(:mod:`src.resolve.over_merged_flag`) and a true node-identity split deferred to external
+rijāl evidence (da#443).
+
+The corpus-internal lever that *is* available
+----------------------------------------------
+The **isnad position** — who a mention transmits *from* (teacher, position −1) and *to*
+(student, position +1) in its own chain — is a discriminating signal even when the name
+string is bare. An ʿAbd Allāh who narrates ⟵ the Prophet and ⟶ Nāfiʿ is ʿAbd Allāh ibn
+ʿUmar, not any other ʿAbd Allāh. This stage peels *those* mentions — the ones whose ±1
+neighbour pair matches a **hand-verified, high-confidence signature** — onto a distinct
+discriminated canonical node, and leaves every unmatched mention on the bare primary
+(which :mod:`over_merged_flag` keeps flagged). It never guesses.
+
+Why a curated signature seed and not a threshold (the da#423 discipline)
+-----------------------------------------------------------------------
+There is **no corpus-internal threshold** that separates the referents of a bare name
+(the #337 §0 negative result): a purely statistical auto-split re-commits the silent-zero
+error, false-splitting a genuine transmitter. So — exactly like the ``over_merged``
+flag's curated list — the peel is driven by a **hand-verified signature seed**
+(:data:`_SEED_PATH`) under a **bidirectional acceptance fixture**
+(``tests/test_resolve/test_contextual_disambiguation.py``): a signature MUST fire on the
+genuine multi-referent mentions it names AND MUST NOT fire on a genuine single narrator
+whose neighbours do not match it. A mention whose neighbour pair matches *no* signature —
+or *more than one* (ambiguous) — is never peeled; it stays on the flagged primary and its
+true identity is deferred to the external-rijāl work (da#443). The seed may be empty: then
+this stage is a pure no-op, and the whole node remains flagged — the safe default.
+
+What this stage does NOT do
+---------------------------
+It mints **no** speculative date-split nodes (that is the abstaining
+:mod:`narrator_split`'s job, and it abstains here). It invents **no** identity for a bare
+mention that lacks a corpus-internal discriminating neighbour pair — that residual is the
+``over_merged`` flag's to disclose and da#443's to resolve with external evidence. The
+peel is confined to mentions that carry, *in the isnad itself*, a neighbour pair a human
+has verified is uniquely identifying.
+
+Algorithm (per curated signature ``S`` on bare name ``N``)
+----------------------------------------------------------
+1. Resolve ``N`` to its canonical id ``C = make_canonical_id(N)`` and gather every
+   mention with ``canonical_narrator_id == C``.
+2. For each such mention, read its ±1 chain neighbours **within the same
+   ``(hadith_id, chain_index)`` chain** (:func:`src.resolve.narrator_split._build_chain_index`,
+   da#411 — never a cross-chain neighbour) and map them to their normalized names: the
+   set of teacher names (position −1) and student names (position +1).
+3. A signature *matches* a mention iff every neighbour role it constrains is satisfied —
+   its ``teacher_ar`` (if given) is among the mention's teacher names AND its
+   ``student_ar`` (if given) among the student names. A mention matched by exactly one
+   signature peels to that signature's target; a mention matched by zero or by ≥2
+   signatures is **left on the primary** (the conservative residual).
+4. The target node id is ``make_discriminated_canonical_id(N, S.discriminator)`` — a
+   distinct ``nar:`` id sharing the bare display name (mirroring ``narrator_split``'s
+   peeled rows), carrying ``S.name_en`` + ``S.note`` as its disambiguation provenance.
+
+Outputs (mirroring ``narrator_split``)
+---------------------------------------
+* ``narrators_canonical.parquet`` rewritten with the peeled target rows appended (each
+  primary's ``mention_count`` reduced by its peeled total, attestation re-derived).
+* ``narrator_mentions_resolved.parquet`` — the peeled mentions' ``canonical_narrator_id``
+  remapped, keyed on ``mention_id`` (a split sends *different* mentions of one id to
+  *different* targets), streaming/idempotent, reusing
+  :func:`src.resolve.narrator_split._remap_split_mentions`.
+* ``contextual_splits.parquet`` — one row per peeled target (bare name, new id,
+  discriminator, matched signature, mention_count): the owner's review artifact.
+* ``contextual_coverage.parquet`` — the **blast-radius** report (da#346 acceptance): per
+  curated bare name, how many of its mentions have a resolvable neighbour pair and how
+  many matched a signature. The real corpus number is produced when this stage runs
+  against the staged artifact; :func:`neighbour_pair_coverage` computes it deterministically.
+
+Idempotence
+-----------
+A second run re-reads the already-peeled table. Peeled target ids no longer carry the
+bare name ``N``, so they are not re-gathered under ``C``; the residual on ``C`` matched no
+signature the first time and still matches none. No file is rewritten; the stage returns
+``None``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
+from src.resolve._run_record import write_canonical
+from src.resolve.attestation import derive_attestation
+from src.resolve.narrator_split import _build_chain_index, _remap_split_mentions
+from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+from src.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = get_logger(__name__)
+
+# The curated signature seed ships beside this module.
+_SEED_PATH = Path(__file__).with_name("contextual_signatures.yaml")
+
+__all__ = [
+    "CONTEXTUAL_SPLITS_SCHEMA",
+    "CONTEXTUAL_COVERAGE_SCHEMA",
+    "ContextualSignature",
+    "NameCoverage",
+    "load_contextual_signatures",
+    "match_signature",
+    "neighbour_pair_coverage",
+    "apply_contextual_disambiguation",
+]
+
+
+# Audit report: one row per peeled (contextually-disambiguated) target node.
+CONTEXTUAL_SPLITS_SCHEMA = pa.schema(
+    [
+        pa.field("name_ar_normalized", pa.string(), nullable=False),
+        pa.field("primary_id", pa.string(), nullable=False),
+        pa.field("new_id", pa.string(), nullable=False),
+        pa.field("discriminator", pa.string(), nullable=False),
+        pa.field("target_name_en", pa.string(), nullable=True),
+        pa.field("teacher_ar", pa.string(), nullable=True),
+        pa.field("student_ar", pa.string(), nullable=True),
+        pa.field("mention_count", pa.int32(), nullable=False),
+    ]
+)
+
+# Blast-radius report (da#346 acceptance): one row per curated bare name.
+CONTEXTUAL_COVERAGE_SCHEMA = pa.schema(
+    [
+        pa.field("name_ar_normalized", pa.string(), nullable=False),
+        pa.field("primary_id", pa.string(), nullable=False),
+        pa.field("total_mentions", pa.int32(), nullable=False),
+        pa.field("with_any_neighbour", pa.int32(), nullable=False),
+        pa.field("with_teacher", pa.int32(), nullable=False),
+        pa.field("with_student", pa.int32(), nullable=False),
+        pa.field("signature_matched", pa.int32(), nullable=False),
+        pa.field("ambiguous_multimatch", pa.int32(), nullable=False),
+    ]
+)
+
+
+@dataclass(frozen=True)
+class ContextualSignature:
+    """One hand-verified isnad-neighbour signature identifying a referent of a bare name.
+
+    ``name_ar`` is the bare over-merged name whose mentions this signature peels;
+    ``teacher_ar`` / ``student_ar`` are the discriminating ±1 neighbour names (at least
+    one required — a signature that constrains neither would match everything). A mention
+    matches iff EVERY specified role is satisfied. ``discriminator`` folds into
+    :func:`make_discriminated_canonical_id` to mint the target's distinct id; ``name_en``
+    and ``note`` carry the (hand-verified) disambiguation provenance onto the target row.
+    """
+
+    name_ar: str
+    teacher_ar: str | None
+    student_ar: str | None
+    discriminator: str
+    name_en: str | None
+    note: str
+
+    def primary_id(self) -> str:
+        """The bare canonical id whose mentions this signature peels from."""
+        return make_canonical_id(normalize_arabic(self.name_ar))
+
+    def target_id(self) -> str:
+        """The distinct discriminated id a matched mention peels onto."""
+        return make_discriminated_canonical_id(normalize_arabic(self.name_ar), self.discriminator)
+
+    def teacher_norm(self) -> str | None:
+        return normalize_arabic(self.teacher_ar) if self.teacher_ar else None
+
+    def student_norm(self) -> str | None:
+        return normalize_arabic(self.student_ar) if self.student_ar else None
+
+    def matches(self, teacher_names: frozenset[str], student_names: frozenset[str]) -> bool:
+        """True iff every neighbour role this signature constrains is present in the mention.
+
+        A constrained role that the mention lacks fails the match; an unconstrained role
+        (``None``) is ignored. Because at least one role is always constrained (validated
+        at load), an all-``None`` signature can never be constructed, so ``matches`` never
+        returns ``True`` on an empty neighbour context.
+        """
+        t, s = self.teacher_norm(), self.student_norm()
+        if t is not None and t not in teacher_names:
+            return False
+        return not (s is not None and s not in student_names)
+
+
+@dataclass(frozen=True)
+class NameCoverage:
+    """Blast-radius tally for one bare name's mentions (da#346 acceptance)."""
+
+    name_ar_normalized: str
+    primary_id: str
+    total_mentions: int
+    with_any_neighbour: int
+    with_teacher: int
+    with_student: int
+    signature_matched: int
+    ambiguous_multimatch: int
+
+
+def load_contextual_signatures(path: Path = _SEED_PATH) -> tuple[ContextualSignature, ...]:
+    """Parse the curated ``contextual_signatures.yaml`` seed (empty when absent).
+
+    Raises ``ValueError`` on a malformed entry — a signature that constrains neither a
+    teacher nor a student would match every mention of the bare name and mass-mislabel it,
+    exactly the silent-defect this hand-verified list exists to prevent, so it is a hard
+    error, never a silently-dropped row.
+    """
+    if not path.exists():
+        return ()
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    rows = raw.get("signatures", []) if isinstance(raw, dict) else raw
+    sigs: list[ContextualSignature] = []
+    for row in rows:
+        name_ar = row.get("name_ar")
+        teacher_ar = row.get("teacher_ar")
+        student_ar = row.get("student_ar")
+        discriminator = row.get("discriminator")
+        note = row.get("note")
+        if not name_ar:
+            raise ValueError("contextual signature entry needs a name_ar")
+        if not teacher_ar and not student_ar:
+            raise ValueError(
+                f"contextual signature for {name_ar!r} needs a teacher_ar and/or student_ar "
+                "(an unconstrained signature would match every mention)"
+            )
+        if not discriminator:
+            raise ValueError(f"contextual signature for {name_ar!r} is missing its discriminator")
+        if not note:
+            raise ValueError(f"contextual signature for {name_ar!r} is missing its note")
+        sigs.append(
+            ContextualSignature(
+                name_ar=name_ar,
+                teacher_ar=teacher_ar,
+                student_ar=student_ar,
+                discriminator=discriminator,
+                name_en=row.get("name_en"),
+                note=note,
+            )
+        )
+    return tuple(sigs)
+
+
+def match_signature(
+    teacher_names: frozenset[str],
+    student_names: frozenset[str],
+    signatures: Iterable[ContextualSignature],
+) -> ContextualSignature | None:
+    """The single signature that confidently matches this neighbour context, else ``None``.
+
+    Zero matches (unknown context) OR ≥2 matches (ambiguous — the pair is consistent with
+    more than one curated referent) both return ``None``: the mention is left on the bare
+    primary. Only an unambiguous single match peels. This is the over-split guard — a
+    mention is disambiguated only when the corpus-internal evidence points to exactly one
+    hand-verified referent.
+    """
+    matched = [s for s in signatures if s.matches(teacher_names, student_names)]
+    return matched[0] if len(matched) == 1 else None
+
+
+def _neighbour_names_by_mention(
+    mentions: list[tuple[str, int, int, str]],
+    chains: dict[tuple[str, int], list[tuple[int, str]]],
+    name_by_id: dict[str, str],
+) -> dict[str, tuple[frozenset[str], frozenset[str]]]:
+    """``mention_id -> (teacher_names, student_names)`` from ±1 in-chain neighbours.
+
+    A neighbour is only ever the ±1 position **within the same ``(hadith_id, chain_index)``
+    chain** (da#411), mirroring the graph loaders' composite chain key. Names are the
+    normalized ``name_ar_normalized`` of the neighbour canonical ids.
+    """
+    out: dict[str, tuple[frozenset[str], frozenset[str]]] = {}
+    for hadith_id, chain_index, position, mention_id in mentions:
+        teachers: set[str] = set()
+        students: set[str] = set()
+        for npos, nid in chains.get((hadith_id, chain_index), ()):
+            if npos == position - 1:
+                name = name_by_id.get(nid)
+                if name:
+                    teachers.add(name)
+            elif npos == position + 1:
+                name = name_by_id.get(nid)
+                if name:
+                    students.add(name)
+        out[mention_id] = (frozenset(teachers), frozenset(students))
+    return out
+
+
+def neighbour_pair_coverage(
+    name_ar_normalized: str,
+    primary_id: str,
+    neighbours_by_mention: dict[str, tuple[frozenset[str], frozenset[str]]],
+    signatures: Iterable[ContextualSignature],
+) -> NameCoverage:
+    """Blast-radius tally for one bare name (da#346 acceptance), pure + deterministic.
+
+    Counts, over the name's mentions: how many have any resolvable neighbour, a teacher, a
+    student, an unambiguous signature match, and an ambiguous ≥2-signature match. The
+    corpus-scale numbers are produced when the stage runs against the staged artifact; this
+    function is what computes them and is unit-tested on fixtures.
+    """
+    sigs = tuple(signatures)
+    total = len(neighbours_by_mention)
+    any_n = teach = stud = matched = ambiguous = 0
+    for teachers, students in neighbours_by_mention.values():
+        if teachers or students:
+            any_n += 1
+        if teachers:
+            teach += 1
+        if students:
+            stud += 1
+        hits = [s for s in sigs if s.matches(teachers, students)]
+        if len(hits) == 1:
+            matched += 1
+        elif len(hits) >= 2:
+            ambiguous += 1
+    return NameCoverage(
+        name_ar_normalized=name_ar_normalized,
+        primary_id=primary_id,
+        total_mentions=total,
+        with_any_neighbour=any_n,
+        with_teacher=teach,
+        with_student=stud,
+        signature_matched=matched,
+        ambiguous_multimatch=ambiguous,
+    )
+
+
+def _as_int(value: Any) -> int:
+    """Best-effort non-negative int for a mention_count cell (None/non-numeric → 0)."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    return 0
+
+
+def _target_record(
+    primary_rec: dict[str, Any], sig: ContextualSignature, count: int
+) -> dict[str, Any]:
+    """A new canonical row for a contextually-disambiguated target node.
+
+    Inherits the shared name/provenance fields from the bare primary (the display name
+    stays the bare ``name_ar`` — we peel identity, not the string a mention shows),
+    carries ``sig.name_en`` + ``sig.note`` as the disambiguation provenance, and its
+    attestation is re-derived from the peeled count (the mentions are real isnad edges).
+    Dates stay unknown — this stage asserts identity from context, never a death year.
+    """
+    rec: dict[str, Any] = dict.fromkeys(f.name for f in NARRATORS_CANONICAL_SCHEMA)
+    for col in (
+        "name_ar",
+        "name_ar_normalized",
+        "aliases",
+        "gender",
+        "trustworthiness",
+        "source_ids",
+        "source_corpus",
+        "source_corpora",
+        "sect_affiliation",
+    ):
+        rec[col] = primary_rec.get(col)
+    rec["canonical_id"] = sig.target_id()
+    if sig.name_en:
+        rec["name_en"] = sig.name_en
+    rec["mention_count"] = count
+    rec["attestation"] = derive_attestation(count)
+    rec["over_merged"] = False
+    rec["over_merge_note"] = None
+    return rec
+
+
+def apply_contextual_disambiguation(
+    output_dir: Path, *, seed_path: Path = _SEED_PATH, staging_dir: Path | None = None
+) -> Path | None:
+    """Peel confidently-identifiable mentions off curated over-merged bare names (da#346).
+
+    Reads ``narrators_canonical.parquet`` + ``narrator_mentions_resolved.parquet`` from
+    ``output_dir``. For every curated signature, gathers its bare name's mentions, matches
+    each mention's ±1 neighbour pair against the signatures, and remaps unambiguously-matched
+    mentions onto discriminated target nodes (appending target rows, reducing the primary's
+    count). Always writes ``contextual_coverage.parquet`` (the blast-radius report) when
+    there is a canonical table and ≥1 signature.
+
+    Returns the canonical path when at least one mention peeled (files rewritten), else
+    ``None`` (no signatures, missing inputs, empty table, or every mention was
+    unknown/ambiguous — including every idempotent re-run). ``staging_dir`` is accepted for
+    run_all call-shape parity; this stage keeps no checkpoint.
+    """
+    canonical_path = output_dir / "narrators_canonical.parquet"
+    mentions_path = output_dir / "narrator_mentions_resolved.parquet"
+    if not canonical_path.exists():
+        logger.warning("contextual_disambiguation_no_canonical", path=str(canonical_path))
+        return None
+
+    signatures = load_contextual_signatures(seed_path)
+    if not signatures:
+        logger.info("contextual_disambiguation_no_signatures")
+        return None
+    if not mentions_path.exists():
+        logger.warning("contextual_disambiguation_no_mentions", path=str(mentions_path))
+        return None
+
+    records: list[dict[str, Any]] = pq.read_table(canonical_path).to_pylist()
+    if not records:
+        return None
+
+    name_by_id: dict[str, str] = {}
+    record_by_id: dict[str, dict[str, Any]] = {}
+    for rec in records:
+        cid = rec.get("canonical_id")
+        if not cid:
+            continue
+        record_by_id[cid] = rec
+        name_norm = rec.get("name_ar_normalized")
+        if name_norm:
+            name_by_id[cid] = name_norm
+
+    # Group signatures by the bare primary id they peel from. A primary present in no
+    # canonical row is a stale seed entry — logged, never invented (over_merged_flag rule).
+    sigs_by_primary: dict[str, list[ContextualSignature]] = {}
+    for sig in signatures:
+        sigs_by_primary.setdefault(sig.primary_id(), []).append(sig)
+    absent = sorted(pid for pid in sigs_by_primary if pid not in record_by_id)
+    if absent:
+        logger.warning("contextual_disambiguation_seed_absent", unmatched=absent, count=len(absent))
+
+    candidate_ids = {pid for pid in sigs_by_primary if pid in record_by_id}
+    if not candidate_ids:
+        logger.info("contextual_disambiguation_no_present_primaries", seed=len(signatures))
+        return None
+
+    chains, candidate_mentions = _build_chain_index(mentions_path, candidate_ids)
+
+    remap: dict[str, str] = {}
+    target_counts: dict[str, int] = {}
+    target_sig: dict[str, ContextualSignature] = {}
+    coverage_rows: list[dict[str, Any]] = []
+    for pid in sorted(candidate_ids):
+        name_norm = name_by_id.get(pid, "")
+        sigs = sigs_by_primary[pid]
+        neighbours = _neighbour_names_by_mention(
+            candidate_mentions.get(pid, []), chains, name_by_id
+        )
+        for mention_id, (teachers, students) in neighbours.items():
+            match = match_signature(teachers, students, sigs)
+            if match is not None:
+                tid = match.target_id()
+                remap[mention_id] = tid
+                target_counts[tid] = target_counts.get(tid, 0) + 1
+                target_sig[tid] = match
+        cov = neighbour_pair_coverage(name_norm, pid, neighbours, sigs)
+        coverage_rows.append(
+            {
+                "name_ar_normalized": cov.name_ar_normalized,
+                "primary_id": cov.primary_id,
+                "total_mentions": cov.total_mentions,
+                "with_any_neighbour": cov.with_any_neighbour,
+                "with_teacher": cov.with_teacher,
+                "with_student": cov.with_student,
+                "signature_matched": cov.signature_matched,
+                "ambiguous_multimatch": cov.ambiguous_multimatch,
+            }
+        )
+
+    # Always emit the blast-radius report (da#346 acceptance) — even a zero-peel run
+    # discloses the coverage so the residual-flag decision is auditable.
+    coverage_path = output_dir / "contextual_coverage.parquet"
+    cov_arrays = {
+        f.name: [r.get(f.name) for r in coverage_rows] for f in CONTEXTUAL_COVERAGE_SCHEMA
+    }
+    pq.write_table(pa.table(cov_arrays, schema=CONTEXTUAL_COVERAGE_SCHEMA), coverage_path)
+
+    if not remap:
+        logger.info(
+            "contextual_disambiguation_no_peel",
+            signatures=len(signatures),
+            candidates=len(candidate_ids),
+            coverage=str(coverage_path),
+        )
+        return None
+
+    # Apply: append target rows (reducing each primary's count), build the audit report.
+    new_rows: list[dict[str, Any]] = []
+    audit_rows: list[dict[str, Any]] = []
+    peeled_by_primary: dict[str, int] = {}
+    for tid, count in sorted(target_counts.items()):
+        sig = target_sig[tid]
+        pid = sig.primary_id()
+        primary_rec = record_by_id[pid]
+        peeled_by_primary[pid] = peeled_by_primary.get(pid, 0) + count
+        new_rows.append(_target_record(primary_rec, sig, count))
+        audit_rows.append(
+            {
+                "name_ar_normalized": primary_rec.get("name_ar_normalized"),
+                "primary_id": pid,
+                "new_id": tid,
+                "discriminator": sig.discriminator,
+                "target_name_en": sig.name_en,
+                "teacher_ar": sig.teacher_ar,
+                "student_ar": sig.student_ar,
+                "mention_count": count,
+            }
+        )
+    for pid, peeled in peeled_by_primary.items():
+        primary_rec = record_by_id[pid]
+        primary_rec["mention_count"] = max(0, _as_int(primary_rec.get("mention_count")) - peeled)
+        primary_rec["attestation"] = derive_attestation(primary_rec["mention_count"])
+
+    all_records = records + new_rows
+    arrays = {f.name: [r.get(f.name) for r in all_records] for f in NARRATORS_CANONICAL_SCHEMA}
+    write_canonical(
+        pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA),
+        canonical_path,
+        stage="contextual_disambiguation",
+    )
+
+    remapped = _remap_split_mentions(mentions_path, remap)
+
+    audit_path = output_dir / "contextual_splits.parquet"
+    audit_arrays = {f.name: [r.get(f.name) for r in audit_rows] for f in CONTEXTUAL_SPLITS_SCHEMA}
+    pq.write_table(pa.table(audit_arrays, schema=CONTEXTUAL_SPLITS_SCHEMA), audit_path)
+
+    logger.info(
+        "contextual_disambiguation_complete",
+        peeled_targets=len(new_rows),
+        mentions_remapped=remapped,
+        canonical_total=len(all_records),
+        audit=str(audit_path),
+        coverage=str(coverage_path),
+    )
+    return canonical_path

--- a/src/resolve/contextual_signatures.yaml
+++ b/src/resolve/contextual_signatures.yaml
@@ -1,0 +1,40 @@
+# Curated isnad-neighbour signature seed for contextual disambiguation (da#346).
+#
+# Each entry peels the mentions of an over-merged BARE name (`name_ar`) whose ±1 isnad
+# neighbours match a HAND-VERIFIED, uniquely-identifying transmitter/transmittee pair onto
+# a distinct discriminated canonical node. This is the corpus-internal lever the date-axis
+# `narrator_split` cannot use: a bare mention has no attested death-band to cut, but its
+# isnad POSITION (who it narrates from / to) can still identify the referent.
+#
+# This is NOT a threshold and NOT an inference — there is no corpus-internal statistic that
+# separates the referents of a bare name (the #337 §0 negative result; a statistical
+# auto-split re-commits the da#423 silent-zero error). It is a curated list under a
+# bidirectional acceptance fixture (tests/test_resolve/test_contextual_disambiguation.py):
+# every signature MUST fire on the genuine multi-referent mentions it names AND MUST NOT
+# fire on a genuine single narrator whose neighbours do not match it. A mention matched by
+# NO signature — or by MORE THAN ONE — is never peeled; it stays on the bare primary, which
+# `over_merged_flag` keeps flagged, and its true identity is left to the external-rijāl work
+# (da#443). The seed may be empty: then this stage is a pure no-op and the node stays flagged.
+#
+# Matching: `teacher_ar` is the neighbour at position-1 (the mention narrates FROM it),
+# `student_ar` the neighbour at position+1 (narrates TO it). At least one is required; a
+# mention matches iff EVERY specified role is present among its in-chain ±1 neighbours. The
+# more roles a signature constrains, the higher its confidence. Names are matched after
+# `normalize_arabic`. The target id = make_discriminated_canonical_id(name_ar, discriminator).
+#
+# Grow-later (owner, seed-now): only textbook, unambiguous, hand-verifiable pairs are seeded
+# here; the high-recall queue + rijāl confirmation grows the list under da#443.
+
+signatures:
+  - name_ar: "عبد الله"
+    teacher_ar: "رسول الله"
+    student_ar: "نافع"
+    name_en: "Abd Allah ibn Umar"
+    discriminator: "ctx:ibn-umar"
+    note: >-
+      Bare ʿAbd Allāh who narrates FROM the Prophet and TO his mawlā Nāfiʿ is ʿAbd Allāh
+      ibn ʿUmar b. al-Khaṭṭāb (d.73 AH). The Nāfiʿ ⟵ Ibn ʿUmar ⟵ the Prophet chain is one
+      of the most attested and textbook isnads in the corpus (the "golden chain" when
+      continued Mālik ⟵ Nāfiʿ), so this teacher+student pair is uniquely identifying and
+      hand-verified. Corpus-internal contextual peel (da#346); identity from isnad position,
+      no death year asserted. Residual bare ʿAbd Allāh stays over_merged-flagged.

--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -168,6 +168,7 @@ __all__ = [
     "PeeledBand",
     "SplitPlan",
     "plan_split",
+    "resolved_chain_neighbours",
     "split_generic_narrators",
 ]
 
@@ -568,6 +569,50 @@ def _build_chain_index(
     return chains, candidate_mentions
 
 
+def resolved_chain_neighbours(
+    chains: dict[tuple[str, int], list[tuple[int, str]]],
+    hadith_id: str,
+    chain_index: int,
+    position: int,
+) -> tuple[str | None, str | None]:
+    """The ``(teacher_id, student_id)`` of a mention's consecutive-resolved chain neighbours.
+
+    The **one** isnad-adjacency definition shared by every stage that reasons about a
+    mention's teacher/student — the date-band splitter (:func:`_collect_datable`), the
+    contextual disambiguator (``contextual_disambiguation``, da#346), and any future
+    isnad-neighbour gate — so they cannot drift the way the splitter and the loader did
+    (da#439). It IS the loader's ``TRANSMITTED_TO`` adjacency
+    (:func:`src.graph.load_edges._build_chain_pairs`):
+
+    * teacher = the **immediately-preceding resolved** mention (lower position),
+      student = the **immediately-following resolved** mention (higher position), in the
+      position-sorted ``(hadith_id, chain_index)`` chain (``chains`` is pre-sorted by
+      :func:`_build_chain_index`) — NOT an exact ``position ± 1`` test, so a gap opened by
+      a dropped unresolved position is bridged exactly as the loader bridges it (da#439);
+    * a neighbour resolving to the mention's OWN canonical id is a self-loop — no
+      ``TRANSMITTED_TO`` edge, so it is dropped and, as in the loader, NOT bridged past
+      to the next resolved mention (that role becomes ``None``);
+    * confined to the same ``(hadith_id, chain_index)`` chain — never a cross-isnad
+      neighbour of a multi-isnad hadith (da#411).
+
+    Returns ``(None, None)`` when the mention's slot is absent from ``chains`` (a pruned
+    chain — never fabricates an adjacency). Pure; no IO.
+    """
+    chain = chains.get((hadith_id, chain_index), ())
+    idx = next((i for i, (p, _c) in enumerate(chain) if p == position), None)
+    if idx is None:
+        return None, None
+    own_id = chain[idx][1]
+
+    def _neighbour(nidx: int) -> str | None:
+        if nidx < 0 or nidx >= len(chain):
+            return None
+        nid = chain[nidx][1]
+        return None if nid == own_id else nid  # self-loop → no edge, not bridged past
+
+    return _neighbour(idx - 1), _neighbour(idx + 1)
+
+
 def _collect_datable(
     mentions: list[tuple[str, int, int, str]],
     chains: dict[tuple[str, int], list[tuple[int, str]]],
@@ -597,27 +642,17 @@ def _collect_datable(
     """
     datable: list[DatableMention] = []
     for hadith_id, chain_index, position, mention_id in mentions:
-        chain = chains.get((hadith_id, chain_index), ())
-        # Locate this mention's slot in the position-sorted resolved chain
-        # (pre-sorted in _build_chain_index). Absent only if the chain was pruned —
-        # defensively skip rather than fabricate an adjacency.
-        idx = next((i for i, (p, _c) in enumerate(chain) if p == position), None)
-        if idx is None:
-            continue
-        own_id = chain[idx][1]
-        estimates: list[int] = []
-        anchors: list[str] = []
         # Teacher = the immediately-preceding resolved mention (lower position, dies
         # earlier → C dies later, sign +1); student = the immediately-following
-        # (higher position, dies later → C dies earlier, sign −1). Consecutive in the
-        # resolved list, so a position gap from a dropped unresolved mention is
-        # bridged exactly as the loader bridges it.
-        for nidx, sign in ((idx - 1, 1), (idx + 1, -1)):
-            if nidx < 0 or nidx >= len(chain):
+        # (higher position, dies later → C dies earlier, sign −1). The shared
+        # consecutive-resolved adjacency helper (da#439) bridges a dropped-position gap
+        # exactly as the loader does and drops self-loops without bridging past them.
+        teacher_id, student_id = resolved_chain_neighbours(chains, hadith_id, chain_index, position)
+        estimates: list[int] = []
+        anchors: list[str] = []
+        for nid, sign in ((teacher_id, 1), (student_id, -1)):
+            if nid is None:
                 continue
-            nid = chain[nidx][1]
-            if nid == own_id:
-                continue  # self-loop: no edge in the graph, no adjacency here
             year = attested_by_id.get(nid)
             if year is None:
                 continue

--- a/tests/test_resolve/test_contextual_disambiguation.py
+++ b/tests/test_resolve/test_contextual_disambiguation.py
@@ -1,0 +1,342 @@
+"""Tests for src.resolve.contextual_disambiguation — da#346 isnad-neighbour peel.
+
+The load-bearing property (feedback_silent_zero_is_not_a_measurement /
+feedback_drop_gate_bidirectional_ab): the peel is driven by a hand-verified signature
+seed, and the instrument MUST SEPARATE the classes — a signature fires on the genuine
+multi-referent mentions it names (bare ʿAbd Allāh ⟵Prophet ⟶Nāfiʿ ⇒ Ibn ʿUmar) and does
+NOT fire on the residual (a different ʿAbd Allāh) or on a partial-match (only one role).
+An unknown or ambiguous (≥2-signature) neighbour pair is never peeled; it stays on the
+bare primary, which over_merged_flag keeps flagged. Coverage:
+
+* signature loading + validation (an unconstrained signature is a hard error);
+* ``ContextualSignature.matches`` / ``match_signature`` role logic + ambiguity guard;
+* ``neighbour_pair_coverage`` blast-radius tally;
+* end-to-end stage over parquet fixtures — instrument separation (peel the matched class,
+  leave the control class AND the partial-match), residual stays, primary count reduced,
+  coverage report emitted, empty-seed / absent-primary no-op, and idempotence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
+from src.resolve.contextual_disambiguation import (
+    ContextualSignature,
+    apply_contextual_disambiguation,
+    load_contextual_signatures,
+    match_signature,
+    neighbour_pair_coverage,
+)
+from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+
+_ABDALLAH = normalize_arabic("عبد الله")
+_PROPHET = normalize_arabic("رسول الله")
+_NAFI = normalize_arabic("نافع")
+_ZUHRI = normalize_arabic("الزهري")
+_MALIK = normalize_arabic("مالك")
+
+_IBN_UMAR_SIG = ContextualSignature(
+    name_ar="عبد الله",
+    teacher_ar="رسول الله",
+    student_ar="نافع",
+    discriminator="ctx:ibn-umar",
+    name_en="Abd Allah ibn Umar",
+    note="Prophet -> Ibn Umar -> Nafi textbook isnad; hand-verified.",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Pure signature / match / coverage logic
+# --------------------------------------------------------------------------- #
+def test_signature_matches_requires_every_constrained_role() -> None:
+    both = _IBN_UMAR_SIG
+    assert both.matches(frozenset({_PROPHET}), frozenset({_NAFI})) is True
+    # Partial: teacher matches but student does not -> no match (both roles required).
+    assert both.matches(frozenset({_PROPHET}), frozenset({_MALIK})) is False
+    assert both.matches(frozenset({_ZUHRI}), frozenset({_NAFI})) is False
+    # Empty neighbour context never matches a constrained signature.
+    assert both.matches(frozenset(), frozenset()) is False
+
+
+def test_signature_single_role_matches_on_that_role_only() -> None:
+    teacher_only = ContextualSignature(
+        name_ar="عبد الله",
+        teacher_ar="رسول الله",
+        student_ar=None,
+        discriminator="ctx:t",
+        name_en=None,
+        note="n",
+    )
+    assert teacher_only.matches(frozenset({_PROPHET}), frozenset()) is True
+    assert teacher_only.matches(frozenset({_ZUHRI}), frozenset({_PROPHET})) is False
+
+
+def test_match_signature_zero_and_ambiguous_return_none() -> None:
+    teacher_only = ContextualSignature(
+        name_ar="عبد الله",
+        teacher_ar="رسول الله",
+        student_ar=None,
+        discriminator="ctx:t",
+        name_en=None,
+        note="n",
+    )
+    student_only = ContextualSignature(
+        name_ar="عبد الله",
+        teacher_ar=None,
+        student_ar="نافع",
+        discriminator="ctx:s",
+        name_en=None,
+        note="n",
+    )
+    sigs = [teacher_only, student_only]
+    # Exactly one matches -> that one.
+    assert match_signature(frozenset({_PROPHET}), frozenset({_MALIK}), sigs) is teacher_only
+    # Zero match -> None.
+    assert match_signature(frozenset({_ZUHRI}), frozenset({_MALIK}), sigs) is None
+    # BOTH match (ambiguous) -> None (never guess between curated referents).
+    assert match_signature(frozenset({_PROPHET}), frozenset({_NAFI}), sigs) is None
+
+
+def test_neighbour_pair_coverage_tally() -> None:
+    neighbours = {
+        "m1": (frozenset({_PROPHET}), frozenset({_NAFI})),  # matches Ibn Umar
+        "m2": (frozenset({_PROPHET}), frozenset({_MALIK})),  # partial, no match
+        "m3": (frozenset(), frozenset()),  # no neighbour at all
+        "m4": (frozenset({_ZUHRI}), frozenset()),  # teacher only, no match
+    }
+    cov = neighbour_pair_coverage(
+        _ABDALLAH, make_canonical_id(_ABDALLAH), neighbours, [_IBN_UMAR_SIG]
+    )
+    assert cov.total_mentions == 4
+    assert cov.with_any_neighbour == 3
+    assert cov.with_teacher == 3
+    assert cov.with_student == 2
+    assert cov.signature_matched == 1
+    assert cov.ambiguous_multimatch == 0
+
+
+def test_load_signatures_validation(tmp_path: Path) -> None:
+    assert load_contextual_signatures(tmp_path / "absent.yaml") == ()
+    good = tmp_path / "good.yaml"
+    good.write_text(
+        "signatures:\n"
+        '  - name_ar: "عبد الله"\n'
+        '    teacher_ar: "رسول الله"\n'
+        '    student_ar: "نافع"\n'
+        '    discriminator: "ctx:ibn-umar"\n'
+        '    note: "hand-verified"\n',
+        encoding="utf-8",
+    )
+    sigs = load_contextual_signatures(good)
+    assert len(sigs) == 1 and sigs[0].discriminator == "ctx:ibn-umar"
+
+    unconstrained = tmp_path / "bad.yaml"
+    unconstrained.write_text(
+        'signatures:\n  - name_ar: "عبد الله"\n    discriminator: "d"\n    note: "n"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="teacher_ar and/or student_ar"):
+        load_contextual_signatures(unconstrained)
+
+
+def test_ships_seed_is_loadable_and_bidirectionally_correct() -> None:
+    """The shipped seed loads, and its Ibn ʿUmar signature fires on the golden chain
+    while NOT firing on a genuine other-ʿAbd-Allāh pair (instrument separation)."""
+    sigs = load_contextual_signatures()
+    assert len(sigs) >= 1
+    ibn_umar = next(s for s in sigs if s.discriminator == "ctx:ibn-umar")
+    # Fires on Prophet -> Nafi (the multi-referent class it names)…
+    assert ibn_umar.matches(frozenset({_PROPHET}), frozenset({_NAFI})) is True
+    # …and does NOT fire on a different pair (the control class stays whole).
+    assert ibn_umar.matches(frozenset({_ZUHRI}), frozenset({_MALIK})) is False
+
+
+# --------------------------------------------------------------------------- #
+# Stage — apply_contextual_disambiguation over parquet fixtures
+# --------------------------------------------------------------------------- #
+def _canonical_row(cid: str, name_norm: str, mention_count: int, **over: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {f.name: None for f in NARRATORS_CANONICAL_SCHEMA}
+    base["canonical_id"] = cid
+    base["name_ar"] = name_norm
+    base["name_ar_normalized"] = name_norm
+    base["mention_count"] = mention_count
+    base["death_date_precision"] = "unknown"
+    base["birth_date_precision"] = "unknown"
+    base.update(over)
+    return base
+
+
+def _mention_row(
+    mention_id: str, hadith_id: str, position: int, cid: str, chain_index: int = 0
+) -> dict[str, Any]:
+    base: dict[str, Any] = {f.name: None for f in NARRATOR_MENTIONS_RESOLVED_SCHEMA}
+    base["mention_id"] = mention_id
+    base["hadith_id"] = hadith_id
+    base["source_corpus"] = "bukhari"
+    base["position_in_chain"] = position
+    base["canonical_narrator_id"] = cid
+    base["chain_index"] = chain_index
+    return base
+
+
+def _chain(
+    hid: str, teacher_id: str, cand_id: str, student_id: str, tag: str
+) -> list[dict[str, Any]]:
+    """A 3-narrator isnad: teacher (pos0) -> candidate (pos1) -> student (pos2)."""
+    return [
+        _mention_row(f"{tag}-t", hid, 0, teacher_id),
+        _mention_row(f"{tag}-c", hid, 1, cand_id),
+        _mention_row(f"{tag}-s", hid, 2, student_id),
+    ]
+
+
+def _write(out: Path, canonical: list[dict[str, Any]], mentions: list[dict[str, Any]]) -> None:
+    out.mkdir(parents=True, exist_ok=True)
+    c_arrays = {f.name: [r[f.name] for r in canonical] for f in NARRATORS_CANONICAL_SCHEMA}
+    pq.write_table(
+        pa.table(c_arrays, schema=NARRATORS_CANONICAL_SCHEMA), out / "narrators_canonical.parquet"
+    )
+    m_arrays = {f.name: [r[f.name] for r in mentions] for f in NARRATOR_MENTIONS_RESOLVED_SCHEMA}
+    pq.write_table(
+        pa.table(m_arrays, schema=NARRATOR_MENTIONS_RESOLVED_SCHEMA),
+        out / "narrator_mentions_resolved.parquet",
+    )
+
+
+def _seed(tmp_path: Path) -> Path:
+    p = tmp_path / "sig.yaml"
+    p.write_text(
+        "signatures:\n"
+        '  - name_ar: "عبد الله"\n'
+        '    teacher_ar: "رسول الله"\n'
+        '    student_ar: "نافع"\n'
+        '    name_en: "Abd Allah ibn Umar"\n'
+        '    discriminator: "ctx:ibn-umar"\n'
+        '    note: "hand-verified golden chain"\n',
+        encoding="utf-8",
+    )
+    return p
+
+
+def _read_canonical(out: Path) -> dict[str, dict[str, Any]]:
+    return {
+        r["canonical_id"]: r for r in pq.read_table(out / "narrators_canonical.parquet").to_pylist()
+    }
+
+
+def test_stage_peels_matched_class_leaves_control_and_partial(tmp_path: Path) -> None:
+    """Instrument separation: only Prophet->Nafi mentions peel to Ibn ʿUmar; a control
+    (Malik->Zuhri) and a partial-match (Prophet->Malik) both STAY on the bare primary."""
+    out = tmp_path / "curated"
+    bare = make_canonical_id(_ABDALLAH)
+    canonical = [
+        _canonical_row(bare, _ABDALLAH, 5),
+        _canonical_row(
+            make_canonical_id(_PROPHET), _PROPHET, 9, death_year_ah=11, death_date_precision="exact"
+        ),
+        _canonical_row(make_canonical_id(_NAFI), _NAFI, 9),
+        _canonical_row(make_canonical_id(_MALIK), _MALIK, 9),
+        _canonical_row(make_canonical_id(_ZUHRI), _ZUHRI, 9),
+    ]
+    mentions: list[dict[str, Any]] = []
+    # 3 golden-chain mentions (Prophet -> AbdAllah -> Nafi) => Ibn ʿUmar.
+    mentions += _chain("h1", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g1")
+    mentions += _chain("h2", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g2")
+    mentions += _chain("h3", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g3")
+    # 1 partial (Prophet -> AbdAllah -> Malik): teacher matches, student does not.
+    mentions += _chain("h4", make_canonical_id(_PROPHET), bare, make_canonical_id(_MALIK), "p1")
+    # 1 control (Malik -> AbdAllah -> Zuhri): a different ʿAbd Allāh, no role matches.
+    mentions += _chain("h5", make_canonical_id(_MALIK), bare, make_canonical_id(_ZUHRI), "c1")
+    _write(out, canonical, mentions)
+
+    result = apply_contextual_disambiguation(out, seed_path=_seed(tmp_path))
+    assert result is not None
+
+    by_id = _read_canonical(out)
+    target = make_discriminated_canonical_id(_ABDALLAH, "ctx:ibn-umar")
+    # The Ibn ʿUmar node was minted with exactly the 3 golden-chain mentions.
+    assert target in by_id
+    assert by_id[target]["mention_count"] == 3
+    assert by_id[target]["name_en"] == "Abd Allah ibn Umar"
+    assert by_id[target]["over_merged"] is False
+    # Primary reduced by 3 (5 recorded - 3 peeled = 2); partial + control stay.
+    assert by_id[bare]["mention_count"] == 2
+
+    m = {
+        r["mention_id"]: r
+        for r in pq.read_table(out / "narrator_mentions_resolved.parquet").to_pylist()
+    }
+    assert m["g1-c"]["canonical_narrator_id"] == target
+    assert m["g2-c"]["canonical_narrator_id"] == target
+    assert m["p1-c"]["canonical_narrator_id"] == bare  # partial NOT peeled
+    assert m["c1-c"]["canonical_narrator_id"] == bare  # control NOT peeled
+
+    # Coverage (blast-radius) report emitted with the right tally.
+    cov = {
+        r["primary_id"]: r for r in pq.read_table(out / "contextual_coverage.parquet").to_pylist()
+    }
+    assert cov[bare]["total_mentions"] == 5
+    assert cov[bare]["signature_matched"] == 3
+    assert cov[bare]["with_any_neighbour"] == 5
+
+    # Audit report: one row per peeled target.
+    audit = pq.read_table(out / "contextual_splits.parquet").to_pylist()
+    assert len(audit) == 1 and audit[0]["new_id"] == target and audit[0]["mention_count"] == 3
+
+
+def test_stage_idempotent(tmp_path: Path) -> None:
+    out = tmp_path / "curated"
+    bare = make_canonical_id(_ABDALLAH)
+    canonical = [
+        _canonical_row(bare, _ABDALLAH, 3),
+        _canonical_row(make_canonical_id(_PROPHET), _PROPHET, 5),
+        _canonical_row(make_canonical_id(_NAFI), _NAFI, 5),
+    ]
+    mentions = _chain("h1", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g1")
+    mentions += _chain("h2", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g2")
+    _write(out, canonical, mentions)
+    seed = _seed(tmp_path)
+
+    assert apply_contextual_disambiguation(out, seed_path=seed) is not None
+    first_c = pq.read_table(out / "narrators_canonical.parquet").to_pylist()
+    first_m = pq.read_table(out / "narrator_mentions_resolved.parquet").to_pylist()
+    # Second run: peeled mentions now point at the Ibn ʿUmar id, residual matches nothing.
+    assert apply_contextual_disambiguation(out, seed_path=seed) is None
+    assert pq.read_table(out / "narrators_canonical.parquet").to_pylist() == first_c
+    assert pq.read_table(out / "narrator_mentions_resolved.parquet").to_pylist() == first_m
+
+
+def test_stage_empty_seed_is_noop(tmp_path: Path) -> None:
+    out = tmp_path / "curated"
+    bare = make_canonical_id(_ABDALLAH)
+    _write(
+        out,
+        [_canonical_row(bare, _ABDALLAH, 3)],
+        _chain("h1", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g1"),
+    )
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("signatures: []\n", encoding="utf-8")
+    assert apply_contextual_disambiguation(out, seed_path=empty) is None
+    assert not (out / "contextual_coverage.parquet").exists()
+
+
+def test_stage_absent_primary_is_noop(tmp_path: Path) -> None:
+    """A seed whose bare name is not in the canonical table peels nothing and mints
+    nothing (the over_merged_flag no-fabricate discipline)."""
+    out = tmp_path / "curated"
+    other = make_canonical_id(_ZUHRI)
+    _write(out, [_canonical_row(other, _ZUHRI, 3)], [_mention_row("z", "h1", 0, other)])
+    assert apply_contextual_disambiguation(out, seed_path=_seed(tmp_path)) is None
+
+
+def test_stage_no_canonical_is_noop(tmp_path: Path) -> None:
+    out = tmp_path / "curated"
+    out.mkdir(parents=True, exist_ok=True)
+    assert apply_contextual_disambiguation(out, seed_path=_seed(tmp_path)) is None

--- a/tests/test_resolve/test_contextual_disambiguation.py
+++ b/tests/test_resolve/test_contextual_disambiguation.py
@@ -324,6 +324,19 @@ def test_stage_gappy_chain_still_matches_signature(tmp_path: Path) -> None:
     target = make_discriminated_canonical_id(_ABDALLAH, "ctx:ibn-umar")
     assert m["g-c"]["canonical_narrator_id"] == target  # peeled across both gaps
 
+    # Oyunbileg's point: the old exact-±1 walk under-counted the NAMED blast-radius
+    # measurement, not just the peel. The gappy mention must now be counted as having a
+    # resolvable teacher AND student AND a signature match in contextual_coverage.parquet.
+    cov = {
+        r["primary_id"]: r for r in pq.read_table(out / "contextual_coverage.parquet").to_pylist()
+    }
+    bare_cov = cov[bare]
+    assert bare_cov["total_mentions"] == 1
+    assert bare_cov["with_any_neighbour"] == 1
+    assert bare_cov["with_teacher"] == 1
+    assert bare_cov["with_student"] == 1
+    assert bare_cov["signature_matched"] == 1
+
 
 def test_stage_idempotent(tmp_path: Path) -> None:
     out = tmp_path / "curated"

--- a/tests/test_resolve/test_contextual_disambiguation.py
+++ b/tests/test_resolve/test_contextual_disambiguation.py
@@ -291,6 +291,40 @@ def test_stage_peels_matched_class_leaves_control_and_partial(tmp_path: Path) ->
     assert len(audit) == 1 and audit[0]["new_id"] == target and audit[0]["mention_count"] == 3
 
 
+def test_stage_gappy_chain_still_matches_signature(tmp_path: Path) -> None:
+    """da#439 shared-helper: a golden chain with dropped interior positions still peels.
+
+    Chain: Prophet(pos0) -> [null pos1] -> ʿAbd Allāh(pos2) -> [null pos3] -> Nāfiʿ(pos4).
+    Under the pre-da#439 exact-``position ± 1`` neighbour read, the candidate at pos2 saw
+    only the (dropped) positions 1 and 3, found neither the Prophet nor Nāfiʿ, and the Ibn
+    ʿUmar signature did NOT fire — silently under-peeling a confident identity. With the
+    shared consecutive-resolved adjacency helper the teacher/student bridge the gaps and
+    the signature matches (GREEN)."""
+    out = tmp_path / "curated"
+    bare = make_canonical_id(_ABDALLAH)
+    canonical = [
+        _canonical_row(bare, _ABDALLAH, 1),
+        _canonical_row(make_canonical_id(_PROPHET), _PROPHET, 5),
+        _canonical_row(make_canonical_id(_NAFI), _NAFI, 5),
+    ]
+    mentions = [
+        _mention_row("g-t", "h1", 0, make_canonical_id(_PROPHET)),
+        _mention_row("g-x1", "h1", 1, None),  # unresolved → dropped from chains
+        _mention_row("g-c", "h1", 2, bare),
+        _mention_row("g-x3", "h1", 3, None),  # unresolved → dropped
+        _mention_row("g-s", "h1", 4, make_canonical_id(_NAFI)),
+    ]
+    _write(out, canonical, mentions)
+
+    assert apply_contextual_disambiguation(out, seed_path=_seed(tmp_path)) is not None
+    m = {
+        r["mention_id"]: r
+        for r in pq.read_table(out / "narrator_mentions_resolved.parquet").to_pylist()
+    }
+    target = make_discriminated_canonical_id(_ABDALLAH, "ctx:ibn-umar")
+    assert m["g-c"]["canonical_narrator_id"] == target  # peeled across both gaps
+
+
 def test_stage_idempotent(tmp_path: Path) -> None:
     out = tmp_path / "curated"
     bare = make_canonical_id(_ABDALLAH)


### PR DESCRIPTION
## Summary

Adds a **contextual (isnad-neighbour) disambiguation** resolve stage (da#346) that peels
the confidently-identifiable mentions off an over-merged bare name onto distinct nodes,
reducing the phantom-hub betweenness — while leaving everything it cannot confidently
identify on the flagged primary.

## Why the date-axis splitter could not do this (acceptance (a))

`narrator_split` **correctly abstains** on bare `عبد الله`: a bare mention carries no
*attested* death-band to cut (Gate 1, single band ⇒ abstain), and the #337 spike proved
forcing a date-band split is infeasible (the chimera does not separate) and unsafe
(false-splits genuine hubs — al-Zuhrī into five impossible-date nodes). That negative
result is why #337 was flag-now and node-identity split deferred to external rijāl
(da#443). Documented in the module docstring.

## The corpus-internal lever (acceptance (b))

The isnad **position** identifies a referent even when the name string is bare: an ʿAbd
Allāh who narrates ⟵the Prophet and ⟶Nāfiʿ is ʿAbd Allāh ibn ʿUmar. For each
hand-verified neighbour-pair signature, the stage remaps the matching mentions to a
distinct discriminated node.

**Not a threshold, not an inference** (the da#423 silent-zero discipline). Driven by a
curated signature seed under a **bidirectional acceptance fixture**: a signature MUST fire
on the multi-referent class it names AND MUST NOT fire on the control class or a
partial (one-role) match. A mention matched by **zero** or **≥2** signatures is never
peeled — it stays on the bare primary. Empty seed ⇒ pure no-op (the safe default).

## Instrument separation (verified)

The end-to-end test builds one bare `عبد الله` node carrying three classes and asserts the
detector **separates** them: 3 golden-chain (Prophet→Nāfiʿ) mentions peel to Ibn ʿUmar; a
partial-match (Prophet→Mālik) and a control (Mālik→Zuhrī) both **stay** on the primary.
This is the "prove the instrument separates the classes before trusting the number" lesson
applied directly.

## Residual (acceptance (c))

The bare `عبد الله` node stays `over_merged`-flagged (seed entry 1 of
`over_merged_narrators.yaml` already flags it); the contextual peel only reduces its count
and does not touch the flag. Bare mentions with no corpus-internal discriminating pair are
left to da#443's external-rijāl split — explicitly out of scope here.

## Blast radius

The number (fraction of the 19,412 with a resolvable neighbour pair) is a **runtime
measurement** produced when the stage runs against the staged corpus — `data/` is empty in
the repo, so it cannot be computed in the PR. `neighbour_pair_coverage` computes it
deterministically (unit-tested), and the stage **always** writes
`contextual_coverage.parquet` (total / with-neighbour / with-teacher / with-student /
matched / ambiguous per bare name) so the re-run discloses it for review.

## Wiring

New `contextual_disambiguation` step in `run_all` (3.57), after `narrator_split`, before
reconcile/tabaqa/`over_merged_flag`, so peeled ids flow through the date stages and the
residual flag counts the reduced primary. Added to `RESOLVE_STEP_ORDER` (CLI `--from-step`
auto-includes it); no checkpoint (not in `RESUMABLE_STEPS`). Reuses narrator_split's
`_build_chain_index` / `_remap_split_mentions`.

## Tests / checks

- `tests/test_resolve/test_contextual_disambiguation.py` — 11 tests (see above).
- Full resolve suite: 576 passed, 6 skipped (orchestrator/from-step wiring unbroken).
- ruff format + lint clean; mypy strict clean; full pre-push green.

## Note for reviewers

The seed ships **one** textbook, hand-verifiable entry (Ibn ʿUmar). Grow-later under
da#443. If the team prefers to defer ALL node-minting to da#443, emptying the seed leaves
the mechanism + coverage harness intact as a pure no-op — flagged in my status to the
team lead.

## Reviewers

- Peer: **Ivana Horvat**
- Secondary: **Oyunbileg Batbayar**

Closes #346
Part of main#928
