### PR TITLE
resolve: unify Anas b. Mālik bare↔qualified via isnad-neighbour gate (da#347)

### DIFF
--- a/src/resolve/narrator_unify.py
+++ b/src/resolve/narrator_unify.py
@@ -118,6 +118,12 @@ class UnifyGroup:
     member_ids: tuple[str, ...] = ()
     kunya_norm: str | None = None
     ism_norm: str | None = None
+    # isnad_neighbor_overlap evidence: the bare ism and its qualified form, and the
+    # required chain-neighbour overlap (|top-K(bare) ∩ top-K(qualified)| / K).
+    bare_norm: str | None = None
+    qualified_norm: str | None = None
+    min_overlap: float = 0.5
+    top_k: int = 50
 
 
 def load_unify_seed(path: Path = _SEED_PATH) -> tuple[UnifyGroup, ...]:
@@ -151,6 +157,13 @@ def load_unify_seed(path: Path = _SEED_PATH) -> tuple[UnifyGroup, ...]:
                 f"unify group {row.get('primary_label')!r} evidence bio_kunya_ism_bridge "
                 "requires kunya_norm and ism_norm"
             )
+        bare = row.get("bare_norm")
+        qualified = row.get("qualified_norm")
+        if evidence == "isnad_neighbor_overlap" and not (bare and qualified):
+            raise ValueError(
+                f"unify group {row.get('primary_label')!r} evidence isnad_neighbor_overlap "
+                "requires bare_norm and qualified_norm"
+            )
         groups.append(
             UnifyGroup(
                 primary_label=row.get("primary_label") or (members[0] if members else "?"),
@@ -161,6 +174,10 @@ def load_unify_seed(path: Path = _SEED_PATH) -> tuple[UnifyGroup, ...]:
                 member_ids=member_ids,
                 kunya_norm=normalize_arabic(kunya) if kunya else None,
                 ism_norm=normalize_arabic(ism) if ism else None,
+                bare_norm=normalize_arabic(bare) if bare else None,
+                qualified_norm=normalize_arabic(qualified) if qualified else None,
+                min_overlap=float(row.get("min_overlap", 0.5)),
+                top_k=int(row.get("top_k", 50)),
             )
         )
     return tuple(groups)
@@ -236,13 +253,69 @@ def _gender_conflict(members: list[dict[str, Any]]) -> bool:
     return False
 
 
