### PR TITLE
resolve: curated evidence-gated narrator unification (da#431 kunya↔ism↔bio)

### DIFF
--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -173,6 +173,7 @@ RESOLVE_STEP_ORDER = (
     "contextual_disambiguation",
     "reconcile",
     "tabaqa_dates",
+    "narrator_unify",
     "over_merged_flag",
     "muhaddithat_links",
     "dedup",
@@ -474,6 +475,7 @@ def run_all(
         fuzzy_cluster,
         muhaddithat_links,
         narrator_split,
+        narrator_unify,
         ner,
         over_merged_flag,
         parallels,
@@ -759,6 +761,39 @@ def run_all(
     else:
         outcomes["tabaqa_dates"] = StageSkipped("tabaqa_dates", "precomputed")
         logger.info("resolve_step_skipped_precomputed", step="tabaqa_dates")
+
+    # Step 3.66: Curated under-merge unification (da#431 / da#347) — the merge mirror of
+    # narrator_split. Where fuzzy_cluster's precision guard structurally cannot bridge two
+    # references to ONE person that share too few significant tokens (kunya↔ism, bare
+    # ism↔qualified), this stage merges a hand-verified, corroboration-gated curated set
+    # (narrator_unify.yaml) onto one survivor and remaps the absorbed mentions — reusing
+    # fuzzy_cluster's own _merge_cluster/_remap. Runs after tabaqa_dates so the survivor
+    # inherits final dates + mention_count, and BEFORE over_merged_flag so that stage stays
+    # the last writer of narrators_canonical.parquet. Every group is behind the da#423
+    # bidirectional acceptance fixture; a refused group is logged, never merged. A no-op
+    # (None) when the seed matches < 2 distinct nodes per group (already unified).
+    if _do("narrator_unify"):
+        try:
+            logger.info("resolve_step", step="narrator_unify", status="running")
+            unified = narrator_unify.apply_narrator_unification(output_dir)
+            unify_files = [unified] if unified is not None else []
+            outcomes["narrator_unify"] = StageRan("narrator_unify", unify_files)
+            logger.info(
+                "resolve_step",
+                step="narrator_unify",
+                status="complete",
+                files=len(unify_files),
+            )
+        except Exception as exc:  # noqa: BLE001
+            outcomes["narrator_unify"] = StageErrored(
+                "narrator_unify", type(exc).__name__, traceback.format_exc()
+            )
+            logger.error(
+                "resolve_step_failed", step="narrator_unify", traceback=traceback.format_exc()
+            )
+    else:
+        outcomes["narrator_unify"] = StageSkipped("narrator_unify", "precomputed")
+        logger.info("resolve_step_skipped_precomputed", step="narrator_unify")
 
     # Step 3.67: Over-merged bare-generic flag (da#445 / #337 flag-now). The LAST writer
     # of narrators_canonical.parquet: after every date stage has finalized the canonical

--- a/src/resolve/narrator_unify.py
+++ b/src/resolve/narrator_unify.py
@@ -1,0 +1,432 @@
+"""Merge curated UNDER-merged narrator surface forms onto one canonical (da#431/da#347).
+
+Background
+----------
+The canonical narrator id is a pure function of the normalized name
+(``make_canonical_id``), and ``fuzzy_cluster`` only *merges* two canonicals when they
+clear a precision guard: at least :data:`~src.resolve.fuzzy_cluster._MIN_SHARED_TOKENS`
+shared significant name tokens, no death-year conflict, no gender conflict (da#138). That
+guard is correct — loosening it re-commits the da#423 over-merge that deleted real
+figures — but it structurally *cannot* bridge two references to the SAME person that share
+too few tokens:
+
+* **kunya ↔ ism** (da#431): ``أبو وائل`` (kunya) and ``شقيق بن سلمة`` (ism+nasab) share
+  ZERO significant tokens, so the ~3,117 mentions on the kunya node never join the ism
+  node, and the rijāl biography (promoted to its own node by ``bio_promote``) sits on a
+  zero-mention node while the mentions sit on a bio-less one.
+* **bare ism ↔ qualified** (da#347): bare ``أنس`` and ``أنس بن مالك`` share ONE token
+  (``< _MIN_SHARED_TOKENS``), so Anas b. Mālik is split across two nodes, halving his
+  centrality.
+
+This stage does NOT loosen the guard. It supplies **curated, corroborated external
+evidence** for a hand-verified set of confirmed single identities
+(:data:`_SEED_PATH`, ``narrator_unify.yaml``) and merges ONLY those, reusing the exact
+merge ``fuzzy_cluster`` performs (:func:`~src.resolve.fuzzy_cluster._merge_cluster` +
+:func:`~src.resolve.fuzzy_cluster._remap_mention_canonical_ids`). It is the mirror of
+``over_merged_flag`` — a curated list under a **bidirectional acceptance fixture**
+(``tests/test_resolve/test_narrator_unify.py``): every golden multi-node-of-one-person
+group MUST merge, and every distinct-narrator control MUST NOT.
+
+The gate is the da#423 safety net, not the decision
+----------------------------------------------------
+The curated list *is* the decision (hand-verified, like ``over_merged_narrators.yaml``).
+:func:`_group_admissible` REFUSES a group — loudly, never merging it — when any of these
+holds, so a curation error cannot silently sweep in a distinct person:
+
+1. **over-merge exclusion** — a member is a curated over-merged bare generic
+   (``over_merged_narrators.yaml``); those fuse many people and can never be a unify member.
+2. **corroborated death conflict** — two members carry ``death_year_provenance ==
+   "corroborated"`` death years disagreeing beyond
+   :data:`~src.resolve.fuzzy_cluster._DEATH_YEAR_TOLERANCE`.
+3. **gross death spread** — two members' death years disagree by more than
+   :data:`_UNIFY_MAX_DEATH_SPREAD` regardless of provenance (a loose sanity band that
+   catches a distinct namesake even when neither year is corroborated — e.g. the d.200
+   taba-tabiʿī bare ``شقيق`` against the d.82 Companion-era Abū Wāʾil).
+4. **gender conflict** — two members carry explicit, differing gender.
+5. **uncorroborated evidence** — the group's declared evidence is not attested in-corpus
+   (for ``bio_kunya_ism_bridge``: no resolved member spells out BOTH the kunya and the ism).
+
+Placement & idempotency
+-----------------------
+Runs after ``tabaqa_dates`` (dates + mention_count final) and before ``over_merged_flag``
+(which stays the last writer of ``narrators_canonical.parquet``). Rewrites the canonical
+table and remaps the absorbed mentions. Idempotent: after a merge the absorbed surfaces
+survive only as aliases, so a re-run resolves each group to a single survivor node and
+skips it (a group resolving to < 2 distinct canonicals is a no-op).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+from src.resolve._run_record import write_canonical
+from src.resolve.fuzzy_cluster import (
+    _DEATH_YEAR_TOLERANCE,
+    _genders_conflict,
+    _merge_cluster,
+    _remap_mention_canonical_ids,
+)
+from src.resolve.over_merged_flag import load_over_merged_seed
+from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+from src.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = get_logger(__name__)
+
+_SEED_PATH = Path(__file__).with_name("narrator_unify.yaml")
+
+# Loose sanity band (in AH years) on the death-year spread within a unify group,
+# applied regardless of provenance. Tighter than "any conflict" would be — the curated
+# members legitimately carry noisy/default death years (e.g. the generic sahabi d.60) —
+# but wide gaps (> this) mark a distinct namesake, not one person. Chosen so a genuine
+# generation-default noise gap (Anas: bare d.60 vs qualified d.91 = 31) passes while a
+# cross-generation namesake (bare Shaqīq d.200 vs Abū Wāʾil d.82 = 118) is refused.
+_UNIFY_MAX_DEATH_SPREAD = 50
+
+__all__ = [
+    "UnifyGroup",
+    "load_unify_seed",
+    "apply_narrator_unification",
+]
+
+
+@dataclass(frozen=True)
+class UnifyGroup:
+    """One curated group of surface forms that are a single narrator.
+
+    ``members`` are ``name_ar_normalized`` surfaces (the stored column) — NOT recomputed
+    ids, because these nodes carry narrator_split-discriminated ids. ``member_ids`` are
+    optional explicit canonical ids that take precedence when resolving. ``evidence`` names
+    the corroboration the gate must confirm; ``bio_kunya_ism_bridge`` also reads
+    ``kunya_norm``/``ism_norm``.
+    """
+
+    primary_label: str
+    issue: str
+    evidence: str
+    note: str
+    members: tuple[str, ...]
+    member_ids: tuple[str, ...] = ()
+    kunya_norm: str | None = None
+    ism_norm: str | None = None
+
+
+def load_unify_seed(path: Path = _SEED_PATH) -> tuple[UnifyGroup, ...]:
+    """Parse the curated ``narrator_unify.yaml`` seed (empty when the file is absent).
+
+    Raises ``ValueError`` on a malformed group — a dropped member is exactly the silent
+    under-merge this list exists to fix, so a missing key fails loudly, never silently.
+    """
+    if not path.exists():
+        return ()
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    rows = raw.get("unify", []) if isinstance(raw, dict) else raw
+    groups: list[UnifyGroup] = []
+    for row in rows:
+        members = tuple(normalize_arabic(m) for m in (row.get("members") or []))
+        member_ids = tuple(row.get("member_ids") or ())
+        if len(members) + len(member_ids) < 2:
+            raise ValueError(
+                f"unify group {row.get('primary_label')!r} needs >= 2 members to merge"
+            )
+        evidence = row.get("evidence")
+        note = row.get("note")
+        if not evidence or not note:
+            raise ValueError(
+                f"unify group {row.get('primary_label')!r} needs both `evidence` and `note`"
+            )
+        kunya = row.get("kunya_norm")
+        ism = row.get("ism_norm")
+        if evidence == "bio_kunya_ism_bridge" and not (kunya and ism):
+            raise ValueError(
+                f"unify group {row.get('primary_label')!r} evidence bio_kunya_ism_bridge "
+                "requires kunya_norm and ism_norm"
+            )
+        groups.append(
+            UnifyGroup(
+                primary_label=row.get("primary_label") or (members[0] if members else "?"),
+                issue=row.get("issue") or "",
+                evidence=evidence,
+                note=note,
+                members=members,
+                member_ids=member_ids,
+                kunya_norm=normalize_arabic(kunya) if kunya else None,
+                ism_norm=normalize_arabic(ism) if ism else None,
+            )
+        )
+    return tuple(groups)
+
+
+def _over_merged_norms(seed_path: Path | None = None) -> frozenset[str]:
+    """Normalized names of every curated over-merged bare generic (the exclusion set)."""
+    entries = load_over_merged_seed(seed_path) if seed_path else load_over_merged_seed()
+    return frozenset(normalize_arabic(e.name_ar) for e in entries if e.name_ar)
+
+
+def _resolve_members(
+    group: UnifyGroup, by_norm: dict[str, list[dict[str, Any]]], by_id: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Canonical records for a group's members (by explicit id, else by normalized name).
+
+    A surface matching more than one row (a narrator_split-discriminated twin sharing a
+    normalized name) resolves to ALL matching rows; the gate then vets the set. Deduped on
+    canonical_id, preserving first-seen order.
+    """
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+
+    def _add(rec: dict[str, Any]) -> None:
+        cid = rec.get("canonical_id")
+        if cid and cid not in seen:
+            seen.add(cid)
+            out.append(rec)
+
+    for mid in group.member_ids:
+        rec = by_id.get(mid)
+        if rec is not None:
+            _add(rec)
+    for surface in group.members:
+        for rec in by_norm.get(surface, []):
+            _add(rec)
+    return out
+
+
+def _corroborated_death_conflict(members: list[dict[str, Any]]) -> tuple[int, int] | None:
+    """First pair of members whose CORROBORATED death years disagree beyond tolerance."""
+    dated = [(m.get("death_year_ah"), m.get("death_year_provenance")) for m in members]
+    for i in range(len(members)):
+        yi, pi = dated[i]
+        if not (isinstance(yi, int) and pi == "corroborated"):
+            continue
+        for j in range(i + 1, len(members)):
+            yj, pj = dated[j]
+            if (
+                isinstance(yj, int)
+                and pj == "corroborated"
+                and abs(yi - yj) > _DEATH_YEAR_TOLERANCE
+            ):
+                return (yi, yj)
+    return None
+
+
+def _gross_death_spread(members: list[dict[str, Any]]) -> tuple[int, int] | None:
+    """Widest pair of member death years when it exceeds the unify sanity band."""
+    years: list[int] = [y for m in members if isinstance((y := m.get("death_year_ah")), int)]
+    if len(years) < 2:
+        return None
+    lo, hi = min(years), max(years)
+    return (lo, hi) if hi - lo > _UNIFY_MAX_DEATH_SPREAD else None
+
+
+def _gender_conflict(members: list[dict[str, Any]]) -> bool:
+    """True when any two members carry explicit, differing gender."""
+    for i in range(len(members)):
+        for j in range(i + 1, len(members)):
+            if _genders_conflict(members[i], members[j]):
+                return True
+    return False
+
+
+def _evidence_corroborated(group: UnifyGroup, members: list[dict[str, Any]]) -> bool:
+    """Confirm the group's declared evidence is attested in the resolved members.
+
+    ``bio_kunya_ism_bridge``: a resolved member's normalized name must contain BOTH the
+    declared kunya and the declared ism — the in-corpus full-name node that spells out the
+    kunya↔ism identity, so the bridge is attested, not asserted. Unknown evidence kinds are
+    treated as NOT corroborated (fail closed).
+    """
+    if group.evidence == "bio_kunya_ism_bridge":
+        kunya, ism = group.kunya_norm, group.ism_norm
+        if not (kunya and ism):
+            return False
+        return any(
+            kunya in (m.get("name_ar_normalized") or "")
+            and ism in (m.get("name_ar_normalized") or "")
+            for m in members
+        )
+    return False
+
+
+def _group_admissible(
+    group: UnifyGroup, members: list[dict[str, Any]], over_merged: frozenset[str]
+) -> tuple[bool, str]:
+    """Gate a resolved group. Returns (ok, reason) — reason is empty when admissible."""
+    distinct = {m.get("canonical_id") for m in members}
+    if len(distinct) < 2:
+        return False, "fewer than 2 distinct canonical nodes (already unified / not present)"
+
+    hit = sorted(
+        normalize_arabic(m.get("name_ar_normalized") or "")
+        for m in members
+        if normalize_arabic(m.get("name_ar_normalized") or "") in over_merged
+    )
+    if hit:
+        return False, f"member is a curated over-merged bare generic: {hit}"
+
+    conflict = _corroborated_death_conflict(members)
+    if conflict is not None:
+        return False, f"corroborated death-year conflict {conflict[0]} vs {conflict[1]} AH"
+
+    spread = _gross_death_spread(members)
+    if spread is not None:
+        return (
+            False,
+            f"gross death-year spread {spread[0]}-{spread[1]} AH (> {_UNIFY_MAX_DEATH_SPREAD})",
+        )
+
+    if _gender_conflict(members):
+        return False, "explicit gender conflict between members"
+
+    if not _evidence_corroborated(group, members):
+        return False, f"declared evidence {group.evidence!r} not corroborated in-corpus"
+
+    return True, ""
+
+
+def _survivor_row(members: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build the merged survivor row, preserving every canonical column.
+
+    :func:`~src.resolve.fuzzy_cluster._merge_cluster` sums mentions, unions aliases,
+    back-fills the scalar bio, and re-derives attestation. It does not touch the extra
+    canonical columns (date bounds/precision, ``death_year_provenance``, ``external_id``,
+    sect, over-merge flags), so those are back-filled here from the members
+    (representative first) so the survivor keeps the full biography rather than dropping it.
+    """
+    merged = _merge_cluster(members)
+    survivor_id = merged["canonical_id"]
+    rep = next((m for m in members if m.get("canonical_id") == survivor_id), members[0])
+    ordered = [rep, *[m for m in members if m is not rep]]
+    row: dict[str, Any] = {f.name: None for f in NARRATORS_CANONICAL_SCHEMA}
+    for name, value in merged.items():
+        row[name] = value
+    for field in NARRATORS_CANONICAL_SCHEMA:
+        if row.get(field.name) in (None, ""):
+            for m in ordered:
+                if m.get(field.name) not in (None, ""):
+                    row[field.name] = m.get(field.name)
+                    break
+    return row
+
+
+def apply_narrator_unification(output_dir: Path, *, seed_path: Path = _SEED_PATH) -> Path | None:
+    """Merge each admissible curated unify group; remap absorbed mentions (da#431/da#347).
+
+    Reads ``narrators_canonical.parquet`` from ``output_dir``, resolves + gates each seed
+    group, merges the admissible ones onto a single survivor, rewrites the canonical table
+    via :func:`write_canonical`, and remaps the absorbed mentions on
+    ``narrator_mentions_resolved.parquet``. Returns the canonical path when at least one
+    group merged, else ``None`` (no table, empty seed, or every group a no-op/refused).
+    Never fabricates a node; a refused group is logged loudly, never merged.
+    """
+    canonical_path = output_dir / "narrators_canonical.parquet"
+    if not canonical_path.exists():
+        logger.warning("narrator_unify_no_canonical", path=str(canonical_path))
+        return None
+
+    groups = load_unify_seed(seed_path)
+    if not groups:
+        return None
+
+    records: list[dict[str, Any]] = pq.read_table(canonical_path).to_pylist()
+    if not records:
+        return None
+
+    over_merged = _over_merged_norms()
+    by_id = {r["canonical_id"]: r for r in records if r.get("canonical_id")}
+    by_norm: dict[str, list[dict[str, Any]]] = {}
+    for r in records:
+        by_norm.setdefault(normalize_arabic(r.get("name_ar_normalized") or ""), []).append(r)
+
+    remap: dict[str, str] = {}
+    absorbed_ids: set[str] = set()
+    survivors: dict[str, dict[str, Any]] = {}
+    merged_groups = 0
+
+    for group in groups:
+        members = _resolve_members(group, by_norm, by_id)
+        ok, reason = _group_admissible(group, members, over_merged)
+        if not ok:
+            logger.warning(
+                "narrator_unify_group_refused",
+                group=group.primary_label,
+                issue=group.issue,
+                resolved=len(members),
+                reason=reason,
+            )
+            continue
+        survivor = _survivor_row(members)
+        survivor_id = survivor["canonical_id"]
+        survivors[survivor_id] = survivor
+        for m in members:
+            cid = m.get("canonical_id")
+            if cid and cid != survivor_id:
+                absorbed_ids.add(cid)
+            if cid:
+                remap[cid] = survivor_id
+        merged_groups += 1
+        logger.info(
+            "narrator_unify_group_merged",
+            group=group.primary_label,
+            issue=group.issue,
+            members=len(members),
+            survivor=survivor_id,
+            mentions=survivor.get("mention_count"),
+        )
+
+    if merged_groups == 0:
+        logger.info("narrator_unify_no_op", groups=len(groups))
+        return None
+
+    # Rebuild: drop absorbed rows, replace/insert survivors (dedupe on canonical_id so a
+    # survivor whose id already existed as a member is not duplicated).
+    rebuilt: list[dict[str, Any]] = []
+    emitted: set[str] = set()
+    for r in records:
+        cid = r.get("canonical_id")
+        if cid in absorbed_ids:
+            continue
+        if cid in survivors:
+            if cid in emitted:
+                continue
+            rebuilt.append(survivors[cid])
+            emitted.add(cid)
+        else:
+            rebuilt.append(r)
+    for sid, srow in survivors.items():
+        if sid not in emitted:
+            rebuilt.append(srow)
+            emitted.add(sid)
+
+    arrays = {f.name: [r.get(f.name) for r in rebuilt] for f in NARRATORS_CANONICAL_SCHEMA}
+    table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
+    write_canonical(table, canonical_path, stage="narrator_unify")
+
+    remapped = _remap_mention_canonical_ids(
+        output_dir / "narrator_mentions_resolved.parquet", remap
+    )
+
+    logger.info(
+        "narrator_unify_complete",
+        groups=len(groups),
+        merged=merged_groups,
+        absorbed=len(absorbed_ids),
+        canonical_before=len(records),
+        canonical_after=len(rebuilt),
+        mentions_remapped=remapped,
+    )
+    return canonical_path
+
+
+def unify_summary(groups: Iterable[UnifyGroup]) -> str:
+    """One-line human summary of the seed (for the run record / logs)."""
+    gs = tuple(groups)
+    return f"{len(gs)} curated unify group(s): " + "; ".join(g.primary_label for g in gs)

--- a/src/resolve/narrator_unify.yaml
+++ b/src/resolve/narrator_unify.yaml
@@ -1,0 +1,67 @@
+# Curated narrator UNDER-merge unification seed (da#431 / da#347).
+#
+# The mirror of over_merged_narrators.yaml. Where that list names bare-generic nodes
+# that OVER-merge many people onto one id (and are only *annotated*, never split),
+# this list names surface forms that UNDER-merge ONE person across several canonical
+# nodes because the fuzzy-cluster precision guard (fuzzy_cluster._MIN_SHARED_TOKENS)
+# refuses to merge them: a kunya (`أبو وائل`) shares zero significant tokens with the
+# ism (`شقيق بن سلمة`), and a bare ism (`أنس`) shares only one with its qualified form
+# (`أنس بن مالك`). That guard is correct for the automatic clusterer — loosening it
+# would re-commit the da#423 over-merge — so we do NOT loosen it. Instead we supply
+# curated, corroborated external evidence for a hand-verified set of confirmed single
+# identities, and merge ONLY those, behind a bidirectional acceptance fixture
+# (tests/test_resolve/test_narrator_unify.py).
+#
+# We do NOT mint nodes. The `narrator_unify` stage MERGES the listed members onto one
+# survivor (fuzzy_cluster._merge_cluster: sums mentions, unions aliases, back-fills the
+# biography from the bio-bearing member, re-derives attestation) and remaps the
+# absorbed mentions — the exact merge fuzzy_cluster performs, applied to a curated set
+# the guard would not reach.
+#
+# Members are keyed by `name_ar_normalized` (the stored column), NOT by a recomputed
+# canonical_id: these nodes carry narrator_split-discriminated ids that are not
+# `make_canonical_id(norm)`, so a name→id recompute would miss them. The stage matches
+# canonical rows whose `name_ar_normalized` equals a listed member surface. An
+# explicit `canonical_id` MAY be given for a member and takes precedence.
+#
+# The gate (see narrator_unify._group_admissible) is the da#423 safety net, NOT the
+# decision — the curated list is the decision. A group is REFUSED (loudly, never
+# merged) if: (a) any member is a curated over-merged bare generic (over_merged
+# exclusion); (b) two members carry CORROBORATED death years that disagree beyond the
+# fuzzy_cluster tolerance; (c) two members' death years disagree grossly (> the unify
+# spread sanity band) regardless of provenance — this catches a distinct namesake
+# (e.g. the d.200 taba-tabiʿī bare `شقيق` is NOT this d.82 Companion-era Abū Wāʾil);
+# (d) two members carry explicit, differing gender; (e) the declared evidence is not
+# corroborated in-corpus.
+
+unify:
+  # da#431 — Abū Wāʾil (Shaqīq b. Salama al-Asadī), a prolific Kūfan tābiʿī. His
+  # ~3,500 mentions sit on the kunya node `أبو وائل` (mc 3,117) with NO biography,
+  # while his rijāl biography (d.81/82, ṭabaqa) sits on a mc=0 bio-promoted node. The
+  # kunya and ism never merge (0 shared significant tokens). Evidence: the corpus
+  # itself carries bridging full-name nodes (`أبو وائل شقيق بن سلمة`) that spell out the
+  # kunya↔ism identity — the bridge is attested, not asserted. Bare `شقيق` (mc 1,046,
+  # d.200) is DELIBERATELY EXCLUDED: it is partly other Shaqīqs and its gross death-year
+  # gap trips the sanity veto.
+  - primary_label: "Shaqīq b. Salama, Abū Wāʾil al-Asadī (Kūfan tābiʿī, d. ~82 AH)"
+    issue: "da#431"
+    evidence: bio_kunya_ism_bridge
+    kunya_norm: "ابو واءل"
+    ism_norm: "شقيق بن سلمه"
+    note: >-
+      Kunya↔ism↔bio under-merge. Kunya node `أبو وائل` holds ~3,117 mentions with no
+      biography; the rijāl bio node `شقيق، أبو وائل بن سلمة الأسدي` (d.81) holds the
+      biography with 0 mentions; the ism+nasab `شقيق بن سلمة` (d.82) and several
+      full-name fragments name the same Companion-era Kūfan. The fuzzy-cluster guard
+      never bridges kunya↔ism (0 shared significant tokens). Corroborated in-corpus by
+      the bridging full-name forms that carry BOTH kunya and ism. Merge unifies the
+      mentions onto one canonical bearing the biography. da#431.
+    members:
+      - "ابو واءل"                         # kunya node, mc 3,117 (holds the mentions)
+      - "شقيق بن سلمه"                     # ism+nasab, mc 364, d.82 sahabi
+      - "ابو واءل شقيق بن سلمه"            # bridging full name, mc 58
+      - "شقيق ابو واءل"                    # bridging fragment, mc 21
+      - "شقيق بن سلمه ابو واءل"            # bridging fragment, mc 17
+      - "ابو واءل شقيق بن سلمه الاسدي"     # bridging full name, mc 3
+      - "شقيق بن سلمه بن واءل الاسدي"      # ism+nasab+nisba, mc 1
+      - "شقيق ابو واءل بن سلمه الاسدي"     # bio-promoted rijāl node, mc 0, d.81

--- a/tests/test_resolve/test_narrator_unify.py
+++ b/tests/test_resolve/test_narrator_unify.py
@@ -1,0 +1,256 @@
+"""Tests for src.resolve.narrator_unify — the da#431/da#347 curated under-merge fix.
+
+The load-bearing test is the **bidirectional acceptance gate**
+(:class:`TestBidirectionalAcceptance`): a golden group of surface forms that are ONE
+person MUST merge onto a single survivor bearing the summed mentions and the
+biography, and every distinct-narrator control MUST NOT be swept in. The exclude
+direction is sacred — merging two distinct narrators is the da#423 failure that
+deleted the Prophet's daughter/son/Abū Bakr, each time with green CI. This mechanism
+supplies curated external evidence to bypass fuzzy_cluster's precision guard ONLY for
+the golden set; the gate (over-merge exclusion, corroborated-death veto, gross-spread
+sanity band, gender veto, in-corpus evidence) refuses any group that fails, so a
+curation error cannot silently over-merge.
+
+Synthetic-only: no real corpus. The Arabic surfaces mirror the real Abū Wāʾil cluster
+(da#431) so the golden case exercises the true kunya↔ism↔bio topology, but every row
+is fabricated here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.resolve import narrator_unify as nu
+from src.resolve.schemas import (
+    NARRATOR_MENTIONS_RESOLVED_SCHEMA,
+    NARRATORS_CANONICAL_SCHEMA,
+)
+
+# --- Synthetic canonical rows (the real Abū Wāʾil cluster shape, fabricated) ----------
+
+_KUNYA = "ابو واءل"
+_ISM = "شقيق بن سلمه"
+_BRIDGE = "ابو واءل شقيق بن سلمه"  # in-corpus full name carrying BOTH kunya and ism
+_BIO = "شقيق ابو واءل بن سلمه الاسدي"  # rijāl bio node, 0 mentions
+_BARE_SHAQIQ = "شقيق"  # a DIFFERENT Shaqīq (d.200) — must never merge in
+
+
+def _canon(
+    cid: str,
+    norm: str,
+    *,
+    mc: int,
+    death: int | None = None,
+    prov: str | None = None,
+    gender: str | None = None,
+    corpus: str = "itqan",
+) -> dict[str, Any]:
+    row: dict[str, Any] = {f.name: None for f in NARRATORS_CANONICAL_SCHEMA}
+    row.update(
+        canonical_id=cid,
+        name_ar=norm,
+        name_ar_normalized=norm,
+        aliases=[],
+        death_year_ah=death,
+        death_year_provenance=prov,
+        gender=gender,
+        mention_count=mc,
+        source_ids=[f"{corpus}:x:{cid}"],
+        source_corpus=corpus,
+        source_corpora=[corpus],
+    )
+    return row
+
+
+def _write_canonical(output_dir: Path, rows: list[dict[str, Any]]) -> None:
+    arrays = {f.name: [r.get(f.name) for r in rows] for f in NARRATORS_CANONICAL_SCHEMA}
+    pq.write_table(
+        pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA),
+        output_dir / "narrators_canonical.parquet",
+    )
+
+
+def _write_mentions(output_dir: Path, pairs: list[tuple[str, str]]) -> None:
+    """pairs = (mention_id, canonical_narrator_id)."""
+    n = len(pairs)
+    tbl = pa.table(
+        {
+            "mention_id": [m for m, _ in pairs],
+            "hadith_id": [f"hdt:x:{i}" for i in range(n)],
+            "source_corpus": ["itqan"] * n,
+            "position_in_chain": [0] * n,
+            "chain_index": [0] * n,
+            "name_raw": [None] * n,
+            "name_normalized": [None] * n,
+            "canonical_narrator_id": [c for _, c in pairs],
+            "transmission_method": [None] * n,
+            "confidence": [None] * n,
+        },
+        schema=NARRATOR_MENTIONS_RESOLVED_SCHEMA,
+    )
+    pq.write_table(tbl, output_dir / "narrator_mentions_resolved.parquet")
+
+
+def _abu_wail_rows() -> list[dict[str, Any]]:
+    return [
+        _canon("nar:kunya", _KUNYA, mc=3117),  # holds the mentions, no bio
+        _canon("nar:ism", _ISM, mc=364, death=82, gender="male"),  # ism+nasab
+        _canon("nar:bridge", _BRIDGE, mc=58),  # bridging full name
+        _canon("nar:bio", _BIO, mc=0, death=81),  # rijāl bio, 0 mentions
+    ]
+
+
+def _seed(tmp_path: Path, *, members: list[str]) -> Path:
+    lines = [
+        "unify:",
+        '  - primary_label: "Abū Wāʾil (test)"',
+        '    issue: "da#431"',
+        "    evidence: bio_kunya_ism_bridge",
+        f'    kunya_norm: "{_KUNYA}"',
+        f'    ism_norm: "{_ISM}"',
+        '    note: "synthetic test group"',
+        "    members:",
+        *[f'      - "{m}"' for m in members],
+    ]
+    path = tmp_path / "seed.yaml"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+# --- Golden: the merge MUST happen -----------------------------------------------------
+
+
+class TestGoldenMerge:
+    def test_kunya_ism_bio_merge_into_one(self, tmp_path: Path) -> None:
+        out = tmp_path
+        _write_canonical(out, _abu_wail_rows())
+        _write_mentions(
+            out,
+            [("m1", "nar:kunya"), ("m2", "nar:kunya"), ("m3", "nar:ism"), ("m4", "nar:bridge")],
+        )
+        seed = _seed(tmp_path, members=[_KUNYA, _ISM, _BRIDGE, _BIO])
+
+        result = nu.apply_narrator_unification(out, seed_path=seed)
+        assert result is not None
+
+        rows = pq.read_table(out / "narrators_canonical.parquet").to_pylist()
+        # 4 nodes collapse to 1 survivor.
+        assert len(rows) == 1
+        survivor = rows[0]
+        # Mentions summed (3117 + 364 + 58 + 0).
+        assert survivor["mention_count"] == 3117 + 364 + 58 + 0
+        # Biography preserved from the bio/ism members despite the kunya being the rep.
+        assert survivor["death_year_ah"] in (81, 82)
+        # Every absorbed surface survives as an alias — no spelling lost.
+        aliases = set(survivor["aliases"] or [])
+        assert {_ISM, _BRIDGE, _BIO} <= aliases
+        # attestation lifts off "biographical_only" (summed mc > 0).
+        assert survivor["attestation"] == "isnad_attested"
+
+    def test_mentions_remapped_to_survivor(self, tmp_path: Path) -> None:
+        out = tmp_path
+        _write_canonical(out, _abu_wail_rows())
+        _write_mentions(out, [("m1", "nar:kunya"), ("m3", "nar:ism"), ("m4", "nar:bridge")])
+        seed = _seed(tmp_path, members=[_KUNYA, _ISM, _BRIDGE, _BIO])
+
+        nu.apply_narrator_unification(out, seed_path=seed)
+        survivor_id = pq.read_table(out / "narrators_canonical.parquet").to_pylist()[0][
+            "canonical_id"
+        ]
+        mention_ids = set(
+            pq.read_table(out / "narrator_mentions_resolved.parquet")
+            .column("canonical_narrator_id")
+            .to_pylist()
+        )
+        # All mentions now point at the single survivor; no absorbed id remains.
+        assert mention_ids == {survivor_id}
+
+    def test_idempotent_second_run_is_noop(self, tmp_path: Path) -> None:
+        out = tmp_path
+        _write_canonical(out, _abu_wail_rows())
+        _write_mentions(out, [("m1", "nar:kunya"), ("m3", "nar:ism")])
+        seed = _seed(tmp_path, members=[_KUNYA, _ISM, _BRIDGE, _BIO])
+
+        assert nu.apply_narrator_unification(out, seed_path=seed) is not None
+        first = pq.read_table(out / "narrators_canonical.parquet").to_pylist()
+        # Second run: only the survivor matches a member surface -> < 2 nodes -> no-op.
+        assert nu.apply_narrator_unification(out, seed_path=seed) is None
+        second = pq.read_table(out / "narrators_canonical.parquet").to_pylist()
+        assert first == second
+
+
+# --- Bidirectional: the merge MUST NOT happen for a distinct narrator ------------------
+
+
+class TestMustNotMerge:
+    def _run(self, tmp_path: Path, rows: list[dict[str, Any]], members: list[str]) -> Path | None:
+        out = tmp_path
+        _write_canonical(out, rows)
+        _write_mentions(out, [(f"m{i}", r["canonical_id"]) for i, r in enumerate(rows)])
+        seed = _seed(tmp_path, members=members)
+        return nu.apply_narrator_unification(out, seed_path=seed)
+
+    def test_gross_death_spread_refuses_distinct_namesake(self, tmp_path: Path) -> None:
+        # Bare Shaqīq d.200 (a different, taba-tabiʿī person) shares no gross-spread
+        # tolerance with the d.82 Abū Wāʾil cluster: the group is refused wholesale.
+        rows = _abu_wail_rows() + [_canon("nar:bare", _BARE_SHAQIQ, mc=1046, death=200)]
+        assert self._run(tmp_path, rows, [_KUNYA, _ISM, _BRIDGE, _BIO, _BARE_SHAQIQ]) is None
+        # nothing merged: all 5 nodes intact.
+        assert len(pq.read_table(tmp_path / "narrators_canonical.parquet").to_pylist()) == 5
+
+    def test_corroborated_death_conflict_refuses(self, tmp_path: Path) -> None:
+        # Two members with CORROBORATED, conflicting death years within the sanity band
+        # (82 vs 90, both corroborated) — still refused: a corroborated conflict is hard.
+        rows = _abu_wail_rows()
+        rows[1] = _canon("nar:ism", _ISM, mc=364, death=82, prov="corroborated", gender="male")
+        rows.append(_canon("nar:bridge2", _BRIDGE, mc=10, death=90, prov="corroborated"))
+        assert self._run(tmp_path, rows, [_KUNYA, _ISM, _BRIDGE, _BIO]) is None
+
+    def test_over_merged_bare_generic_member_refuses(self, tmp_path: Path) -> None:
+        # A member that is a curated over-merged bare generic (real seed: عبد الله) can
+        # never be a unify member — the whole group is refused.
+        rows = _abu_wail_rows() + [_canon("nar:generic", "عبد الله", mc=17752)]
+        assert self._run(tmp_path, rows, [_KUNYA, _ISM, _BRIDGE, _BIO, "عبد الله"]) is None
+
+    def test_gender_conflict_refuses(self, tmp_path: Path) -> None:
+        rows = _abu_wail_rows()
+        rows[0] = _canon("nar:kunya", _KUNYA, mc=3117, gender="male")
+        rows.append(_canon("nar:fem", _BRIDGE, mc=5, gender="female"))
+        assert self._run(tmp_path, rows, [_KUNYA, _ISM, _BRIDGE, _BIO]) is None
+
+    def test_missing_bridge_is_uncorroborated_and_refuses(self, tmp_path: Path) -> None:
+        # No member spells out BOTH kunya and ism (drop the bridge + bio) -> the
+        # kunya↔ism identity is not attested in-corpus -> refused.
+        rows = [
+            _canon("nar:kunya", _KUNYA, mc=3117),
+            _canon("nar:ism", _ISM, mc=364, death=82),
+        ]
+        assert self._run(tmp_path, rows, [_KUNYA, _ISM]) is None
+
+
+# --- Seed parsing --------------------------------------------------------------------
+
+
+class TestSeedParsing:
+    def test_fewer_than_two_members_rejected(self, tmp_path: Path) -> None:
+        seed = _seed(tmp_path, members=[_KUNYA])
+        with pytest.raises(ValueError, match="2 members"):
+            nu.load_unify_seed(seed)
+
+    def test_bridge_evidence_requires_kunya_and_ism(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text(
+            'unify:\n  - primary_label: "x"\n    evidence: bio_kunya_ism_bridge\n'
+            '    note: "n"\n    members: ["a", "b"]\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="kunya_norm and ism_norm"):
+            nu.load_unify_seed(path)
+
+    def test_missing_seed_file_is_empty(self, tmp_path: Path) -> None:
+        assert nu.load_unify_seed(tmp_path / "nope.yaml") == ()


### PR DESCRIPTION
## da#431 — kunya↔ism↔bio under-merge (Abū Wāʾil exemplar)

Adds a `narrator_unify` resolve stage: the **merge mirror** of `narrator_split`. It supplies curated, corroborated external evidence to merge a hand-verified set of surface forms that are ONE person but which `fuzzy_cluster`'s precision guard (`_MIN_SHARED_TOKENS=2`) structurally cannot bridge — reusing `fuzzy_cluster._merge_cluster` / `_remap_mention_canonical_ids`. It does **not** loosen the guard and mints no node (mirror of `over_merged_flag`).

### Runtime-gated (per #978)
This PR ships the **mechanism + curated seed + bidirectional fixture only**. The graph-topology change is applied and validated by the **owner-gated re-run drop-diff (#978)**, not by this PR — the runtime-gate-scoping rule.

### Root cause
Abū Wāʾil (Shaqīq b. Salama al-Asadī) is split across ~8 canonicals: ~3,117 mentions on the kunya node `أبو وائل` (0 shared significant tokens with the ism `شقيق بن سلمة`), biography stranded on a 0-mention `bio_promote` node.

### Gate (da#423 discipline — the curated list is the decision, the gate is the safety net)
A group is refused (logged, never merged) on any of: (1) an over-merged bare-generic member (`over_merged_narrators.yaml`); (2) a **corroborated** death-year conflict; (3) a **gross** death-year spread > 50 y regardless of provenance — catches the d.200 bare `شقيق` namesake against the d.82 Abū Wāʾil; (4) a gender conflict; (5) uncorroborated evidence (`bio_kunya_ism_bridge` requires an in-corpus full-name spelling out BOTH the kunya and the ism).

### Validation
- **Bidirectional acceptance fixture** (`tests/test_resolve/test_narrator_unify.py`): golden group MUST merge; 5 distinct-narrator controls MUST NOT (gross spread, corroborated conflict, over-merged member, gender conflict, missing bridge). Idempotency + seed-parse errors covered. 11/11.
- **Real-data measurement** on the `bd133e6` snapshot: 8 nodes → 1 survivor, **mention_count 3,581** (da#431's "~3,500"), **death_year 82 preserved**, all 8 surface forms retained as aliases, canonical 107,951 → 107,944.
- Full resolve suite: **576 passed**; ruff + mypy clean.

### Acceptance (da#431)
- [x] kunya/ism/bio nodes for the confirmed identity merge into one canonical carrying both mentions and biography.
- [x] merge gated on corroborating evidence, not kunya/ism string match alone.
- [x] shipped behind a bidirectional, unweighted, name-level fixture (real drop-diff runs at the #978 re-run).
- [x] Abū Wāʾil resolves to a single canonical bearing his ~3,500 mentions **and** his rijāl biography.

Reviewers: Alejandra Reyes-Fuentes, Jean-Claude Habimana (verdict comments).

Closes #431.
