### PR TITLE
resolve: date-coherence abstain gate on narrator_split peels (da#452)

### DIFF
--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -323,6 +323,21 @@ def _band_label(midpoint: int) -> str:
     return f"d:{(midpoint // 25) * 25}"
 
 
+def _band_is_date_coherent(band: list[DatableMention]) -> bool:
+    """True when the band's midpoint falls inside a known ṭabaqa generation window.
+
+    A midpoint outside every :data:`~src.resolve.tabaqa_dates._GENERATION_DEATH_WINDOW_AH`
+    window maps to :attr:`~src.models.enums.NarratorGeneration.UNKNOWN` — an impossibly
+    LATE (> ~400 AH) or impossibly EARLY (< 11 AH) death that no rijāl authority would
+    accept for a hadith-isnad narrator (da#452). Peeling such a band would mint a phantom
+    twin carrying ``gen=unknown`` + that impossible death year (the 546–693 AH twins Ivana
+    found) while still holding real mentions. Tied to :func:`_generation_for_year`, the
+    SAME function :func:`_peeled_record` uses to stamp a peeled node's generation, so the
+    coherence check and the stamp can never disagree.
+    """
+    return _generation_for_year(_band_midpoint(band)) is not NarratorGeneration.UNKNOWN
+
+
 def plan_split(name_ar_normalized: str, datable: list[DatableMention]) -> SplitPlan:
     """Decide whether/how to split candidate ``name_ar_normalized``; pure + deterministic.
 
@@ -338,11 +353,12 @@ def plan_split(name_ar_normalized: str, datable: list[DatableMention]) -> SplitP
     bands = _cut_bands(datable)
     qualifying = [b for b in bands if len(b) >= SPLIT_MIN_SUPPORT]
 
-    # Gate 1: need ≥2 well-supported bands. A single-band name (a genuinely single
-    # person like Sufyān al-Thawrī / al-Zuhrī) abstains here — the load-bearing guard.
-    if len(qualifying) < 2:
-        return abstain
-    # Gate 2: too many well-supported bands ⇒ generic bucket, not a few people.
+    # Gate 2: too many well-supported bands ⇒ generic bucket, not a few people. Evaluated
+    # on the RAW qualifying count (before the da#452 coherence prune below): a name that
+    # throws off more than SPLIT_MAX_CLUSTERS distinct date bands is an unresolvable
+    # bucket regardless of whether some of those bands are date-incoherent — and running
+    # it first keeps it reachable (a coherent-only count can never exceed the ~5 bands
+    # that fit the ṭabaqa window >SPLIT_BAND_GAP apart, which would make this dead code).
     if len(qualifying) > SPLIT_MAX_CLUSTERS:
         logger.info(
             "narrator_split_abstain_noise",
@@ -350,6 +366,32 @@ def plan_split(name_ar_normalized: str, datable: list[DatableMention]) -> SplitP
             qualifying_bands=len(qualifying),
             max_clusters=SPLIT_MAX_CLUSTERS,
         )
+        return abstain
+
+    # Gate 0 (da#452 — date coherence): drop any qualifying band whose midpoint maps to
+    # NarratorGeneration.UNKNOWN (outside every ṭabaqa window — impossibly late >400 AH or
+    # early <11 AH). Peeling such a band mints a phantom twin with gen=unknown + an
+    # impossible death year that still holds real mentions, corrupting the betweenness
+    # leaderboard (the 546–693 AH twins, da#452). A dropped band is NOT peeled and NOT
+    # retained; its mentions stay on the primary (peel-not-partition), exactly like a
+    # below-support band. An in-window late narrator (the LATER 280–400 band) is coherent
+    # and still peels — the instrument must separate the two (the mandatory da#452 fixture).
+    coherent = [b for b in qualifying if _band_is_date_coherent(b)]
+    if len(coherent) != len(qualifying):
+        logger.info(
+            "narrator_split_drop_incoherent_band",
+            name=name_ar_normalized,
+            dropped_bands=len(qualifying) - len(coherent),
+            dropped_midpoints=[
+                _band_midpoint(b) for b in qualifying if not _band_is_date_coherent(b)
+            ],
+        )
+    qualifying = coherent
+
+    # Gate 1: need ≥2 well-supported, date-coherent bands. A single-band name (a genuinely
+    # single person like Sufyān al-Thawrī / al-Zuhrī), or a name left with one coherent
+    # band after Gate 0, abstains here — the load-bearing guard.
+    if len(qualifying) < 2:
         return abstain
     # Gate 1 (single band) + Gate 2 (too many) are the complete guard set. A third
     # "adjacent midpoints too close ⇒ abstain" separation guard was removed as dead code

--- a/tests/test_resolve/test_narrator_split.py
+++ b/tests/test_resolve/test_narrator_split.py
@@ -23,7 +23,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
-from src.models.enums import DatePrecision
+from src.models.enums import DatePrecision, NarratorGeneration
 from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
 from src.resolve import MissingInputError
 from src.resolve.generic_name import is_generic_name
@@ -35,6 +35,7 @@ from src.resolve.narrator_split import (
     DatableMention,
     _band_midpoint,
     _cut_bands,
+    _generation_for_year,
     plan_split,
     split_generic_narrators,
 )
@@ -127,8 +128,11 @@ def test_removed_gate3_separation_is_dead_code() -> None:
     #     they do their adjacent midpoints are always > SPLIT_BAND_GAP apart (never <=50);
     #   * the only two outcomes are a single-band abstain (Gate 1) or a clean split —
     #     a separation-based abstain never occurs.
+    # Both bands are held inside the ṭabaqa window (120..400) so the da#452 Gate 0
+    # coherence prune never fires here — an out-of-window separation is Gate 0's domain,
+    # covered by test_gate0_out_of_window_band_abstains_no_phantom_twin, not this sweep.
     n = SPLIT_MIN_SUPPORT + 5
-    for sep in range(0, 301):
+    for sep in range(0, 281):
         datable = _dm(120, n, "early") + _dm(120 + sep, n, "late")
         qual = [b for b in _cut_bands(datable) if len(b) >= SPLIT_MIN_SUPPORT]
         plan = plan_split(_ABU_ABDALLAH, datable)
@@ -139,6 +143,39 @@ def test_removed_gate3_separation_is_dead_code() -> None:
             assert plan.is_split  # two well-supported separated bands always peel
         else:
             assert not plan.is_split  # collapsed to one band → Gate 1 abstain
+
+
+def test_gate0_out_of_window_band_abstains_no_phantom_twin() -> None:
+    # da#452 — instrument separation (out-of-window side): a big in-window band (d.150)
+    # plus a well-supported band whose midpoint is impossibly late (d.600, outside every
+    # ṭabaqa window → NarratorGeneration.UNKNOWN). WITHOUT Gate 0 this splits and mints a
+    # phantom twin dated 600 AH with gen=unknown (the da#452 defect). WITH Gate 0 the
+    # incoherent band is dropped, leaving one qualifying band → Gate 1 abstains → the node
+    # stays whole and NO phantom twin is minted (its mentions stay on the primary).
+    assert _generation_for_year(600) is NarratorGeneration.UNKNOWN  # the fixture is real
+    datable = _dm(150, 30, "early") + _dm(600, 15, "late")
+    plan = plan_split(_ABU_ABDALLAH, datable)
+    assert not plan.is_split
+    # And no peeled band could ever carry an UNKNOWN-generation midpoint.
+    assert all(
+        _generation_for_year(b.midpoint_ah) is not NarratorGeneration.UNKNOWN for b in plan.peeled
+    )
+
+
+def test_gate0_in_window_later_band_still_peels() -> None:
+    # da#452 — instrument separation (in-window side): the gate must NOT false-abstain a
+    # genuine late-but-plausible narrator. A big band (d.150) + an in-window LATER band
+    # (d.340 ∈ the 280–400 window) → still splits, peeling the d.340 band onto its own
+    # node with a REAL generation (never unknown). Pairs with the out-of-window test above
+    # to prove the gate separates the coherent from the incoherent late band.
+    assert _generation_for_year(340) is NarratorGeneration.LATER
+    datable = _dm(150, 30, "early") + _dm(340, 15, "late")
+    plan = plan_split(_ABU_ABDALLAH, datable)
+    assert plan.is_split
+    assert len(plan.peeled) == 1
+    band = plan.peeled[0]
+    assert band.midpoint_ah == 340
+    assert _generation_for_year(band.midpoint_ah) is NarratorGeneration.LATER
 
 
 def test_same_band_label_collision_tiebreak_by_anchor() -> None:


### PR DESCRIPTION
## Summary

Adds a **date-coherence abstain gate** (Gate 0) to `narrator_split.plan_split` so the splitter can no longer peel mentions onto phantom "twin" nodes with `gen=unknown` and impossible death years (546–693 AH) — the 206-node defect Ivana found on the re-run base (da#452).

## Root cause

`plan_split` trusts a chain neighbour's attested `death_year_ah` with **no plausibility bound**. An impossibly-late neighbour date (a chimeric/corrupt bio date — tracked separately as **da#454**) propagates into the band midpoint, and `_peeled_record` stamps a twin at that midpoint with `generation = _generation_for_year(midpoint)` = `UNKNOWN` (the ṭabaqa windows top out at 400 AH). The twin still holds the real mentions it peeled, distorting betweenness/choke-point centrality (the #928/#958 target metric). `mononym_split` is NOT implicated — it dates from a curated registry gated by `_temporally_plausible`.

## Fix — Gate 0 (date coherence)

A qualifying band whose midpoint maps to `NarratorGeneration.UNKNOWN` (outside every ṭabaqa window — impossibly late >400 AH or early <11 AH) does **not** qualify to peel; its mentions stay on the primary (peel-not-partition), exactly like a below-support band. The gate is tied to `_generation_for_year` — the **same** function that stamps a peeled node's generation — so the check and the stamp can never disagree and no peeled node can carry `gen=unknown`. Covers both the impossible-late AND impossible-early tails.

### Gate ordering (kept Gate 2 reachable)

Gate 2 (too-many-bands ⇒ generic bucket) now runs on the **raw** qualifying count *before* the coherence prune: a name throwing off >`SPLIT_MAX_CLUSTERS` date bands is an unresolvable bucket regardless of coherence, and evaluating it first keeps it reachable — a coherent-only count can never exceed the ~5 bands that fit the ṭabaqa window >`SPLIT_BAND_GAP` apart, which would have made Gate 2 dead code (the exact thing da#444 just removed). Order is now Gate 2 (raw) → Gate 0 (prune) → Gate 1 (≥2 coherent).

## Instrument-separation fixture (the merge-blocker)

Per the da#452 / da#423 discipline — prove the gate SEPARATES the classes, both sides:
- `test_gate0_out_of_window_band_abstains_no_phantom_twin`: d.150 + impossibly-late d.600 (UNKNOWN) → node stays whole, **no** phantom twin minted (RED without the gate — it would split and mint a 600 AH gen=unknown twin).
- `test_gate0_in_window_later_band_still_peels`: d.150 + in-window LATER d.340 (280–400) → **still peels** with a real generation — proving the gate does NOT false-abstain a genuine late-but-plausible narrator (the inverse erasure risk).

## Scope / magnitude

Ships the gate + fixture (unit-mechanic correctness). Magnitude — 206 nodes, total phantom-held mentions, single-class-or-not — is an owner-gated **re-run measurement**. The upstream impossibly-late attested neighbour dates are a **separate track (da#454)**, re-run prep; this output gate defends the split regardless of da#454.

## Checks

- New instrument-separation pair (above); existing `test_too_many_bands` / gate3-dead-code tests updated for the reorder + in-window scoping.
- Full resolve suite: 582 passed, 6 skipped. ruff + mypy clean; full pre-push green.

## Reviewers
- Peer: **Nikolaos Papadopoulos**
- Secondary: **Oyunbileg Batbayar**

Closes #452
Part of main#928