-def _evidence_corroborated(group: UnifyGroup, members: list[dict[str, Any]]) -> bool:
+def _chain_neighbor_overlap(mentions_path: Path, id_a: str, id_b: str, *, top_k: int) -> float:
+    """Overlap coefficient of the two canonical ids' top-``top_k`` chain neighbours.
+
+    Builds each id's multiset of isnad chain neighbours and returns the overlap
+    coefficient ``|top(id_a) ∩ top(id_b)| / min(|top(id_a)|, |top(id_b)|)`` over each id's
+    top-``top_k`` neighbours. This is the da#347 instrument that SEPARATES the classes: a
+    bare ism that is genuinely the same person as its qualified form transmits from/to the
+    same teachers and students, so their neighbourhoods overlap heavily (Anas: 0.68); a
+    distinct namesake's does not. The overlap coefficient (denominator = the SMALLER
+    neighbour set) is used rather than ``/top_k`` so the measure is not diluted when one
+    node has fewer than ``top_k`` distinct neighbours — on the real Anas nodes both sets are
+    full at 50 so the two agree.
+
+    Adjacency is the SHARED :func:`~src.resolve.narrator_split.resolved_chain_neighbours`
+    definition (da#346/da#439) — the immediately-preceding/-following RESOLVED mention in
+    the position-sorted ``(hadith_id, chain_index)`` chain, gap-bridging and self-loop
+    dropping — NOT an exact position ±1 test. This is the loader's ``TRANSMITTED_TO``
+    topology, so the gate measures the same neighbourhood the graph actually builds and
+    cannot drift from it (and does not under-count on gappy isnads). Bounded memory:
+    :func:`~src.resolve.narrator_split._build_chain_index` restricts the resident chains to
+    only those touching one of the two ids. Returns 0.0 when the file is absent or either
+    id has no neighbours (fail closed).
+    """
+    from collections import Counter
+
+    from src.resolve.narrator_split import _build_chain_index, resolved_chain_neighbours
+
+    if not mentions_path.exists():
+        return 0.0
+    chains, candidate_mentions = _build_chain_index(mentions_path, {id_a, id_b})
+
+    def _neighbours(cid: str) -> Counter[str]:
+        counts: Counter[str] = Counter()
+        for hid, cidx, pos, _mid in candidate_mentions.get(cid, []):
+            teacher, student = resolved_chain_neighbours(chains, hid, cidx, pos)
+            for neighbour in (teacher, student):
+                if neighbour is not None and neighbour != cid:
+                    counts[neighbour] += 1
+        return counts
+
+    na, nb = _neighbours(id_a), _neighbours(id_b)
+    top_a = {n for n, _ in na.most_common(top_k)}
+    top_b = {n for n, _ in nb.most_common(top_k)}
+    if not top_a or not top_b:
+        return 0.0
+    return len(top_a & top_b) / min(len(top_a), len(top_b))
+
+
+def _evidence_corroborated(
+    group: UnifyGroup, members: list[dict[str, Any]], mentions_path: Path
+) -> bool:
     """Confirm the group's declared evidence is attested in the resolved members.
 
     ``bio_kunya_ism_bridge``: a resolved member's normalized name must contain BOTH the
     declared kunya and the declared ism — the in-corpus full-name node that spells out the
-    kunya↔ism identity, so the bridge is attested, not asserted. Unknown evidence kinds are
-    treated as NOT corroborated (fail closed).
+    kunya↔ism identity, so the bridge is attested, not asserted.
+
+    ``isnad_neighbor_overlap``: the bare-ism member and the qualified member must both be
+    present and share at least ``min_overlap`` of their top-``top_k`` chain neighbours —
+    the isnad-neighbourhood instrument that separates a genuine same-person split (Anas b.
+    Mālik) from a distinct namesake.
+
+    Unknown evidence kinds are treated as NOT corroborated (fail closed).
     """
     if group.evidence == "bio_kunya_ism_bridge":
         kunya, ism = group.kunya_norm, group.ism_norm
@@ -253,11 +326,40 @@ def _evidence_corroborated(group: UnifyGroup, members: list[dict[str, Any]]) -> 
             and ism in (m.get("name_ar_normalized") or "")
             for m in members
         )
+    if group.evidence == "isnad_neighbor_overlap":
+        bare_n, qual_n = group.bare_norm, group.qualified_norm
+        if not (bare_n and qual_n):
+            return False
+        bare = next(
+            (m for m in members if normalize_arabic(m.get("name_ar_normalized") or "") == bare_n),
+            None,
+        )
+        qual = next(
+            (m for m in members if normalize_arabic(m.get("name_ar_normalized") or "") == qual_n),
+            None,
+        )
+        if bare is None or qual is None:
+            return False
+        overlap = _chain_neighbor_overlap(
+            mentions_path, bare["canonical_id"], qual["canonical_id"], top_k=group.top_k
+        )
+        if overlap < group.min_overlap:
+            logger.info(
+                "narrator_unify_isnad_overlap",
+                group=group.primary_label,
+                overlap=round(overlap, 3),
+                min_overlap=group.min_overlap,
+                top_k=group.top_k,
+            )
+        return overlap >= group.min_overlap
     return False
 
 
 def _group_admissible(
-    group: UnifyGroup, members: list[dict[str, Any]], over_merged: frozenset[str]
+    group: UnifyGroup,
+    members: list[dict[str, Any]],
+    over_merged: frozenset[str],
+    mentions_path: Path,
 ) -> tuple[bool, str]:
     """Gate a resolved group. Returns (ok, reason) — reason is empty when admissible."""
     distinct = {m.get("canonical_id") for m in members}
@@ -286,7 +388,7 @@ def _group_admissible(
     if _gender_conflict(members):
         return False, "explicit gender conflict between members"
 
-    if not _evidence_corroborated(group, members):
+    if not _evidence_corroborated(group, members, mentions_path):
         return False, f"declared evidence {group.evidence!r} not corroborated in-corpus"
 
     return True, ""
@@ -340,6 +442,7 @@ def apply_narrator_unification(output_dir: Path, *, seed_path: Path = _SEED_PATH
     if not records:
         return None
 
+    mentions_path = output_dir / "narrator_mentions_resolved.parquet"
     over_merged = _over_merged_norms()
     by_id = {r["canonical_id"]: r for r in records if r.get("canonical_id")}
     by_norm: dict[str, list[dict[str, Any]]] = {}
@@ -353,7 +456,7 @@ def apply_narrator_unification(output_dir: Path, *, seed_path: Path = _SEED_PATH
 
     for group in groups:
         members = _resolve_members(group, by_norm, by_id)
-        ok, reason = _group_admissible(group, members, over_merged)
+        ok, reason = _group_admissible(group, members, over_merged, mentions_path)
         if not ok:
             logger.warning(
                 "narrator_unify_group_refused",

--- a/src/resolve/narrator_unify.yaml
+++ b/src/resolve/narrator_unify.yaml
@@ -65,3 +65,36 @@ unify:
       - "ابو واءل شقيق بن سلمه الاسدي"     # bridging full name, mc 3
       - "شقيق بن سلمه بن واءل الاسدي"      # ism+nasab+nisba, mc 1
       - "شقيق ابو واءل بن سلمه الاسدي"     # bio-promoted rijāl node, mc 0, d.81
+
+  # da#347 — Anas b. Mālik, the Companion, split between his fully-qualified node
+  # `أنس بن مالك` (mc 17,820, d.91) and the bare ism `أنس` (mc 16,951, d.60 — the generic
+  # sahabi death-year default, not a real dating). They share ONE significant token, below
+  # fuzzy_cluster's _MIN_SHARED_TOKENS=2, so they never merge and his true centrality is
+  # roughly halved. Evidence is isnad-neighbourhood: the two nodes share 34/50 of their top
+  # chain neighbours (measured on bd133e6), both led by Anas's canonical students — Qatāda,
+  # Thābit al-Bunānī, Ḥumayd al-Ṭawīl, al-Zuhrī, Isḥāq b. Abī Ṭalḥa — so the bare node is
+  # overwhelmingly the same person. Bare `أنس` is NOT a curated over-merged generic (unlike
+  # `عبد الله`/`محمد`); the isnad-overlap gate is what separates it from a distinct namesake.
+  #
+  # NOT included here (deliberate, per da#347 secondary + da#443): `ابن عبس` is a
+  # dropped-alif OCR corruption of `ابن عباس`, NOT a diacritic fold — it must NOT be merged
+  # into Ibn ʿAbbās on a string subset; its low isnad overlap with the Ibn ʿAbbās hub would
+  # fail this gate anyway, and a real fix needs external evidence, not corpus-internal
+  # string surgery. `قتادة`/`قَتَادَةَ` already normalize to one node in #928 — no action.
+  - primary_label: "Anas b. Mālik, the Companion (bare ism ↔ qualified, d. ~91-93 AH)"
+    issue: "da#347"
+    evidence: isnad_neighbor_overlap
+    bare_norm: "انس"
+    qualified_norm: "انس بن مالك"
+    min_overlap: 0.5
+    top_k: 50
+    note: >-
+      Bare-ism↔qualified under-merge. `أنس` (bare, mc 16,951, d.60 generic default) and
+      `أنس بن مالك` (mc 17,820, d.91) are one Companion split across two nodes because they
+      share only one significant token (< _MIN_SHARED_TOKENS). Corroborated by isnad
+      neighbourhood: 34/50 shared top chain-neighbours on bd133e6, both dominated by Anas's
+      canonical students (Qatāda, Thābit al-Bunānī, Ḥumayd al-Ṭawīl, al-Zuhrī). Merge folds
+      the bare node into the qualified survivor, restoring his true centrality. da#347.
+    members:
+      - "انس"            # bare ism, mc 16,951
+      - "انس بن مالك"    # qualified ism+nasab, mc 17,820, d.91 (survivor)

--- a/tests/test_resolve/test_narrator_unify.py
+++ b/tests/test_resolve/test_narrator_unify.py
@@ -233,6 +233,120 @@ class TestMustNotMerge:
         assert self._run(tmp_path, rows, [_KUNYA, _ISM]) is None
 
 
+# --- da#347: bare-ism ↔ qualified via isnad-neighbour overlap -------------------------
+
+_BARE_ANAS = "انس"
+_QUAL_ANAS = "انس بن مالك"
+
+
+def _write_chain_mentions(output_dir: Path, chains: list[list[str]]) -> None:
+    """Write resolved mentions as isnad sequences (one chain = one ordered id list)."""
+    rows: list[tuple[str, int, int, str]] = []  # (hadith_id, chain_index, position, cid)
+    for ci, chain in enumerate(chains):
+        for pos, cid in enumerate(chain):
+            rows.append((f"hdt:x:{ci}", 0, pos, cid))
+    n = len(rows)
+    tbl = pa.table(
+        {
+            "mention_id": [f"m{i}" for i in range(n)],
+            "hadith_id": [r[0] for r in rows],
+            "source_corpus": ["itqan"] * n,
+            "position_in_chain": [r[2] for r in rows],
+            "chain_index": [r[1] for r in rows],
+            "name_raw": [None] * n,
+            "name_normalized": [None] * n,
+            "canonical_narrator_id": [r[3] for r in rows],
+            "transmission_method": [None] * n,
+            "confidence": [None] * n,
+        },
+        schema=NARRATOR_MENTIONS_RESOLVED_SCHEMA,
+    )
+    pq.write_table(tbl, output_dir / "narrator_mentions_resolved.parquet")
+
+
+def _anas_rows() -> list[dict[str, Any]]:
+    return [
+        _canon("nar:bare_anas", _BARE_ANAS, mc=16951, death=60),  # bare ism, generic d.60
+        _canon("nar:qual_anas", _QUAL_ANAS, mc=17820, death=91, gender="male"),  # survivor
+    ]
+
+
+def _anas_seed(tmp_path: Path, *, min_overlap: float = 0.5, top_k: int = 50) -> Path:
+    lines = [
+        "unify:",
+        '  - primary_label: "Anas b. Mālik (test)"',
+        '    issue: "da#347"',
+        "    evidence: isnad_neighbor_overlap",
+        f'    bare_norm: "{_BARE_ANAS}"',
+        f'    qualified_norm: "{_QUAL_ANAS}"',
+        f"    min_overlap: {min_overlap}",
+        f"    top_k: {top_k}",
+        '    note: "synthetic isnad-overlap group"',
+        "    members:",
+        f'      - "{_BARE_ANAS}"',
+        f'      - "{_QUAL_ANAS}"',
+    ]
+    path = tmp_path / "anas_seed.yaml"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+class TestIsnadOverlapMerge:
+    def test_shared_neighbours_merge(self, tmp_path: Path) -> None:
+        # Both nodes transmit with the same six teachers/students (Anas's canonical
+        # students) -> overlap 1.0 >= 0.5 -> merge into the qualified survivor.
+        teachers = [f"nar:t{i}" for i in range(6)]
+        chains = [[t, "nar:bare_anas"] for t in teachers] + [[t, "nar:qual_anas"] for t in teachers]
+        _write_canonical(tmp_path, _anas_rows())
+        _write_chain_mentions(tmp_path, chains)
+        assert nu.apply_narrator_unification(tmp_path, seed_path=_anas_seed(tmp_path)) is not None
+        rows = pq.read_table(tmp_path / "narrators_canonical.parquet").to_pylist()
+        assert len(rows) == 1
+        survivor = rows[0]
+        assert survivor["mention_count"] == 16951 + 17820
+        # survivor is the QUALIFIED node (higher mention_count) and keeps its dating.
+        assert survivor["name_ar_normalized"] == _QUAL_ANAS
+        assert survivor["death_year_ah"] == 91
+        # every bare mention now points at the survivor; no absorbed bare id remains
+        # (teacher/neighbour nodes are untouched).
+        mids = set(
+            pq.read_table(tmp_path / "narrator_mentions_resolved.parquet")
+            .column("canonical_narrator_id")
+            .to_pylist()
+        )
+        assert "nar:bare_anas" not in mids
+        assert survivor["canonical_id"] in mids
+
+    def test_disjoint_neighbours_refuse_distinct_namesake(self, tmp_path: Path) -> None:
+        # A namesake: the bare node and the qualified node transmit with entirely
+        # different circles -> overlap 0.0 < 0.5 -> refused (the da#423 exclude direction).
+        chains = [[f"nar:a{i}", "nar:bare_anas"] for i in range(6)] + [
+            [f"nar:b{i}", "nar:qual_anas"] for i in range(6)
+        ]
+        _write_canonical(tmp_path, _anas_rows())
+        _write_chain_mentions(tmp_path, chains)
+        assert nu.apply_narrator_unification(tmp_path, seed_path=_anas_seed(tmp_path)) is None
+        assert len(pq.read_table(tmp_path / "narrators_canonical.parquet").to_pylist()) == 2
+
+    def test_no_mentions_file_fails_closed(self, tmp_path: Path) -> None:
+        # No mentions -> no neighbours -> overlap 0.0 -> refused (never merge without the
+        # instrument).
+        _write_canonical(tmp_path, _anas_rows())
+        assert nu.apply_narrator_unification(tmp_path, seed_path=_anas_seed(tmp_path)) is None
+
+    def test_overlap_below_threshold_refuses(self, tmp_path: Path) -> None:
+        # Partial overlap (2 of 6 shared) = 0.33 < 0.5 -> refused.
+        shared = [f"nar:s{i}" for i in range(2)]
+        bare_only = [f"nar:a{i}" for i in range(4)]
+        qual_only = [f"nar:q{i}" for i in range(4)]
+        chains = [[t, "nar:bare_anas"] for t in shared + bare_only] + [
+            [t, "nar:qual_anas"] for t in shared + qual_only
+        ]
+        _write_canonical(tmp_path, _anas_rows())
+        _write_chain_mentions(tmp_path, chains)
+        assert nu.apply_narrator_unification(tmp_path, seed_path=_anas_seed(tmp_path)) is None
+
+
 # --- Seed parsing --------------------------------------------------------------------
 
 


### PR DESCRIPTION
## da#347 — Anas b. Mālik bare-ism ↔ qualified under-merge

> Supersedes #457, which GitHub auto-closed when #455's branch (its stacked base) was deleted on merge. Same branch, now rebased directly onto `deployments/phase-9/wave-25` (which carries #455's `narrator_unify` stage + composed step order).

Anas b. Mālik is split between `أنس بن مالك` (mc 17,820, d.91) and the bare ism `أنس` (mc 16,951, d.60 — the generic sahabi default). One shared significant token (< `_MIN_SHARED_TOKENS=2`), so they never merge and his centrality is ~halved.

### Mechanism
Extends the merged `narrator_unify` stage (da#431) with an **`isnad_neighbor_overlap`** evidence gate — the instrument da#347 demanded. Merges the bare→qualified pair ONLY when their top-K isnad chain-neighbour sets overlap ≥ `min_overlap` (overlap coefficient). Survivor is the qualified node; the bare node's mentions remap onto it.

**Adjacency reuses the shared `narrator_split.resolved_chain_neighbours` helper** (da#346/da#439) — the loader's consecutive-resolved TRANSMITTED_TO topology (gap-bridging, self-loop-dropping), NOT a private position±1 scan — so the gate measures the same neighbourhood the graph builds and cannot drift/under-count on gappy isnads. `_build_chain_index` bounds resident memory to the two ids' chains.

### Runtime-gated (#978)
Mechanism + seed + fixture only; topology change + real drop-diff land at the owner-gated re-run.

### Conservatism (da#347 secondaries)
- `ابن عبس` (dropped-alif OCR of `ابن عباس`) deliberately NOT merged — string subset ≠ identity; low isnad overlap with the Ibn ʿAbbās hub would fail the gate anyway; real fix needs external evidence (da#443).
- `قتادة`/`قَتَادَةَ` already one node in #928.

### Validation
- **Bidirectional fixture** (`TestIsnadOverlapMerge`): shared-neighbour pair MUST merge (qualified survivor, summed mentions, bare absorbed); disjoint-neighbour namesake MUST NOT; below-threshold (0.33) MUST NOT; no-mentions fails closed. 15/15.
- **Real-data** (`bd133e6`, shared adjacency): Anas overlap **0.66** ≥ 0.5 → PASS; top neighbours are his canonical students (Qatāda, Thābit al-Bunānī, Ḥumayd al-Ṭawīl, al-Zuhrī).
- Full resolve suite **595 passed** on the composed tree; ruff + mypy clean; pre-push green.

### Acceptance (da#347)
- [x] `أنس`/`أنس بن مالك` confirmed one person (isnad overlap 0.66) and unified.
- [x] gated on quantified isnad-neighbourhood evidence, not string subset.
- [x] normalization notes handled (قتاده one node; ابن عبس excluded).
- [x] behind a bidirectional fixture; real drop-diff at #978.

Reviewers: Jean-Claude Habimana, Alejandra Reyes-Fuentes (verdict comments).

Closes #347.
