### PR TITLE
Phase 9 Wave 25 → main (noorinalabs-data-acquisition)

### DIFF
--- a/scripts/da366_measure_recovery.py
+++ b/scripts/da366_measure_recovery.py
@@ -1,0 +1,131 @@
+"""Measure da#366 matn-embedded isnad recovery against the real sanadset corpus.
+
+This is the instrument the issue asks for: run the two-convention splitter over
+the real ``No SANAD`` rows and report how many carry a recoverable isnad
+(expected ~122,000, a lower bound), broken down by convention; and check the
+boundary does not pull matn into the isnad.
+
+**Why it is data-gated.** No real corpus ships in the repo (``data/raw`` is
+empty), so this cannot run in CI. The recovery magnitude is a re-run
+measurement, not a unit assertion — the splitter's CORRECTNESS is unit-proven in
+``tests/test_parse/test_isnad_matn_split.py``; this script produces the MAGNITUDE
+once the raw CSVs are present. Run with no data and it prints a loud SKIP and
+exits 0 (non-gating), rather than emit a zero that looks like a measurement
+("silent zero is not a measurement").
+
+The pure summarisers (:func:`summarize_recovery`, :func:`boundary_precision`)
+are unit-tested in ``tests/test_scripts/test_da366_measure.py``.
+
+Usage:
+    PYTHONPATH=. python3 scripts/da366_measure_recovery.py [RAW_DIR]
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from src.parse.isnad_matn_split import split_isnad_matn
+from src.parse.narrator_extraction import extract_narrator_mentions
+
+
+@dataclass(frozen=True)
+class RecoveryStats:
+    """Recovery tally over a set of candidate matn texts."""
+
+    total: int
+    recovered: int
+    by_convention: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def rate(self) -> float:
+        return self.recovered / self.total if self.total else 0.0
+
+
+def summarize_recovery(texts: Iterable[str]) -> RecoveryStats:
+    """Run the splitter over *texts* and tally recoveries by convention."""
+    total = 0
+    conv: Counter[str] = Counter()
+    for text in texts:
+        total += 1
+        result = split_isnad_matn(text)
+        if result is not None:
+            conv[result.convention] += 1
+    return RecoveryStats(total=total, recovered=sum(conv.values()), by_convention=dict(conv))
+
+
+def boundary_precision(pairs: Iterable[tuple[str, str]]) -> tuple[int, int]:
+    """Boundary-precision check over known ``(isnad, matn)`` pairs.
+
+    Reconstructs the untagged shape ``isnad + " " + matn`` and asserts the
+    splitter does not pull a matn token into the recovered isnad. Returns
+    ``(clean, recovered)`` — ``clean`` is the number of recoveries whose isnad
+    narrator set is a subset of the isnad-only segmentation (no matn leaked in).
+
+    Recall is deliberately NOT reported: the tagged rows strip their opener, so
+    they are a different textual representation and cannot calibrate the
+    splitter's sensitivity (da#366). This measures precision only.
+    """
+    clean = 0
+    recovered = 0
+    for isnad, matn in pairs:
+        result = split_isnad_matn(f"{isnad} {matn}")
+        if result is None:
+            continue
+        recovered += 1
+        truth = {s.name for s in extract_narrator_mentions(isnad, "ar")}
+        got = {s.name for s in result.spans}
+        if got <= truth:
+            clean += 1
+    return clean, recovered
+
+
+def _iter_no_sanad_matns(raw_dir: Path) -> list[str]:  # pragma: no cover - needs real data
+    """Yield the matn text of every ``No SANAD`` row across the raw CSVs.
+
+    Mirrors the parser's tag extraction (``src/parse/sanadset.py``) so the
+    population matches what the loader would see.
+    """
+    from src.parse.base import read_csv_robust
+    from src.parse.sanadset import _MATN_RE, _SANAD_RE, _extract_tag, _strip_structural_tags
+
+    texts: list[str] = []
+    for csv_file in sorted(raw_dir.glob("*.csv")):
+        table, _enc = read_csv_robust(csv_file)
+        for i in range(table.num_rows):
+            full = table.column("Hadith")[i].as_py() if "Hadith" in table.column_names else None
+            if not full:
+                continue
+            sanad = _extract_tag(_SANAD_RE, full)
+            if sanad and sanad.lower() != "no sanad":
+                continue
+            matn = _strip_structural_tags(_extract_tag(_MATN_RE, full))
+            if matn:
+                texts.append(matn)
+    return texts
+
+
+def main(argv: list[str]) -> int:  # pragma: no cover - CLI wrapper
+    raw_dir = Path(argv[1]) if len(argv) > 1 else Path("data/raw/sanadset")
+    if not raw_dir.exists() or not any(raw_dir.glob("*.csv")):
+        print(
+            f"SKIP: no sanadset CSVs under {raw_dir} — recovery magnitude is a re-run "
+            "measurement, not obtainable without the corpus. Splitter correctness is "
+            "covered by tests/test_parse/test_isnad_matn_split.py.",
+            file=sys.stderr,
+        )
+        return 0
+
+    stats = summarize_recovery(_iter_no_sanad_matns(raw_dir))
+    print(f"No SANAD rows scanned : {stats.total}")
+    print(f"isnad recovered       : {stats.recovered} ({stats.rate:.1%})")
+    for conv, n in sorted(stats.by_convention.items()):
+        print(f"  {conv:9s}: {n}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv))

--- a/src/parse/isnad_matn_split.py
+++ b/src/parse/isnad_matn_split.py
@@ -1,0 +1,269 @@
+"""Recover a matn-embedded isnad from sanadset's "No SANAD" rows (da#366).
+
+Sanadset's 159,558 rows whose ``Sanad`` column reads literally ``No SANAD`` are
+NOT chainless: the dataset author simply failed to segment them, and ~122,000
+carry an isnad embedded in the running matn text. This module recovers that
+isnad **without** the NER ``full_text_ar`` fallback (``src/resolve/ner.py``,
+da#369) — that fallback mines the whole body and mints matn sentences as
+narrators (measured on ``lk``: mentions/hadith 5.49 → 7.91, 1.44×; 53.7% of the
+extra names are substrings of the *matn*, 0.1% of the isnad).
+
+Two isnad conventions occur and no single probe sees both (da#366):
+
+  1. RECEIPT-VERB opener   ``حدثنا فلان، حدثنا فلان، عن فلان``   (``lk``-shaped)
+  2. BARE-NAME + ``عن``     ``علي بن إبراهيم عن أبيه عن ابن أبي عمير``  (``tusi``/sanadset-shaped)
+
+An opener-only probe is blind to (2); a ``عن``-only probe is noisy. The
+calibrated detector (da#366) takes either:
+
+    D(text) = head_opener(text) OR (>= 2 standalone عن within the first 25 tokens)
+
+measured at 66.5% / 77.2% on the ``No SANAD`` rows against 0.1% / 3.1% on known
+matn.
+
+**Precision is paramount.** A splitter that pulls matn tokens into the isnad
+fabricates narrators — the exact #317/#369 pollution this recovery exists to
+avoid. So the isnad→matn boundary is found conservatively and the module
+**fails closed** (recovers nothing) whenever the boundary is not locatable or
+the isolated head is not cleanly segmentable by the existing fail-loud
+segmenter. Recovering fewer chains is the correct failure mode; recovering a
+matn sentence as a chain is not. Recovery is therefore an accepted lower bound.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from src.parse.narrator_extraction import (
+    IsnadSegmentationError,
+    NarratorSpan,
+    extract_narrator_mentions,
+)
+from src.utils.arabic import extract_transmission_phrases, normalize_arabic
+
+__all__ = [
+    "DETECTOR_TOKEN_WINDOW",
+    "SplitResult",
+    "detect_isnad",
+    "split_isnad_matn",
+]
+
+# --- detector -------------------------------------------------------------
+
+# Head openers (receipt verbs) that mark convention (1). Includes the abbreviated
+# forms ``ثنا``/``ثني`` (clipped ``حدثنا``/``حدثني``) and ``أبنا`` (clipped
+# ``أنبأنا``) that the shared ``_TRANSMISSION_TERMS`` set omits but the corpus
+# uses (da#366). Compared against the *normalized* head token, so orthographic
+# and diacritic variants collapse (``أخبرنا`` → ``اخبرنا``); the comparison is
+# therefore exact-token, never a substring match.
+_RAW_HEAD_OPENERS: tuple[str, ...] = (
+    "حدثنا",
+    "حدثني",
+    "ثنا",
+    "ثني",
+    "أخبرنا",
+    "أخبرني",
+    "أنبأنا",
+    "أبنا",
+    "سمعت",
+)
+_HEAD_OPENERS: frozenset[str] = frozenset(normalize_arabic(t) for t in _RAW_HEAD_OPENERS)
+
+# Detector window and the ``عن`` count that marks convention (2).
+DETECTOR_TOKEN_WINDOW = 25
+_MIN_AN_FOR_CHAIN = 2
+
+# --- boundary -------------------------------------------------------------
+
+# ``extract_transmission_phrases`` labels (from ``src.utils.arabic``) that CHAIN
+# one narrator to the next — an opener or ``عن``/``سمع`` links the following name
+# into the isnad. ``قال`` ("qala") is deliberately absent: it is ambiguous and
+# handled separately.
+_LINK_LABELS: frozenset[str] = frozenset(
+    {
+        "haddathana",
+        "haddathani",
+        "akhbarana",
+        "akhbarani",
+        "anba_ana",
+        "anba_ani",
+        "samitu",
+        "samia",
+        "an",
+        "nawalani",
+        "kataba_ilayya",
+    }
+)
+
+# A ``قال`` is a chain LINK (``حدثنا فلان قال حدثنا فلان``) only when a linking
+# phrase follows it closely; otherwise it introduces the matn
+# (``عن أبي هريرة قال: …``) and marks the boundary. This is the gap, in
+# characters, from the ``قال`` match end to the next phrase's start within which
+# the next phrase is treated as a continuation. Kept small: matn openers are
+# rare (0.1% per calibration), so a genuine boundary ``قال`` is very unlikely to
+# have a spurious opener within a few characters.
+_QALA_LINK_LOOKAHEAD_CHARS = 12
+
+# Matn-introducing punctuation: a colon or an opening/closing quotation mark
+# begins direct speech, so it terminates the isnad.
+_MATN_PUNCT: tuple[str, ...] = (":", '"', "«", "»", "“", "”", "‹", "›", "﴿")
+
+# Standalone ``أن`` / ``أنّ`` / ``أنه`` / ``أنها`` ("that …") introduces the
+# reported content — the classic bare-name isnad→matn hinge
+# (``… عن ابن عمر أن رسول الله``). Diacritic-tolerant and boundary-anchored so it
+# never fires inside a name (``أنس`` → followed by a letter, excluded).
+_DIAC = r"[ً-ٰٟ]*"
+_AR_LETTER = r"ء-ي"
+_AN_BOUNDARY_RE: re.Pattern[str] = re.compile(
+    rf"(?<![{_AR_LETTER}])"
+    rf"[اأإآٱ]{_DIAC}ن{_DIAC}"  # أن / ان
+    rf"(?:[ها]{_DIAC})*"  # optional أنه / أنها / أنا tail
+    rf"(?![{_AR_LETTER}])"
+)
+
+# First Arabic-letter word of a text, skipping any leading punctuation/whitespace.
+_FIRST_AR_WORD_RE: re.Pattern[str] = re.compile(rf"[^{_AR_LETTER}]*([{_AR_LETTER}]+)")
+
+
+@dataclass(frozen=True)
+class SplitResult:
+    """A recovered isnad/matn split.
+
+    ``spans`` are the narrator mentions segmented from ``isnad_ar`` by the shared
+    fail-loud :func:`extract_narrator_mentions`; the caller maps them to mention
+    rows (and applies its own narrator-likeness filter).
+    """
+
+    isnad_ar: str
+    matn_ar: str
+    convention: str  # "opener" | "an_chain" | "both"
+    spans: tuple[NarratorSpan, ...]
+
+
+def _head_opener(text: str) -> bool:
+    """True if the first Arabic word is a transmission opener.
+
+    Leading punctuation/whitespace is skipped so an opener that follows an
+    editorial mark still counts; the comparison is on the *normalized* first
+    Arabic word, so it is exact-token, never a substring of a longer word.
+    """
+    match = _FIRST_AR_WORD_RE.match(normalize_arabic(text))
+    if match is None:
+        return False
+    return match.group(1) in _HEAD_OPENERS
+
+
+def _window_end(text: str) -> int:
+    """Char offset just past the :data:`DETECTOR_TOKEN_WINDOW`-th whitespace token."""
+    tokens = list(re.finditer(r"\S+", text))
+    if len(tokens) <= DETECTOR_TOKEN_WINDOW:
+        return len(text)
+    return tokens[DETECTOR_TOKEN_WINDOW - 1].end()
+
+
+def _an_count_in_window(text: str, phrases: list[tuple[int, int, str]]) -> int:
+    """Count standalone ``عن`` transmission phrases within the detector window."""
+    limit = _window_end(text)
+    return sum(1 for start, _end, label in phrases if label == "an" and start < limit)
+
+
+def detect_isnad(text: str, phrases: list[tuple[int, int, str]]) -> str | None:
+    """Return the matched convention, or ``None`` if the detector does not fire.
+
+    ``"both"`` when a head opener AND >= 2 windowed ``عن`` are present,
+    ``"opener"`` / ``"an_chain"`` when only one signal fires.
+    """
+    opener = _head_opener(text)
+    an_chain = _an_count_in_window(text, phrases) >= _MIN_AN_FOR_CHAIN
+    if opener and an_chain:
+        return "both"
+    if opener:
+        return "opener"
+    if an_chain:
+        return "an_chain"
+    return None
+
+
+def _matn_boundary(text: str, phrases: list[tuple[int, int, str]]) -> int | None:
+    """Char offset where the matn begins, or ``None`` if not locatable.
+
+    The isnad must keep at least the first transmission phrase, so a boundary is
+    only valid at or after that phrase's end. The earliest reliable matn
+    introducer (a non-linking ``قال``, a standalone ``أن``, or matn punctuation)
+    wins. ``None`` (fail closed) when no reliable introducer follows the chain —
+    guessing a boundary would risk absorbing matn into the final narrator.
+    """
+    if not phrases:
+        return None
+    min_boundary = phrases[0][1]
+
+    candidates: list[int] = []
+
+    # Non-linking ``قال`` → boundary; linking ``قال`` (opener/عن follows closely) → skip.
+    for idx, (_start, end, label) in enumerate(phrases):
+        if label != "qala":
+            continue
+        nxt = phrases[idx + 1] if idx + 1 < len(phrases) else None
+        if (
+            nxt is not None
+            and nxt[2] in _LINK_LABELS
+            and (nxt[0] - end) <= _QALA_LINK_LOOKAHEAD_CHARS
+        ):
+            continue
+        candidates.append(_start)
+
+    # Standalone ``أن`` / ``أنه`` introducing the reported content.
+    candidates.extend(m.start() for m in _AN_BOUNDARY_RE.finditer(text))
+
+    # Matn punctuation.
+    for punct in _MATN_PUNCT:
+        pos = text.find(punct)
+        if pos != -1:
+            candidates.append(pos)
+
+    valid = [c for c in candidates if c >= min_boundary]
+    return min(valid) if valid else None
+
+
+def split_isnad_matn(text: str | None) -> SplitResult | None:
+    """Recover a matn-embedded isnad from *text*, or ``None`` (fail closed).
+
+    Steps: detect the convention (D), find a conservative isnad→matn boundary,
+    isolate the head, and segment ONLY that head with the shared fail-loud
+    :func:`extract_narrator_mentions`. Returns ``None`` — recovering nothing —
+    at any ambiguity: detector miss, unlocatable boundary, empty head,
+    unsegmentable head (a chain blob, da#158), or a head yielding no spans.
+    """
+    if not text or not text.strip():
+        return None
+
+    phrases = extract_transmission_phrases(text)
+    convention = detect_isnad(text, phrases)
+    if convention is None:
+        return None
+
+    boundary = _matn_boundary(text, phrases)
+    if boundary is None:
+        return None
+
+    isnad_ar = text[:boundary].strip()
+    matn_ar = text[boundary:].strip()
+    if not isnad_ar:
+        return None
+
+    try:
+        spans = extract_narrator_mentions(isnad_ar, "ar")
+    except IsnadSegmentationError:
+        # The isolated head carries a transmission marker but would not segment —
+        # a partial chain blob. Fail closed rather than mint a blob (da#158).
+        return None
+    if not spans:
+        return None
+
+    return SplitResult(
+        isnad_ar=isnad_ar,
+        matn_ar=matn_ar,
+        convention=convention,
+        spans=tuple(spans),
+    )

--- a/src/parse/sanadset.py
+++ b/src/parse/sanadset.py
@@ -71,6 +71,7 @@ from src.parse.base import (
 )
 from src.parse.collection_metadata import apply_collection_metadata
 from src.parse.identity import ID_DELIMITER
+from src.parse.isnad_matn_split import SplitResult, split_isnad_matn
 from src.parse.narrator_extraction import (
     IsnadSegmentationError,
     extract_narrator_mentions,
@@ -444,6 +445,46 @@ def _mentions_from_names(
     return mentions
 
 
+def _mentions_from_recovered_isnad(
+    split: SplitResult,
+    source_hadith_id: str,
+) -> list[dict[str, str | int | None]]:
+    """Build narrator mentions from a matn-embedded isnad recovery (da#366).
+
+    ``split.spans`` were segmented from the isolated isnad head by the shared
+    fail-loud :func:`extract_narrator_mentions` (raw text, no ``<NAR>`` tags).
+    Pollution is filtered by the SAME :func:`_is_narrator_like` gate the other
+    two paths apply (relational pronouns, honorifics, bare particles), so
+    recovered mentions carry the same quality bar. ``position_in_chain`` is
+    numbered over the *accepted* mentions so it stays gap-free; the span's
+    normalized name and transmission method follow the ``lk`` raw-Arabic-isnad
+    convention (``src/parse/lk_corpus.py``).
+    """
+    mentions: list[dict[str, str | int | None]] = []
+    position = 0
+    for span in split.spans:
+        if not _is_narrator_like(span.name):
+            continue
+        mention_id = generate_source_id(_SOURCE_CORPUS, "mention", source_hadith_id, str(position))
+        mentions.append(
+            {
+                "mention_id": mention_id,
+                "source_hadith_id": source_hadith_id,
+                "source_corpus": _SOURCE_CORPUS,
+                "position_in_chain": position,
+                # One sanad per hadith row → chain 0 (da#282); matches the other
+                # two mention paths.
+                "chain_index": 0,
+                "name_ar": span.name,
+                "name_en": None,
+                "name_ar_normalized": normalize_arabic(span.name),
+                "transmission_method": span.transmission_method,
+            }
+        )
+        position += 1
+    return mentions
+
+
 def _book_key(name_ar: str) -> str:
     """Stable, content-derived collection key for a Sanadset book *name* (da#353).
 
@@ -618,11 +659,21 @@ def _collection_row(
 def _process_chunk(
     rows: list[dict[str, object]],
     collection_name: str,
-) -> tuple[list[dict[str, object]], list[dict[str, str | int | None]], int, int, int, int]:
+) -> tuple[
+    list[dict[str, object]],
+    list[dict[str, str | int | None]],
+    int,
+    int,
+    int,
+    int,
+    int,
+    int,
+]:
     """Process a chunk of rows.
 
     Returns ``(hadiths, mentions, malformed_count, raw_nar_count,
-    recovered_sanad_count, column_mention_count)``. ``raw_nar_count`` is the number
+    recovered_sanad_count, column_mention_count, recovered_embedded_count,
+    embedded_mention_count)``. ``raw_nar_count`` is the number
     of raw ``<NAR>`` tags seen before B3 re-segmentation / filtering; comparing it
     to the *tag-derived* mention count quantifies how much coarse-tag pollution the
     B3 filter removed (da#221). ``recovered_sanad_count`` is the number of rows
@@ -630,6 +681,10 @@ def _process_chunk(
     ``<SANAD>`` markup was empty/orphaned (da#368); ``column_mention_count`` is the
     mentions those rows contributed (kept separate so the B3 firehose metric, which
     is about ``<NAR>`` tags only, is not skewed by the tag-free column path).
+    ``recovered_embedded_count`` is the number of "No SANAD" rows whose isnad was
+    recovered from the matn text by the da#366 two-convention splitter, and
+    ``embedded_mention_count`` the mentions they contributed — also tag-free, so
+    likewise excluded from the firehose metric.
 
     Source columns are resolved case-insensitively (da#353): the production
     Sanadset header is ``Hadith,Book,Num_hadith,Matn,Sanad,Sanad_Length``, and the
@@ -648,6 +703,8 @@ def _process_chunk(
     raw_nar_count = 0
     recovered_sanad_count = 0
     column_mention_count = 0
+    recovered_embedded_count = 0
+    embedded_mention_count = 0
     if not rows:
         return (
             hadiths,
@@ -656,6 +713,8 @@ def _process_chunk(
             raw_nar_count,
             recovered_sanad_count,
             column_mention_count,
+            recovered_embedded_count,
+            embedded_mention_count,
         )
 
     # Resolve the source columns ONCE per chunk (all rows share one header).
@@ -758,6 +817,7 @@ def _process_chunk(
         # usable ``Sanad`` value (the 159,558 "No SANAD" rows, #366) stays null.
         isnad_raw_ar: str | None = None
         column_names: list[str] | None = None
+        split_result: SplitResult | None = None
         if sanad_text and sanad_text.lower() != "no sanad":
             isnad_raw_ar = sanad_text
         else:
@@ -777,6 +837,20 @@ def _process_chunk(
                         "sanad_recovered_from_column_orphaned_markup",
                         source_id=source_id,
                     )
+            elif matn_text:
+                # No usable tag and no usable ``Sanad`` column — a "No SANAD" row
+                # (#366). ~122,000 of these carry an isnad embedded in the matn.
+                # Recover it with the two-convention splitter, which fails closed
+                # rather than mine the whole body (the da#369 NER fallback that
+                # mints matn sentences as narrators is deliberately NOT used). On
+                # recovery, ``isnad_raw_ar`` becomes the isolated head and
+                # ``matn_text`` the residual body, so the isnad text is not left
+                # duplicated in ``matn_ar``.
+                split_result = split_isnad_matn(matn_text)
+                if split_result is not None:
+                    isnad_raw_ar = split_result.isnad_ar
+                    matn_text = split_result.matn_ar or None
+                    recovered_embedded_count += 1
 
         hadiths.append(
             {
@@ -803,12 +877,17 @@ def _process_chunk(
         )
 
         # Extract narrator mentions. A column-recovered chain (da#368) is already
-        # segmented, so build mentions directly from the names; otherwise parse the
-        # ``<NAR>`` tags out of the tag-derived isnad.
+        # segmented, so build mentions directly from the names; a matn-embedded
+        # recovery (da#366) is raw text already segmented by the splitter; a
+        # tag-derived isnad still carries ``<NAR>`` tags to parse.
         if column_names is not None:
             row_mentions = _mentions_from_names(column_names, source_id)
             mentions.extend(row_mentions)
             column_mention_count += len(row_mentions)
+        elif split_result is not None:
+            row_mentions = _mentions_from_recovered_isnad(split_result, source_id)
+            mentions.extend(row_mentions)
+            embedded_mention_count += len(row_mentions)
         elif isnad_raw_ar:
             raw_nar_count += len(_NAR_RE.findall(isnad_raw_ar))
             try:
@@ -825,6 +904,8 @@ def _process_chunk(
         raw_nar_count,
         recovered_sanad_count,
         column_mention_count,
+        recovered_embedded_count,
+        embedded_mention_count,
     )
 
 
@@ -986,6 +1067,8 @@ def parse_sanadset(
     total_raw_nar = 0
     total_recovered_sanad = 0
     total_column_mentions = 0
+    total_recovered_embedded = 0
+    total_embedded_mentions = 0
     total_rows = 0
 
     for csv_file in csv_files:
@@ -1003,11 +1086,18 @@ def parse_sanadset(
 
         for chunk_start in range(0, len(rows), _CHUNK_SIZE):
             chunk = rows[chunk_start : chunk_start + _CHUNK_SIZE]
-            hadiths, mentions, malformed, raw_nar, recovered_sanad, column_mentions = (
-                _process_chunk(
-                    chunk,
-                    collection_name,
-                )
+            (
+                hadiths,
+                mentions,
+                malformed,
+                raw_nar,
+                recovered_sanad,
+                column_mentions,
+                recovered_embedded,
+                embedded_mentions,
+            ) = _process_chunk(
+                chunk,
+                collection_name,
             )
             all_hadiths.extend(hadiths)
             all_mentions.extend(mentions)
@@ -1015,6 +1105,8 @@ def parse_sanadset(
             total_raw_nar += raw_nar
             total_recovered_sanad += recovered_sanad
             total_column_mentions += column_mentions
+            total_recovered_embedded += recovered_embedded
+            total_embedded_mentions += embedded_mentions
 
             logger.info(
                 "chunk_processed",
@@ -1030,9 +1122,10 @@ def parse_sanadset(
     avg_narrators = len(all_mentions) / valid_sanad_count if valid_sanad_count > 0 else 0
     # B3 (da#221) observability: how much coarse-tag pollution the re-segmentation
     # filter removed. total_raw_nar counts raw <NAR> tags; the *tag-derived* mention
-    # count is the clean post-filter total. Column-recovered mentions (da#368) carry
-    # no <NAR> tags, so they are excluded here or the firehose drop would read low.
-    tag_mentions = len(all_mentions) - total_column_mentions
+    # count is the clean post-filter total. Column-recovered (da#368) and
+    # matn-embedded-recovered (da#366) mentions carry no <NAR> tags, so both are
+    # excluded here or the firehose drop would read low.
+    tag_mentions = len(all_mentions) - total_column_mentions - total_embedded_mentions
     filtered_nar = total_raw_nar - tag_mentions
     filtered_nar_pct = (filtered_nar / total_raw_nar * 100) if total_raw_nar else 0
 
@@ -1052,6 +1145,12 @@ def parse_sanadset(
         # contributed. Expected ~6,143 recovered on the full corpus.
         recovered_sanad_from_column=total_recovered_sanad,
         column_mentions=total_column_mentions,
+        # da#366: "No SANAD" rows whose isnad was recovered from the matn text by
+        # the two-convention splitter, and the mentions they contributed. Expected
+        # ~122,000 recovered on the full corpus (a lower bound — the splitter fails
+        # closed on ambiguous boundaries rather than pollute the narrator index).
+        recovered_isnad_from_matn=total_recovered_embedded,
+        embedded_mentions=total_embedded_mentions,
     )
 
     # Write hadith Parquet

--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -173,6 +173,7 @@ RESOLVE_STEP_ORDER = (
     "contextual_disambiguation",
     "reconcile",
     "tabaqa_dates",
+    "narrator_unify",
     "over_merged_flag",
     "muhaddithat_links",
     "dedup",
@@ -474,6 +475,7 @@ def run_all(
         fuzzy_cluster,
         muhaddithat_links,
         narrator_split,
+        narrator_unify,
         ner,
         over_merged_flag,
         parallels,
@@ -759,6 +761,39 @@ def run_all(
     else:
         outcomes["tabaqa_dates"] = StageSkipped("tabaqa_dates", "precomputed")
         logger.info("resolve_step_skipped_precomputed", step="tabaqa_dates")
+
+    # Step 3.66: Curated under-merge unification (da#431 / da#347) — the merge mirror of
+    # narrator_split. Where fuzzy_cluster's precision guard structurally cannot bridge two
+    # references to ONE person that share too few significant tokens (kunya↔ism, bare
+    # ism↔qualified), this stage merges a hand-verified, corroboration-gated curated set
+    # (narrator_unify.yaml) onto one survivor and remaps the absorbed mentions — reusing
+    # fuzzy_cluster's own _merge_cluster/_remap. Runs after tabaqa_dates so the survivor
+    # inherits final dates + mention_count, and BEFORE over_merged_flag so that stage stays
+    # the last writer of narrators_canonical.parquet. Every group is behind the da#423
+    # bidirectional acceptance fixture; a refused group is logged, never merged. A no-op
+    # (None) when the seed matches < 2 distinct nodes per group (already unified).
+    if _do("narrator_unify"):
+        try:
+            logger.info("resolve_step", step="narrator_unify", status="running")
+            unified = narrator_unify.apply_narrator_unification(output_dir)
+            unify_files = [unified] if unified is not None else []
+            outcomes["narrator_unify"] = StageRan("narrator_unify", unify_files)
+            logger.info(
+                "resolve_step",
+                step="narrator_unify",
+                status="complete",
+                files=len(unify_files),
+            )
+        except Exception as exc:  # noqa: BLE001
+            outcomes["narrator_unify"] = StageErrored(
+                "narrator_unify", type(exc).__name__, traceback.format_exc()
+            )
+            logger.error(
+                "resolve_step_failed", step="narrator_unify", traceback=traceback.format_exc()
+            )
+    else:
+        outcomes["narrator_unify"] = StageSkipped("narrator_unify", "precomputed")
+        logger.info("resolve_step_skipped_precomputed", step="narrator_unify")
 
     # Step 3.67: Over-merged bare-generic flag (da#445 / #337 flag-now). The LAST writer
     # of narrators_canonical.parquet: after every date stage has finalized the canonical

--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -170,6 +170,7 @@ RESOLVE_STEP_ORDER = (
     "bio_promote",
     "cluster",
     "narrator_split",
+    "contextual_disambiguation",
     "reconcile",
     "tabaqa_dates",
     "over_merged_flag",
@@ -466,6 +467,7 @@ def run_all(
 
     from src.resolve import (
         bio_promote,
+        contextual_disambiguation,
         date_reconcile,
         dedup,
         disambiguate,
@@ -657,6 +659,47 @@ def run_all(
     else:
         outcomes["narrator_split"] = StageSkipped("narrator_split", "precomputed")
         logger.info("resolve_step_skipped_precomputed", step="narrator_split")
+
+    # Step 3.57: Contextual (isnad-neighbour) disambiguation (da#346). The date-axis
+    # narrator_split abstains on a BARE name (no attested death-band to cut), but the
+    # isnad POSITION still identifies a referent: a bare ʿAbd Allāh narrating ⟵Prophet
+    # ⟶Nāfiʿ is Ibn ʿUmar. For each curated, hand-verified neighbour-pair signature,
+    # peel the matching mentions onto a distinct discriminated node; leave every unknown
+    # or ambiguous mention on the bare primary (which over_merged_flag keeps flagged) and
+    # to da#443's external-rijāl split. Runs AFTER narrator_split (operates on the settled
+    # canonical set) and BEFORE reconcile/tabaqa_dates/over_merged_flag so the peeled ids
+    # + remapped mentions flow through the date stages and the residual flag counts the
+    # reduced primary. Empty seed ⇒ pure no-op. Idempotent (peeled ids no longer carry the
+    # bare name; the residual still matches no signature). Emits contextual_splits.parquet
+    # (audit) + contextual_coverage.parquet (the da#346 blast-radius report).
+    if _do("contextual_disambiguation"):
+        try:
+            logger.info("resolve_step", step="contextual_disambiguation", status="running")
+            ctx_path = contextual_disambiguation.apply_contextual_disambiguation(
+                output_dir, staging_dir=staging_dir
+            )
+            ctx_files = [ctx_path] if ctx_path is not None else []
+            outcomes["contextual_disambiguation"] = StageRan("contextual_disambiguation", ctx_files)
+            logger.info(
+                "resolve_step",
+                step="contextual_disambiguation",
+                status="complete",
+                files=len(ctx_files),
+            )
+        except Exception as exc:  # noqa: BLE001
+            outcomes["contextual_disambiguation"] = StageErrored(
+                "contextual_disambiguation", type(exc).__name__, traceback.format_exc()
+            )
+            logger.error(
+                "resolve_step_failed",
+                step="contextual_disambiguation",
+                traceback=traceback.format_exc(),
+            )
+    else:
+        outcomes["contextual_disambiguation"] = StageSkipped(
+            "contextual_disambiguation", "precomputed"
+        )
+        logger.info("resolve_step_skipped_precomputed", step="contextual_disambiguation")
 
     # Step 3.6: Multi-source date reconciliation (da#165). After bio_promote and
     # cluster have built the final canonical set, fold each narrator's per-source

--- a/src/resolve/contextual_disambiguation.py
+++ b/src/resolve/contextual_disambiguation.py
@@ -51,10 +51,12 @@ Algorithm (per curated signature ``S`` on bare name ``N``)
 ----------------------------------------------------------
 1. Resolve ``N`` to its canonical id ``C = make_canonical_id(N)`` and gather every
    mention with ``canonical_narrator_id == C``.
-2. For each such mention, read its ±1 chain neighbours **within the same
-   ``(hadith_id, chain_index)`` chain** (:func:`src.resolve.narrator_split._build_chain_index`,
-   da#411 — never a cross-chain neighbour) and map them to their normalized names: the
-   set of teacher names (position −1) and student names (position +1).
+2. For each such mention, read its **consecutive-resolved** teacher/student neighbours
+   within the same ``(hadith_id, chain_index)`` chain — the SHARED adjacency helper
+   :func:`src.resolve.narrator_split.resolved_chain_neighbours` (da#439), identical to
+   the loader's ``TRANSMITTED_TO`` adjacency and the date-band splitter's, so a gappy
+   isnad cannot silently erase a discriminating pair (da#411 — never a cross-chain
+   neighbour) — and map them to their normalized names.
 3. A signature *matches* a mention iff every neighbour role it constrains is satisfied —
    its ``teacher_ar`` (if given) is among the mention's teacher names AND its
    ``student_ar`` (if given) among the student names. A mention matched by exactly one
@@ -100,7 +102,11 @@ import yaml
 from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
 from src.resolve._run_record import write_canonical
 from src.resolve.attestation import derive_attestation
-from src.resolve.narrator_split import _build_chain_index, _remap_split_mentions
+from src.resolve.narrator_split import (
+    _build_chain_index,
+    _remap_split_mentions,
+    resolved_chain_neighbours,
+)
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
@@ -280,26 +286,28 @@ def _neighbour_names_by_mention(
     chains: dict[tuple[str, int], list[tuple[int, str]]],
     name_by_id: dict[str, str],
 ) -> dict[str, tuple[frozenset[str], frozenset[str]]]:
-    """``mention_id -> (teacher_names, student_names)`` from ±1 in-chain neighbours.
+    """``mention_id -> (teacher_names, student_names)`` from the consecutive-resolved neighbours.
 
-    A neighbour is only ever the ±1 position **within the same ``(hadith_id, chain_index)``
-    chain** (da#411), mirroring the graph loaders' composite chain key. Names are the
-    normalized ``name_ar_normalized`` of the neighbour canonical ids.
+    Uses the **shared** isnad-adjacency helper
+    (:func:`src.resolve.narrator_split.resolved_chain_neighbours`, da#439) so this stage's
+    notion of teacher/student is byte-identical to the date-band splitter's and to the
+    loader's ``TRANSMITTED_TO`` adjacency — the immediately-preceding / -following
+    **resolved** mention in the position-sorted ``(hadith_id, chain_index)`` chain (a
+    dropped-position gap bridged as the loader bridges it; self-loop dropped, not bridged
+    past; never a cross-isnad neighbour, da#411). Reading exact ``position ± 1`` here (the
+    pre-da#439 form) would have silently erased a golden-chain teacher/student pair on any
+    gappy isnad — under-peeling a confident identity. Names are the neighbour ids'
+    ``name_ar_normalized``; each role is a singleton or empty set.
     """
     out: dict[str, tuple[frozenset[str], frozenset[str]]] = {}
     for hadith_id, chain_index, position, mention_id in mentions:
-        teachers: set[str] = set()
-        students: set[str] = set()
-        for npos, nid in chains.get((hadith_id, chain_index), ()):
-            if npos == position - 1:
-                name = name_by_id.get(nid)
-                if name:
-                    teachers.add(name)
-            elif npos == position + 1:
-                name = name_by_id.get(nid)
-                if name:
-                    students.add(name)
-        out[mention_id] = (frozenset(teachers), frozenset(students))
+        teacher_id, student_id = resolved_chain_neighbours(chains, hadith_id, chain_index, position)
+        teacher_name = name_by_id.get(teacher_id) if teacher_id else None
+        student_name = name_by_id.get(student_id) if student_id else None
+        out[mention_id] = (
+            frozenset({teacher_name} if teacher_name else ()),
+            frozenset({student_name} if student_name else ()),
+        )
     return out
 
 

--- a/src/resolve/contextual_disambiguation.py
+++ b/src/resolve/contextual_disambiguation.py
@@ -1,0 +1,548 @@
+"""Peel confidently-identifiable mentions off an over-merged bare name by isnad context (da#346).
+
+The problem this addresses (why ``narrator_split`` could not)
+-------------------------------------------------------------
+The bare ism ``عبد الله`` collapses ~19k mentions of *many* historically-distinct ʿAbd
+Allāhs (Ibn ʿUmar, Ibn ʿAbbās, Ibn Masʿūd, …) onto one ``nar:`` node — the classic
+over-merge that inflates betweenness (da#346). The date-axis splitter
+(:mod:`src.resolve.narrator_split`) **correctly abstains** here: a bare mention carries
+no *attested* death-year neighbour band to discriminate on, so there is nothing for the
+death-band evidence gate to cut (Gate 1, single band ⇒ abstain). The #337 spike proved
+that forcing a date-band split of such a node is both infeasible (the chimera does not
+separate) and unsafe (it false-splits genuine hubs — al-Zuhrī peeled into five fabricated
+impossible-date nodes). That negative result is why #337 was resolved *flag-now*
+(:mod:`src.resolve.over_merged_flag`) and a true node-identity split deferred to external
+rijāl evidence (da#443).
+
+The corpus-internal lever that *is* available
+----------------------------------------------
+The **isnad position** — who a mention transmits *from* (teacher, position −1) and *to*
+(student, position +1) in its own chain — is a discriminating signal even when the name
+string is bare. An ʿAbd Allāh who narrates ⟵ the Prophet and ⟶ Nāfiʿ is ʿAbd Allāh ibn
+ʿUmar, not any other ʿAbd Allāh. This stage peels *those* mentions — the ones whose ±1
+neighbour pair matches a **hand-verified, high-confidence signature** — onto a distinct
+discriminated canonical node, and leaves every unmatched mention on the bare primary
+(which :mod:`over_merged_flag` keeps flagged). It never guesses.
+
+Why a curated signature seed and not a threshold (the da#423 discipline)
+-----------------------------------------------------------------------
+There is **no corpus-internal threshold** that separates the referents of a bare name
+(the #337 §0 negative result): a purely statistical auto-split re-commits the silent-zero
+error, false-splitting a genuine transmitter. So — exactly like the ``over_merged``
+flag's curated list — the peel is driven by a **hand-verified signature seed**
+(:data:`_SEED_PATH`) under a **bidirectional acceptance fixture**
+(``tests/test_resolve/test_contextual_disambiguation.py``): a signature MUST fire on the
+genuine multi-referent mentions it names AND MUST NOT fire on a genuine single narrator
+whose neighbours do not match it. A mention whose neighbour pair matches *no* signature —
+or *more than one* (ambiguous) — is never peeled; it stays on the flagged primary and its
+true identity is deferred to the external-rijāl work (da#443). The seed may be empty: then
+this stage is a pure no-op, and the whole node remains flagged — the safe default.
+
+What this stage does NOT do
+---------------------------
+It mints **no** speculative date-split nodes (that is the abstaining
+:mod:`narrator_split`'s job, and it abstains here). It invents **no** identity for a bare
+mention that lacks a corpus-internal discriminating neighbour pair — that residual is the
+``over_merged`` flag's to disclose and da#443's to resolve with external evidence. The
+peel is confined to mentions that carry, *in the isnad itself*, a neighbour pair a human
+has verified is uniquely identifying.
+
+Algorithm (per curated signature ``S`` on bare name ``N``)
+----------------------------------------------------------
+1. Resolve ``N`` to its canonical id ``C = make_canonical_id(N)`` and gather every
+   mention with ``canonical_narrator_id == C``.
+2. For each such mention, read its ±1 chain neighbours **within the same
+   ``(hadith_id, chain_index)`` chain** (:func:`src.resolve.narrator_split._build_chain_index`,
+   da#411 — never a cross-chain neighbour) and map them to their normalized names: the
+   set of teacher names (position −1) and student names (position +1).
+3. A signature *matches* a mention iff every neighbour role it constrains is satisfied —
+   its ``teacher_ar`` (if given) is among the mention's teacher names AND its
+   ``student_ar`` (if given) among the student names. A mention matched by exactly one
+   signature peels to that signature's target; a mention matched by zero or by ≥2
+   signatures is **left on the primary** (the conservative residual).
+4. The target node id is ``make_discriminated_canonical_id(N, S.discriminator)`` — a
+   distinct ``nar:`` id sharing the bare display name (mirroring ``narrator_split``'s
+   peeled rows), carrying ``S.name_en`` + ``S.note`` as its disambiguation provenance.
+
+Outputs (mirroring ``narrator_split``)
+---------------------------------------
+* ``narrators_canonical.parquet`` rewritten with the peeled target rows appended (each
+  primary's ``mention_count`` reduced by its peeled total, attestation re-derived).
+* ``narrator_mentions_resolved.parquet`` — the peeled mentions' ``canonical_narrator_id``
+  remapped, keyed on ``mention_id`` (a split sends *different* mentions of one id to
+  *different* targets), streaming/idempotent, reusing
+  :func:`src.resolve.narrator_split._remap_split_mentions`.
+* ``contextual_splits.parquet`` — one row per peeled target (bare name, new id,
+  discriminator, matched signature, mention_count): the owner's review artifact.
+* ``contextual_coverage.parquet`` — the **blast-radius** report (da#346 acceptance): per
+  curated bare name, how many of its mentions have a resolvable neighbour pair and how
+  many matched a signature. The real corpus number is produced when this stage runs
+  against the staged artifact; :func:`neighbour_pair_coverage` computes it deterministically.
+
+Idempotence
+-----------
+A second run re-reads the already-peeled table. Peeled target ids no longer carry the
+bare name ``N``, so they are not re-gathered under ``C``; the residual on ``C`` matched no
+signature the first time and still matches none. No file is rewritten; the stage returns
+``None``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
+from src.resolve._run_record import write_canonical
+from src.resolve.attestation import derive_attestation
+from src.resolve.narrator_split import _build_chain_index, _remap_split_mentions
+from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+from src.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = get_logger(__name__)
+
+# The curated signature seed ships beside this module.
+_SEED_PATH = Path(__file__).with_name("contextual_signatures.yaml")
+
+__all__ = [
+    "CONTEXTUAL_SPLITS_SCHEMA",
+    "CONTEXTUAL_COVERAGE_SCHEMA",
+    "ContextualSignature",
+    "NameCoverage",
+    "load_contextual_signatures",
+    "match_signature",
+    "neighbour_pair_coverage",
+    "apply_contextual_disambiguation",
+]
+
+
+# Audit report: one row per peeled (contextually-disambiguated) target node.
+CONTEXTUAL_SPLITS_SCHEMA = pa.schema(
+    [
+        pa.field("name_ar_normalized", pa.string(), nullable=False),
+        pa.field("primary_id", pa.string(), nullable=False),
+        pa.field("new_id", pa.string(), nullable=False),
+        pa.field("discriminator", pa.string(), nullable=False),
+        pa.field("target_name_en", pa.string(), nullable=True),
+        pa.field("teacher_ar", pa.string(), nullable=True),
+        pa.field("student_ar", pa.string(), nullable=True),
+        pa.field("mention_count", pa.int32(), nullable=False),
+    ]
+)
+
+# Blast-radius report (da#346 acceptance): one row per curated bare name.
+CONTEXTUAL_COVERAGE_SCHEMA = pa.schema(
+    [
+        pa.field("name_ar_normalized", pa.string(), nullable=False),
+        pa.field("primary_id", pa.string(), nullable=False),
+        pa.field("total_mentions", pa.int32(), nullable=False),
+        pa.field("with_any_neighbour", pa.int32(), nullable=False),
+        pa.field("with_teacher", pa.int32(), nullable=False),
+        pa.field("with_student", pa.int32(), nullable=False),
+        pa.field("signature_matched", pa.int32(), nullable=False),
+        pa.field("ambiguous_multimatch", pa.int32(), nullable=False),
+    ]
+)
+
+
+@dataclass(frozen=True)
+class ContextualSignature:
+    """One hand-verified isnad-neighbour signature identifying a referent of a bare name.
+
+    ``name_ar`` is the bare over-merged name whose mentions this signature peels;
+    ``teacher_ar`` / ``student_ar`` are the discriminating ±1 neighbour names (at least
+    one required — a signature that constrains neither would match everything). A mention
+    matches iff EVERY specified role is satisfied. ``discriminator`` folds into
+    :func:`make_discriminated_canonical_id` to mint the target's distinct id; ``name_en``
+    and ``note`` carry the (hand-verified) disambiguation provenance onto the target row.
+    """
+
+    name_ar: str
+    teacher_ar: str | None
+    student_ar: str | None
+    discriminator: str
+    name_en: str | None
+    note: str
+
+    def primary_id(self) -> str:
+        """The bare canonical id whose mentions this signature peels from."""
+        return make_canonical_id(normalize_arabic(self.name_ar))
+
+    def target_id(self) -> str:
+        """The distinct discriminated id a matched mention peels onto."""
+        return make_discriminated_canonical_id(normalize_arabic(self.name_ar), self.discriminator)
+
+    def teacher_norm(self) -> str | None:
+        return normalize_arabic(self.teacher_ar) if self.teacher_ar else None
+
+    def student_norm(self) -> str | None:
+        return normalize_arabic(self.student_ar) if self.student_ar else None
+
+    def matches(self, teacher_names: frozenset[str], student_names: frozenset[str]) -> bool:
+        """True iff every neighbour role this signature constrains is present in the mention.
+
+        A constrained role that the mention lacks fails the match; an unconstrained role
+        (``None``) is ignored. Because at least one role is always constrained (validated
+        at load), an all-``None`` signature can never be constructed, so ``matches`` never
+        returns ``True`` on an empty neighbour context.
+        """
+        t, s = self.teacher_norm(), self.student_norm()
+        if t is not None and t not in teacher_names:
+            return False
+        return not (s is not None and s not in student_names)
+
+
+@dataclass(frozen=True)
+class NameCoverage:
+    """Blast-radius tally for one bare name's mentions (da#346 acceptance)."""
+
+    name_ar_normalized: str
+    primary_id: str
+    total_mentions: int
+    with_any_neighbour: int
+    with_teacher: int
+    with_student: int
+    signature_matched: int
+    ambiguous_multimatch: int
+
+
+def load_contextual_signatures(path: Path = _SEED_PATH) -> tuple[ContextualSignature, ...]:
+    """Parse the curated ``contextual_signatures.yaml`` seed (empty when absent).
+
+    Raises ``ValueError`` on a malformed entry — a signature that constrains neither a
+    teacher nor a student would match every mention of the bare name and mass-mislabel it,
+    exactly the silent-defect this hand-verified list exists to prevent, so it is a hard
+    error, never a silently-dropped row.
+    """
+    if not path.exists():
+        return ()
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    rows = raw.get("signatures", []) if isinstance(raw, dict) else raw
+    sigs: list[ContextualSignature] = []
+    for row in rows:
+        name_ar = row.get("name_ar")
+        teacher_ar = row.get("teacher_ar")
+        student_ar = row.get("student_ar")
+        discriminator = row.get("discriminator")
+        note = row.get("note")
+        if not name_ar:
+            raise ValueError("contextual signature entry needs a name_ar")
+        if not teacher_ar and not student_ar:
+            raise ValueError(
+                f"contextual signature for {name_ar!r} needs a teacher_ar and/or student_ar "
+                "(an unconstrained signature would match every mention)"
+            )
+        if not discriminator:
+            raise ValueError(f"contextual signature for {name_ar!r} is missing its discriminator")
+        if not note:
+            raise ValueError(f"contextual signature for {name_ar!r} is missing its note")
+        sigs.append(
+            ContextualSignature(
+                name_ar=name_ar,
+                teacher_ar=teacher_ar,
+                student_ar=student_ar,
+                discriminator=discriminator,
+                name_en=row.get("name_en"),
+                note=note,
+            )
+        )
+    return tuple(sigs)
+
+
+def match_signature(
+    teacher_names: frozenset[str],
+    student_names: frozenset[str],
+    signatures: Iterable[ContextualSignature],
+) -> ContextualSignature | None:
+    """The single signature that confidently matches this neighbour context, else ``None``.
+
+    Zero matches (unknown context) OR ≥2 matches (ambiguous — the pair is consistent with
+    more than one curated referent) both return ``None``: the mention is left on the bare
+    primary. Only an unambiguous single match peels. This is the over-split guard — a
+    mention is disambiguated only when the corpus-internal evidence points to exactly one
+    hand-verified referent.
+    """
+    matched = [s for s in signatures if s.matches(teacher_names, student_names)]
+    return matched[0] if len(matched) == 1 else None
+
+
+def _neighbour_names_by_mention(
+    mentions: list[tuple[str, int, int, str]],
+    chains: dict[tuple[str, int], list[tuple[int, str]]],
+    name_by_id: dict[str, str],
+) -> dict[str, tuple[frozenset[str], frozenset[str]]]:
+    """``mention_id -> (teacher_names, student_names)`` from ±1 in-chain neighbours.
+
+    A neighbour is only ever the ±1 position **within the same ``(hadith_id, chain_index)``
+    chain** (da#411), mirroring the graph loaders' composite chain key. Names are the
+    normalized ``name_ar_normalized`` of the neighbour canonical ids.
+    """
+    out: dict[str, tuple[frozenset[str], frozenset[str]]] = {}
+    for hadith_id, chain_index, position, mention_id in mentions:
+        teachers: set[str] = set()
+        students: set[str] = set()
+        for npos, nid in chains.get((hadith_id, chain_index), ()):
+            if npos == position - 1:
+                name = name_by_id.get(nid)
+                if name:
+                    teachers.add(name)
+            elif npos == position + 1:
+                name = name_by_id.get(nid)
+                if name:
+                    students.add(name)
+        out[mention_id] = (frozenset(teachers), frozenset(students))
+    return out
+
+
+def neighbour_pair_coverage(
+    name_ar_normalized: str,
+    primary_id: str,
+    neighbours_by_mention: dict[str, tuple[frozenset[str], frozenset[str]]],
+    signatures: Iterable[ContextualSignature],
+) -> NameCoverage:
+    """Blast-radius tally for one bare name (da#346 acceptance), pure + deterministic.
+
+    Counts, over the name's mentions: how many have any resolvable neighbour, a teacher, a
+    student, an unambiguous signature match, and an ambiguous ≥2-signature match. The
+    corpus-scale numbers are produced when the stage runs against the staged artifact; this
+    function is what computes them and is unit-tested on fixtures.
+    """
+    sigs = tuple(signatures)
+    total = len(neighbours_by_mention)
+    any_n = teach = stud = matched = ambiguous = 0
+    for teachers, students in neighbours_by_mention.values():
+        if teachers or students:
+            any_n += 1
+        if teachers:
+            teach += 1
+        if students:
+            stud += 1
+        hits = [s for s in sigs if s.matches(teachers, students)]
+        if len(hits) == 1:
+            matched += 1
+        elif len(hits) >= 2:
+            ambiguous += 1
+    return NameCoverage(
+        name_ar_normalized=name_ar_normalized,
+        primary_id=primary_id,
+        total_mentions=total,
+        with_any_neighbour=any_n,
+        with_teacher=teach,
+        with_student=stud,
+        signature_matched=matched,
+        ambiguous_multimatch=ambiguous,
+    )
+
+
+def _as_int(value: Any) -> int:
+    """Best-effort non-negative int for a mention_count cell (None/non-numeric → 0)."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    return 0
+
+
+def _target_record(
+    primary_rec: dict[str, Any], sig: ContextualSignature, count: int
+) -> dict[str, Any]:
+    """A new canonical row for a contextually-disambiguated target node.
+
+    Inherits the shared name/provenance fields from the bare primary (the display name
+    stays the bare ``name_ar`` — we peel identity, not the string a mention shows),
+    carries ``sig.name_en`` + ``sig.note`` as the disambiguation provenance, and its
+    attestation is re-derived from the peeled count (the mentions are real isnad edges).
+    Dates stay unknown — this stage asserts identity from context, never a death year.
+    """
+    rec: dict[str, Any] = dict.fromkeys(f.name for f in NARRATORS_CANONICAL_SCHEMA)
+    for col in (
+        "name_ar",
+        "name_ar_normalized",
+        "aliases",
+        "gender",
+        "trustworthiness",
+        "source_ids",
+        "source_corpus",
+        "source_corpora",
+        "sect_affiliation",
+    ):
+        rec[col] = primary_rec.get(col)
+    rec["canonical_id"] = sig.target_id()
+    if sig.name_en:
+        rec["name_en"] = sig.name_en
+    rec["mention_count"] = count
+    rec["attestation"] = derive_attestation(count)
+    rec["over_merged"] = False
+    rec["over_merge_note"] = None
+    return rec
+
+
+def apply_contextual_disambiguation(
+    output_dir: Path, *, seed_path: Path = _SEED_PATH, staging_dir: Path | None = None
+) -> Path | None:
+    """Peel confidently-identifiable mentions off curated over-merged bare names (da#346).
+
+    Reads ``narrators_canonical.parquet`` + ``narrator_mentions_resolved.parquet`` from
+    ``output_dir``. For every curated signature, gathers its bare name's mentions, matches
+    each mention's ±1 neighbour pair against the signatures, and remaps unambiguously-matched
+    mentions onto discriminated target nodes (appending target rows, reducing the primary's
+    count). Always writes ``contextual_coverage.parquet`` (the blast-radius report) when
+    there is a canonical table and ≥1 signature.
+
+    Returns the canonical path when at least one mention peeled (files rewritten), else
+    ``None`` (no signatures, missing inputs, empty table, or every mention was
+    unknown/ambiguous — including every idempotent re-run). ``staging_dir`` is accepted for
+    run_all call-shape parity; this stage keeps no checkpoint.
+    """
+    canonical_path = output_dir / "narrators_canonical.parquet"
+    mentions_path = output_dir / "narrator_mentions_resolved.parquet"
+    if not canonical_path.exists():
+        logger.warning("contextual_disambiguation_no_canonical", path=str(canonical_path))
+        return None
+
+    signatures = load_contextual_signatures(seed_path)
+    if not signatures:
+        logger.info("contextual_disambiguation_no_signatures")
+        return None
+    if not mentions_path.exists():
+        logger.warning("contextual_disambiguation_no_mentions", path=str(mentions_path))
+        return None
+
+    records: list[dict[str, Any]] = pq.read_table(canonical_path).to_pylist()
+    if not records:
+        return None
+
+    name_by_id: dict[str, str] = {}
+    record_by_id: dict[str, dict[str, Any]] = {}
+    for rec in records:
+        cid = rec.get("canonical_id")
+        if not cid:
+            continue
+        record_by_id[cid] = rec
+        name_norm = rec.get("name_ar_normalized")
+        if name_norm:
+            name_by_id[cid] = name_norm
+
+    # Group signatures by the bare primary id they peel from. A primary present in no
+    # canonical row is a stale seed entry — logged, never invented (over_merged_flag rule).
+    sigs_by_primary: dict[str, list[ContextualSignature]] = {}
+    for sig in signatures:
+        sigs_by_primary.setdefault(sig.primary_id(), []).append(sig)
+    absent = sorted(pid for pid in sigs_by_primary if pid not in record_by_id)
+    if absent:
+        logger.warning("contextual_disambiguation_seed_absent", unmatched=absent, count=len(absent))
+
+    candidate_ids = {pid for pid in sigs_by_primary if pid in record_by_id}
+    if not candidate_ids:
+        logger.info("contextual_disambiguation_no_present_primaries", seed=len(signatures))
+        return None
+
+    chains, candidate_mentions = _build_chain_index(mentions_path, candidate_ids)
+
+    remap: dict[str, str] = {}
+    target_counts: dict[str, int] = {}
+    target_sig: dict[str, ContextualSignature] = {}
+    coverage_rows: list[dict[str, Any]] = []
+    for pid in sorted(candidate_ids):
+        name_norm = name_by_id.get(pid, "")
+        sigs = sigs_by_primary[pid]
+        neighbours = _neighbour_names_by_mention(
+            candidate_mentions.get(pid, []), chains, name_by_id
+        )
+        for mention_id, (teachers, students) in neighbours.items():
+            match = match_signature(teachers, students, sigs)
+            if match is not None:
+                tid = match.target_id()
+                remap[mention_id] = tid
+                target_counts[tid] = target_counts.get(tid, 0) + 1
+                target_sig[tid] = match
+        cov = neighbour_pair_coverage(name_norm, pid, neighbours, sigs)
+        coverage_rows.append(
+            {
+                "name_ar_normalized": cov.name_ar_normalized,
+                "primary_id": cov.primary_id,
+                "total_mentions": cov.total_mentions,
+                "with_any_neighbour": cov.with_any_neighbour,
+                "with_teacher": cov.with_teacher,
+                "with_student": cov.with_student,
+                "signature_matched": cov.signature_matched,
+                "ambiguous_multimatch": cov.ambiguous_multimatch,
+            }
+        )
+
+    # Always emit the blast-radius report (da#346 acceptance) — even a zero-peel run
+    # discloses the coverage so the residual-flag decision is auditable.
+    coverage_path = output_dir / "contextual_coverage.parquet"
+    cov_arrays = {
+        f.name: [r.get(f.name) for r in coverage_rows] for f in CONTEXTUAL_COVERAGE_SCHEMA
+    }
+    pq.write_table(pa.table(cov_arrays, schema=CONTEXTUAL_COVERAGE_SCHEMA), coverage_path)
+
+    if not remap:
+        logger.info(
+            "contextual_disambiguation_no_peel",
+            signatures=len(signatures),
+            candidates=len(candidate_ids),
+            coverage=str(coverage_path),
+        )
+        return None
+
+    # Apply: append target rows (reducing each primary's count), build the audit report.
+    new_rows: list[dict[str, Any]] = []
+    audit_rows: list[dict[str, Any]] = []
+    peeled_by_primary: dict[str, int] = {}
+    for tid, count in sorted(target_counts.items()):
+        sig = target_sig[tid]
+        pid = sig.primary_id()
+        primary_rec = record_by_id[pid]
+        peeled_by_primary[pid] = peeled_by_primary.get(pid, 0) + count
+        new_rows.append(_target_record(primary_rec, sig, count))
+        audit_rows.append(
+            {
+                "name_ar_normalized": primary_rec.get("name_ar_normalized"),
+                "primary_id": pid,
+                "new_id": tid,
+                "discriminator": sig.discriminator,
+                "target_name_en": sig.name_en,
+                "teacher_ar": sig.teacher_ar,
+                "student_ar": sig.student_ar,
+                "mention_count": count,
+            }
+        )
+    for pid, peeled in peeled_by_primary.items():
+        primary_rec = record_by_id[pid]
+        primary_rec["mention_count"] = max(0, _as_int(primary_rec.get("mention_count")) - peeled)
+        primary_rec["attestation"] = derive_attestation(primary_rec["mention_count"])
+
+    all_records = records + new_rows
+    arrays = {f.name: [r.get(f.name) for r in all_records] for f in NARRATORS_CANONICAL_SCHEMA}
+    write_canonical(
+        pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA),
+        canonical_path,
+        stage="contextual_disambiguation",
+    )
+
+    remapped = _remap_split_mentions(mentions_path, remap)
+
+    audit_path = output_dir / "contextual_splits.parquet"
+    audit_arrays = {f.name: [r.get(f.name) for r in audit_rows] for f in CONTEXTUAL_SPLITS_SCHEMA}
+    pq.write_table(pa.table(audit_arrays, schema=CONTEXTUAL_SPLITS_SCHEMA), audit_path)
+
+    logger.info(
+        "contextual_disambiguation_complete",
+        peeled_targets=len(new_rows),
+        mentions_remapped=remapped,
+        canonical_total=len(all_records),
+        audit=str(audit_path),
+        coverage=str(coverage_path),
+    )
+    return canonical_path

--- a/src/resolve/contextual_signatures.yaml
+++ b/src/resolve/contextual_signatures.yaml
@@ -1,0 +1,40 @@
+# Curated isnad-neighbour signature seed for contextual disambiguation (da#346).
+#
+# Each entry peels the mentions of an over-merged BARE name (`name_ar`) whose ±1 isnad
+# neighbours match a HAND-VERIFIED, uniquely-identifying transmitter/transmittee pair onto
+# a distinct discriminated canonical node. This is the corpus-internal lever the date-axis
+# `narrator_split` cannot use: a bare mention has no attested death-band to cut, but its
+# isnad POSITION (who it narrates from / to) can still identify the referent.
+#
+# This is NOT a threshold and NOT an inference — there is no corpus-internal statistic that
+# separates the referents of a bare name (the #337 §0 negative result; a statistical
+# auto-split re-commits the da#423 silent-zero error). It is a curated list under a
+# bidirectional acceptance fixture (tests/test_resolve/test_contextual_disambiguation.py):
+# every signature MUST fire on the genuine multi-referent mentions it names AND MUST NOT
+# fire on a genuine single narrator whose neighbours do not match it. A mention matched by
+# NO signature — or by MORE THAN ONE — is never peeled; it stays on the bare primary, which
+# `over_merged_flag` keeps flagged, and its true identity is left to the external-rijāl work
+# (da#443). The seed may be empty: then this stage is a pure no-op and the node stays flagged.
+#
+# Matching: `teacher_ar` is the neighbour at position-1 (the mention narrates FROM it),
+# `student_ar` the neighbour at position+1 (narrates TO it). At least one is required; a
+# mention matches iff EVERY specified role is present among its in-chain ±1 neighbours. The
+# more roles a signature constrains, the higher its confidence. Names are matched after
+# `normalize_arabic`. The target id = make_discriminated_canonical_id(name_ar, discriminator).
+#
+# Grow-later (owner, seed-now): only textbook, unambiguous, hand-verifiable pairs are seeded
+# here; the high-recall queue + rijāl confirmation grows the list under da#443.
+
+signatures:
+  - name_ar: "عبد الله"
+    teacher_ar: "رسول الله"
+    student_ar: "نافع"
+    name_en: "Abd Allah ibn Umar"
+    discriminator: "ctx:ibn-umar"
+    note: >-
+      Bare ʿAbd Allāh who narrates FROM the Prophet and TO his mawlā Nāfiʿ is ʿAbd Allāh
+      ibn ʿUmar b. al-Khaṭṭāb (d.73 AH). The Nāfiʿ ⟵ Ibn ʿUmar ⟵ the Prophet chain is one
+      of the most attested and textbook isnads in the corpus (the "golden chain" when
+      continued Mālik ⟵ Nāfiʿ), so this teacher+student pair is uniquely identifying and
+      hand-verified. Corpus-internal contextual peel (da#346); identity from isnad position,
+      no death year asserted. Residual bare ʿAbd Allāh stays over_merged-flagged.

--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -323,6 +323,21 @@ def _band_label(midpoint: int) -> str:
     return f"d:{(midpoint // 25) * 25}"
 
 
+def _band_is_date_coherent(band: list[DatableMention]) -> bool:
+    """True when the band's midpoint falls inside a known ṭabaqa generation window.
+
+    A midpoint outside every :data:`~src.resolve.tabaqa_dates._GENERATION_DEATH_WINDOW_AH`
+    window maps to :attr:`~src.models.enums.NarratorGeneration.UNKNOWN` — an impossibly
+    LATE (> ~400 AH) or impossibly EARLY (< 11 AH) death that no rijāl authority would
+    accept for a hadith-isnad narrator (da#452). Peeling such a band would mint a phantom
+    twin carrying ``gen=unknown`` + that impossible death year (the 546–693 AH twins Ivana
+    found) while still holding real mentions. Tied to :func:`_generation_for_year`, the
+    SAME function :func:`_peeled_record` uses to stamp a peeled node's generation, so the
+    coherence check and the stamp can never disagree.
+    """
+    return _generation_for_year(_band_midpoint(band)) is not NarratorGeneration.UNKNOWN
+
+
 def plan_split(name_ar_normalized: str, datable: list[DatableMention]) -> SplitPlan:
     """Decide whether/how to split candidate ``name_ar_normalized``; pure + deterministic.
 
@@ -338,11 +353,12 @@ def plan_split(name_ar_normalized: str, datable: list[DatableMention]) -> SplitP
     bands = _cut_bands(datable)
     qualifying = [b for b in bands if len(b) >= SPLIT_MIN_SUPPORT]
 
-    # Gate 1: need ≥2 well-supported bands. A single-band name (a genuinely single
-    # person like Sufyān al-Thawrī / al-Zuhrī) abstains here — the load-bearing guard.
-    if len(qualifying) < 2:
-        return abstain
-    # Gate 2: too many well-supported bands ⇒ generic bucket, not a few people.
+    # Gate 2: too many well-supported bands ⇒ generic bucket, not a few people. Evaluated
+    # on the RAW qualifying count (before the da#452 coherence prune below): a name that
+    # throws off more than SPLIT_MAX_CLUSTERS distinct date bands is an unresolvable
+    # bucket regardless of whether some of those bands are date-incoherent — and running
+    # it first keeps it reachable (a coherent-only count can never exceed the ~5 bands
+    # that fit the ṭabaqa window >SPLIT_BAND_GAP apart, which would make this dead code).
     if len(qualifying) > SPLIT_MAX_CLUSTERS:
         logger.info(
             "narrator_split_abstain_noise",
@@ -350,6 +366,32 @@ def plan_split(name_ar_normalized: str, datable: list[DatableMention]) -> SplitP
             qualifying_bands=len(qualifying),
             max_clusters=SPLIT_MAX_CLUSTERS,
         )
+        return abstain
+
+    # Gate 0 (da#452 — date coherence): drop any qualifying band whose midpoint maps to
+    # NarratorGeneration.UNKNOWN (outside every ṭabaqa window — impossibly late >400 AH or
+    # early <11 AH). Peeling such a band mints a phantom twin with gen=unknown + an
+    # impossible death year that still holds real mentions, corrupting the betweenness
+    # leaderboard (the 546–693 AH twins, da#452). A dropped band is NOT peeled and NOT
+    # retained; its mentions stay on the primary (peel-not-partition), exactly like a
+    # below-support band. An in-window late narrator (the LATER 280–400 band) is coherent
+    # and still peels — the instrument must separate the two (the mandatory da#452 fixture).
+    coherent = [b for b in qualifying if _band_is_date_coherent(b)]
+    if len(coherent) != len(qualifying):
+        logger.info(
+            "narrator_split_drop_incoherent_band",
+            name=name_ar_normalized,
+            dropped_bands=len(qualifying) - len(coherent),
+            dropped_midpoints=[
+                _band_midpoint(b) for b in qualifying if not _band_is_date_coherent(b)
+            ],
+        )
+    qualifying = coherent
+
+    # Gate 1: need ≥2 well-supported, date-coherent bands. A single-band name (a genuinely
+    # single person like Sufyān al-Thawrī / al-Zuhrī), or a name left with one coherent
+    # band after Gate 0, abstains here — the load-bearing guard.
+    if len(qualifying) < 2:
         return abstain
     # Gate 1 (single band) + Gate 2 (too many) are the complete guard set. A third
     # "adjacent midpoints too close ⇒ abstain" separation guard was removed as dead code

--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -47,8 +47,15 @@ Algorithm (per eligible canonical id ``C``, name ``N``)
 4. **ABSTAIN — leave ``C`` as ONE node — UNLESS ALL hold** (the over-split guard):
    * ≥2 clusters each with ≥ :data:`SPLIT_MIN_SUPPORT` mentions (*qualifying*);
    * ≤ :data:`SPLIT_MAX_CLUSTERS` qualifying clusters (more ⇒ the name is a generic
-     bucket we cannot cleanly resolve → abstain, logged for audit);
-   * adjacent qualifying-cluster midpoints separated by > :data:`SPLIT_MIN_SEPARATION`.
+     bucket we cannot cleanly resolve → abstain, logged for audit).
+
+   A separate "adjacent bands too close ⇒ abstain" separation guard is **not** needed:
+   :func:`_cut_bands` only ever starts a new band on a consecutive gap exceeding
+   :data:`SPLIT_BAND_GAP` (80 AH), so any two distinct bands — and therefore any two
+   qualifying bands — are already > 80 AH apart by construction, well beyond any
+   contemporaries-scatter threshold. (A ``SPLIT_MIN_SEPARATION = 50`` gate once sat here;
+   because ``SPLIT_BAND_GAP > 50`` it was structurally unreachable and was removed as
+   dead code — da#444.)
 5. **Peel-not-partition** — undatable mentions, and any mention in a below-support
    band, STAY on the primary node. Only confidently-dated distinct clusters peel off.
 6. **Id assignment** (deterministic — a pure function of the input, reproducible
@@ -147,7 +154,6 @@ logger = get_logger(__name__)
 __all__ = [
     "SPLIT_BAND_GAP",
     "SPLIT_MIN_SUPPORT",
-    "SPLIT_MIN_SEPARATION",
     "SPLIT_MAX_CLUSTERS",
     "MID_GAP",
     "NARRATOR_SPLITS_SCHEMA",
@@ -176,10 +182,6 @@ SPLIT_BAND_GAP = 80
 # Below it, a band is left on the primary (peel-not-partition) — a handful of
 # adjacency estimates is not enough to mint a distinct historical person.
 SPLIT_MIN_SUPPORT = 10
-
-# Two qualifying bands whose midpoints are closer than this are treated as one
-# referent's scatter, not two people — abstain. Secondary to SPLIT_BAND_GAP.
-SPLIT_MIN_SEPARATION = 50
 
 # More than this many *qualifying* bands means the name is a generic bucket we cannot
 # cleanly resolve into a few people — abstain and log for audit rather than shatter it.
@@ -341,11 +343,12 @@ def plan_split(name_ar_normalized: str, datable: list[DatableMention]) -> SplitP
             max_clusters=SPLIT_MAX_CLUSTERS,
         )
         return abstain
-    # Gate 3: adjacent qualifying midpoints must be well separated.
+    # Gate 1 (single band) + Gate 2 (too many) are the complete guard set. A third
+    # "adjacent midpoints too close ⇒ abstain" separation guard was removed as dead code
+    # (da#444): _cut_bands starts a new band only on a gap > SPLIT_BAND_GAP (80 AH), so
+    # any two qualifying bands are already > 80 AH apart — the removed SPLIT_MIN_SEPARATION
+    # (50) check could never fire.
     qsorted = sorted(qualifying, key=_band_midpoint)
-    mids = [_band_midpoint(b) for b in qsorted]
-    if any(b - a <= SPLIT_MIN_SEPARATION for a, b in zip(mids, mids[1:], strict=False)):
-        return abstain
 
     # The largest qualifying band (ties → lower midpoint) keeps the primary id; the
     # undatable/below-support remainder is already off the peel list by construction.

--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -31,15 +31,22 @@ not by the name shape.
 Algorithm (per eligible canonical id ``C``, name ``N``)
 -------------------------------------------------------
 1. Gather every mention with ``canonical_narrator_id == C``.
-2. **Isnad-adjacency evidence** — for each such mention, look at the chain neighbours
-   at ``position_in_chain`` ±1 in the same ``(hadith_id, chain_index)`` chain (da#411 —
-   the composite key the graph loaders use; NOT ``hadith_id`` alone, which would
-   fabricate cross-chain neighbours in a multi-isnad hadith) and map them to their
-   *attested* ``death_year_ah`` (precision ≠ ``tabaqa_estimate`` — an *estimated*
-   window is never used as evidence, which also keeps the pass cascade-free on
-   re-run). A teacher (neighbour at position−1) dies a transmission gap *earlier*;
-   a student (position+1) a gap *later* — so ``C``'s per-mention death estimate is
-   ``neighbour_death ± MID_GAP`` (``MID_GAP`` the midpoint of
+2. **Isnad-adjacency evidence** — for each such mention, look at its immediately
+   preceding / following **resolved** chain neighbours in the same
+   ``(hadith_id, chain_index)`` chain (da#411 — the composite key the graph loaders
+   use; NOT ``hadith_id`` alone, which would fabricate cross-chain neighbours in a
+   multi-isnad hadith) and map them to their *attested* ``death_year_ah``
+   (precision ≠ ``tabaqa_estimate`` — an *estimated* window is never used as
+   evidence, which also keeps the pass cascade-free on re-run). "Adjacent" is the
+   **consecutive-resolved** notion the loader pairs into ``TRANSMITTED_TO`` edges
+   (:func:`src.graph.load_edges._build_chain_pairs`, da#439), NOT an exact
+   ``position ± 1`` test: an intermediate position left unresolved (null
+   ``canonical_narrator_id``) opens a position gap that the loader bridges and that
+   an exact-±1 window would silently skip — erasing the adjacency of any narrator
+   seen only in gappy chains (the drop-gate erasure class, main#928 / da#423). A
+   teacher (the earlier-position neighbour) dies a transmission gap *earlier*; a
+   student (the later-position neighbour) a gap *later* — so ``C``'s per-mention
+   death estimate is ``neighbour_death ± MID_GAP`` (``MID_GAP`` the midpoint of
    :data:`~src.resolve.mononym_split._MIN_GAP`/``_MAX_GAP``), averaged over the
    mention's attested neighbours. A mention with no attested neighbour is *undatable*.
 3. **Cluster** the per-mention estimates 1-D, gap-based: sort and cut wherever a
@@ -548,6 +555,13 @@ def _build_chain_index(
             key = (hid, _coalesce_chain_index(cidx))
             if key in candidate_chain_keys:
                 chains.setdefault(key, []).append((int(pos), cid))
+    # Position-sort each chain once so :func:`_collect_datable` can read a mention's
+    # immediately-preceding / -following resolved neighbour by list index — the SAME
+    # position-sorted, consecutive-resolved adjacency the loader pairs into
+    # TRANSMITTED_TO edges (load_edges._build_chain_pairs, da#439). Tie-break on the
+    # canonical id so two resolved mentions sharing a position order deterministically.
+    for chain in chains.values():
+        chain.sort(key=lambda pc: (pc[0], pc[1]))
     return chains, candidate_mentions
 
 
@@ -559,21 +573,48 @@ def _collect_datable(
 ) -> list[DatableMention]:
     """Per-mention death estimates from attested chain neighbours (undatable dropped).
 
-    A neighbour is only ever the mention's ±1 position **within the same
-    ``(hadith_id, chain_index)`` chain** — never another isnad of the same hadith
-    (da#411) — mirroring the graph loaders' composite chain key.
+    A neighbour is the mention's immediately-preceding / -following **resolved**
+    mention in its position-sorted ``(hadith_id, chain_index)`` chain — never another
+    isnad of the same hadith (da#411). This is the **consecutive-resolved** adjacency
+    the graph loader pairs into ``TRANSMITTED_TO`` edges
+    (:func:`src.graph.load_edges._build_chain_pairs`), NOT an exact ``position ± 1``
+    test (da#439): when an intermediate position is unresolved (null
+    ``canonical_narrator_id``, dropped from ``chains`` in :func:`_build_chain_index`),
+    it opens a position gap. The loader still pairs across that gap (consecutive in the
+    resolved list), so an exact-±1 window here would diverge from the loaded graph —
+    systematically erasing the teacher/student adjacency of any narrator that appears
+    only in gappy chains (the drop-gate erasure class, main#928 / da#423). Reading the
+    immediate sorted-list neighbours instead keeps the split's evidence and the loaded
+    topology in agreement.
+
+    The loader's self-loop drop is mirrored too: a neighbour that resolves to the
+    mention's own canonical id forms no ``TRANSMITTED_TO`` edge (``from_id == to_id``),
+    so it contributes no adjacency here — and, as in the loader, is NOT bridged past to
+    the next resolved mention.
     """
     datable: list[DatableMention] = []
     for hadith_id, chain_index, position, mention_id in mentions:
+        chain = chains.get((hadith_id, chain_index), ())
+        # Locate this mention's slot in the position-sorted resolved chain
+        # (pre-sorted in _build_chain_index). Absent only if the chain was pruned —
+        # defensively skip rather than fabricate an adjacency.
+        idx = next((i for i, (p, _c) in enumerate(chain) if p == position), None)
+        if idx is None:
+            continue
+        own_id = chain[idx][1]
         estimates: list[int] = []
         anchors: list[str] = []
-        for npos, nid in chains.get((hadith_id, chain_index), ()):
-            if npos == position - 1:
-                sign = 1  # neighbour is the teacher (dies earlier) → C dies later
-            elif npos == position + 1:
-                sign = -1  # neighbour is the student (dies later) → C dies earlier
-            else:
+        # Teacher = the immediately-preceding resolved mention (lower position, dies
+        # earlier → C dies later, sign +1); student = the immediately-following
+        # (higher position, dies later → C dies earlier, sign −1). Consecutive in the
+        # resolved list, so a position gap from a dropped unresolved mention is
+        # bridged exactly as the loader bridges it.
+        for nidx, sign in ((idx - 1, 1), (idx + 1, -1)):
+            if nidx < 0 or nidx >= len(chain):
                 continue
+            nid = chain[nidx][1]
+            if nid == own_id:
+                continue  # self-loop: no edge in the graph, no adjacency here
             year = attested_by_id.get(nid)
             if year is None:
                 continue

--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -168,6 +168,7 @@ __all__ = [
     "PeeledBand",
     "SplitPlan",
     "plan_split",
+    "resolved_chain_neighbours",
     "split_generic_narrators",
 ]
 
@@ -568,6 +569,50 @@ def _build_chain_index(
     return chains, candidate_mentions
 
 
+def resolved_chain_neighbours(
+    chains: dict[tuple[str, int], list[tuple[int, str]]],
+    hadith_id: str,
+    chain_index: int,
+    position: int,
+) -> tuple[str | None, str | None]:
+    """The ``(teacher_id, student_id)`` of a mention's consecutive-resolved chain neighbours.
+
+    The **one** isnad-adjacency definition shared by every stage that reasons about a
+    mention's teacher/student — the date-band splitter (:func:`_collect_datable`), the
+    contextual disambiguator (``contextual_disambiguation``, da#346), and any future
+    isnad-neighbour gate — so they cannot drift the way the splitter and the loader did
+    (da#439). It IS the loader's ``TRANSMITTED_TO`` adjacency
+    (:func:`src.graph.load_edges._build_chain_pairs`):
+
+    * teacher = the **immediately-preceding resolved** mention (lower position),
+      student = the **immediately-following resolved** mention (higher position), in the
+      position-sorted ``(hadith_id, chain_index)`` chain (``chains`` is pre-sorted by
+      :func:`_build_chain_index`) — NOT an exact ``position ± 1`` test, so a gap opened by
+      a dropped unresolved position is bridged exactly as the loader bridges it (da#439);
+    * a neighbour resolving to the mention's OWN canonical id is a self-loop — no
+      ``TRANSMITTED_TO`` edge, so it is dropped and, as in the loader, NOT bridged past
+      to the next resolved mention (that role becomes ``None``);
+    * confined to the same ``(hadith_id, chain_index)`` chain — never a cross-isnad
+      neighbour of a multi-isnad hadith (da#411).
+
+    Returns ``(None, None)`` when the mention's slot is absent from ``chains`` (a pruned
+    chain — never fabricates an adjacency). Pure; no IO.
+    """
+    chain = chains.get((hadith_id, chain_index), ())
+    idx = next((i for i, (p, _c) in enumerate(chain) if p == position), None)
+    if idx is None:
+        return None, None
+    own_id = chain[idx][1]
+
+    def _neighbour(nidx: int) -> str | None:
+        if nidx < 0 or nidx >= len(chain):
+            return None
+        nid = chain[nidx][1]
+        return None if nid == own_id else nid  # self-loop → no edge, not bridged past
+
+    return _neighbour(idx - 1), _neighbour(idx + 1)
+
+
 def _collect_datable(
     mentions: list[tuple[str, int, int, str]],
     chains: dict[tuple[str, int], list[tuple[int, str]]],
@@ -597,27 +642,17 @@ def _collect_datable(
     """
     datable: list[DatableMention] = []
     for hadith_id, chain_index, position, mention_id in mentions:
-        chain = chains.get((hadith_id, chain_index), ())
-        # Locate this mention's slot in the position-sorted resolved chain
-        # (pre-sorted in _build_chain_index). Absent only if the chain was pruned —
-        # defensively skip rather than fabricate an adjacency.
-        idx = next((i for i, (p, _c) in enumerate(chain) if p == position), None)
-        if idx is None:
-            continue
-        own_id = chain[idx][1]
-        estimates: list[int] = []
-        anchors: list[str] = []
         # Teacher = the immediately-preceding resolved mention (lower position, dies
         # earlier → C dies later, sign +1); student = the immediately-following
-        # (higher position, dies later → C dies earlier, sign −1). Consecutive in the
-        # resolved list, so a position gap from a dropped unresolved mention is
-        # bridged exactly as the loader bridges it.
-        for nidx, sign in ((idx - 1, 1), (idx + 1, -1)):
-            if nidx < 0 or nidx >= len(chain):
+        # (higher position, dies later → C dies earlier, sign −1). The shared
+        # consecutive-resolved adjacency helper (da#439) bridges a dropped-position gap
+        # exactly as the loader does and drops self-loops without bridging past them.
+        teacher_id, student_id = resolved_chain_neighbours(chains, hadith_id, chain_index, position)
+        estimates: list[int] = []
+        anchors: list[str] = []
+        for nid, sign in ((teacher_id, 1), (student_id, -1)):
+            if nid is None:
                 continue
-            nid = chain[nidx][1]
-            if nid == own_id:
-                continue  # self-loop: no edge in the graph, no adjacency here
             year = attested_by_id.get(nid)
             if year is None:
                 continue

--- a/src/resolve/narrator_unify.py
+++ b/src/resolve/narrator_unify.py
@@ -1,0 +1,432 @@
+"""Merge curated UNDER-merged narrator surface forms onto one canonical (da#431/da#347).
+
+Background
+----------
+The canonical narrator id is a pure function of the normalized name
+(``make_canonical_id``), and ``fuzzy_cluster`` only *merges* two canonicals when they
+clear a precision guard: at least :data:`~src.resolve.fuzzy_cluster._MIN_SHARED_TOKENS`
+shared significant name tokens, no death-year conflict, no gender conflict (da#138). That
+guard is correct — loosening it re-commits the da#423 over-merge that deleted real
+figures — but it structurally *cannot* bridge two references to the SAME person that share
+too few tokens:
+
+* **kunya ↔ ism** (da#431): ``أبو وائل`` (kunya) and ``شقيق بن سلمة`` (ism+nasab) share
+  ZERO significant tokens, so the ~3,117 mentions on the kunya node never join the ism
+  node, and the rijāl biography (promoted to its own node by ``bio_promote``) sits on a
+  zero-mention node while the mentions sit on a bio-less one.
+* **bare ism ↔ qualified** (da#347): bare ``أنس`` and ``أنس بن مالك`` share ONE token
+  (``< _MIN_SHARED_TOKENS``), so Anas b. Mālik is split across two nodes, halving his
+  centrality.
+
+This stage does NOT loosen the guard. It supplies **curated, corroborated external
+evidence** for a hand-verified set of confirmed single identities
+(:data:`_SEED_PATH`, ``narrator_unify.yaml``) and merges ONLY those, reusing the exact
+merge ``fuzzy_cluster`` performs (:func:`~src.resolve.fuzzy_cluster._merge_cluster` +
+:func:`~src.resolve.fuzzy_cluster._remap_mention_canonical_ids`). It is the mirror of
+``over_merged_flag`` — a curated list under a **bidirectional acceptance fixture**
+(``tests/test_resolve/test_narrator_unify.py``): every golden multi-node-of-one-person
+group MUST merge, and every distinct-narrator control MUST NOT.
+
+The gate is the da#423 safety net, not the decision
+----------------------------------------------------
+The curated list *is* the decision (hand-verified, like ``over_merged_narrators.yaml``).
+:func:`_group_admissible` REFUSES a group — loudly, never merging it — when any of these
+holds, so a curation error cannot silently sweep in a distinct person:
+
+1. **over-merge exclusion** — a member is a curated over-merged bare generic
+   (``over_merged_narrators.yaml``); those fuse many people and can never be a unify member.
+2. **corroborated death conflict** — two members carry ``death_year_provenance ==
+   "corroborated"`` death years disagreeing beyond
+   :data:`~src.resolve.fuzzy_cluster._DEATH_YEAR_TOLERANCE`.
+3. **gross death spread** — two members' death years disagree by more than
+   :data:`_UNIFY_MAX_DEATH_SPREAD` regardless of provenance (a loose sanity band that
+   catches a distinct namesake even when neither year is corroborated — e.g. the d.200
+   taba-tabiʿī bare ``شقيق`` against the d.82 Companion-era Abū Wāʾil).
+4. **gender conflict** — two members carry explicit, differing gender.
+5. **uncorroborated evidence** — the group's declared evidence is not attested in-corpus
+   (for ``bio_kunya_ism_bridge``: no resolved member spells out BOTH the kunya and the ism).
+
+Placement & idempotency
+-----------------------
+Runs after ``tabaqa_dates`` (dates + mention_count final) and before ``over_merged_flag``
+(which stays the last writer of ``narrators_canonical.parquet``). Rewrites the canonical
+table and remaps the absorbed mentions. Idempotent: after a merge the absorbed surfaces
+survive only as aliases, so a re-run resolves each group to a single survivor node and
+skips it (a group resolving to < 2 distinct canonicals is a no-op).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+from src.resolve._run_record import write_canonical
+from src.resolve.fuzzy_cluster import (
+    _DEATH_YEAR_TOLERANCE,
+    _genders_conflict,
+    _merge_cluster,
+    _remap_mention_canonical_ids,
+)
+from src.resolve.over_merged_flag import load_over_merged_seed
+from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+from src.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = get_logger(__name__)
+
+_SEED_PATH = Path(__file__).with_name("narrator_unify.yaml")
+
+# Loose sanity band (in AH years) on the death-year spread within a unify group,
+# applied regardless of provenance. Tighter than "any conflict" would be — the curated
+# members legitimately carry noisy/default death years (e.g. the generic sahabi d.60) —
+# but wide gaps (> this) mark a distinct namesake, not one person. Chosen so a genuine
+# generation-default noise gap (Anas: bare d.60 vs qualified d.91 = 31) passes while a
+# cross-generation namesake (bare Shaqīq d.200 vs Abū Wāʾil d.82 = 118) is refused.
+_UNIFY_MAX_DEATH_SPREAD = 50
+
+__all__ = [
+    "UnifyGroup",
+    "load_unify_seed",
+    "apply_narrator_unification",
+]
+
+
+@dataclass(frozen=True)
+class UnifyGroup:
+    """One curated group of surface forms that are a single narrator.
+
+    ``members`` are ``name_ar_normalized`` surfaces (the stored column) — NOT recomputed
+    ids, because these nodes carry narrator_split-discriminated ids. ``member_ids`` are
+    optional explicit canonical ids that take precedence when resolving. ``evidence`` names
+    the corroboration the gate must confirm; ``bio_kunya_ism_bridge`` also reads
+    ``kunya_norm``/``ism_norm``.
+    """
+
+    primary_label: str
+    issue: str
+    evidence: str
+    note: str
+    members: tuple[str, ...]
+    member_ids: tuple[str, ...] = ()
+    kunya_norm: str | None = None
+    ism_norm: str | None = None
+
+
+def load_unify_seed(path: Path = _SEED_PATH) -> tuple[UnifyGroup, ...]:
+    """Parse the curated ``narrator_unify.yaml`` seed (empty when the file is absent).
+
+    Raises ``ValueError`` on a malformed group — a dropped member is exactly the silent
+    under-merge this list exists to fix, so a missing key fails loudly, never silently.
+    """
+    if not path.exists():
+        return ()
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    rows = raw.get("unify", []) if isinstance(raw, dict) else raw
+    groups: list[UnifyGroup] = []
+    for row in rows:
+        members = tuple(normalize_arabic(m) for m in (row.get("members") or []))
+        member_ids = tuple(row.get("member_ids") or ())
+        if len(members) + len(member_ids) < 2:
+            raise ValueError(
+                f"unify group {row.get('primary_label')!r} needs >= 2 members to merge"
+            )
+        evidence = row.get("evidence")
+        note = row.get("note")
+        if not evidence or not note:
+            raise ValueError(
+                f"unify group {row.get('primary_label')!r} needs both `evidence` and `note`"
+            )
+        kunya = row.get("kunya_norm")
+        ism = row.get("ism_norm")
+        if evidence == "bio_kunya_ism_bridge" and not (kunya and ism):
+            raise ValueError(
+                f"unify group {row.get('primary_label')!r} evidence bio_kunya_ism_bridge "
+                "requires kunya_norm and ism_norm"
+            )
+        groups.append(
+            UnifyGroup(
+                primary_label=row.get("primary_label") or (members[0] if members else "?"),
+                issue=row.get("issue") or "",
+                evidence=evidence,
+                note=note,
+                members=members,
+                member_ids=member_ids,
+                kunya_norm=normalize_arabic(kunya) if kunya else None,
+                ism_norm=normalize_arabic(ism) if ism else None,
+            )
+        )
+    return tuple(groups)
+
+
+def _over_merged_norms(seed_path: Path | None = None) -> frozenset[str]:
+    """Normalized names of every curated over-merged bare generic (the exclusion set)."""
+    entries = load_over_merged_seed(seed_path) if seed_path else load_over_merged_seed()
+    return frozenset(normalize_arabic(e.name_ar) for e in entries if e.name_ar)
+
+
+def _resolve_members(
+    group: UnifyGroup, by_norm: dict[str, list[dict[str, Any]]], by_id: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Canonical records for a group's members (by explicit id, else by normalized name).
+
+    A surface matching more than one row (a narrator_split-discriminated twin sharing a
+    normalized name) resolves to ALL matching rows; the gate then vets the set. Deduped on
+    canonical_id, preserving first-seen order.
+    """
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+
+    def _add(rec: dict[str, Any]) -> None:
+        cid = rec.get("canonical_id")
+        if cid and cid not in seen:
+            seen.add(cid)
+            out.append(rec)
+
+    for mid in group.member_ids:
+        rec = by_id.get(mid)
+        if rec is not None:
+            _add(rec)
+    for surface in group.members:
+        for rec in by_norm.get(surface, []):
+            _add(rec)
+    return out
+
+
+def _corroborated_death_conflict(members: list[dict[str, Any]]) -> tuple[int, int] | None:
+    """First pair of members whose CORROBORATED death years disagree beyond tolerance."""
+    dated = [(m.get("death_year_ah"), m.get("death_year_provenance")) for m in members]
+    for i in range(len(members)):
+        yi, pi = dated[i]
+        if not (isinstance(yi, int) and pi == "corroborated"):
+            continue
+        for j in range(i + 1, len(members)):
+            yj, pj = dated[j]
+            if (
+                isinstance(yj, int)
+                and pj == "corroborated"
+                and abs(yi - yj) > _DEATH_YEAR_TOLERANCE
+            ):
+                return (yi, yj)
+    return None
+
+
+def _gross_death_spread(members: list[dict[str, Any]]) -> tuple[int, int] | None:
+    """Widest pair of member death years when it exceeds the unify sanity band."""
+    years: list[int] = [y for m in members if isinstance((y := m.get("death_year_ah")), int)]
+    if len(years) < 2:
+        return None
+    lo, hi = min(years), max(years)
+    return (lo, hi) if hi - lo > _UNIFY_MAX_DEATH_SPREAD else None
+
+
+def _gender_conflict(members: list[dict[str, Any]]) -> bool:
+    """True when any two members carry explicit, differing gender."""
+    for i in range(len(members)):
+        for j in range(i + 1, len(members)):
+            if _genders_conflict(members[i], members[j]):
+                return True
+    return False
+
+
+def _evidence_corroborated(group: UnifyGroup, members: list[dict[str, Any]]) -> bool:
+    """Confirm the group's declared evidence is attested in the resolved members.
+
+    ``bio_kunya_ism_bridge``: a resolved member's normalized name must contain BOTH the
+    declared kunya and the declared ism — the in-corpus full-name node that spells out the
+    kunya↔ism identity, so the bridge is attested, not asserted. Unknown evidence kinds are
+    treated as NOT corroborated (fail closed).
+    """
+    if group.evidence == "bio_kunya_ism_bridge":
+        kunya, ism = group.kunya_norm, group.ism_norm
+        if not (kunya and ism):
+            return False
+        return any(
+            kunya in (m.get("name_ar_normalized") or "")
+            and ism in (m.get("name_ar_normalized") or "")
+            for m in members
+        )
+    return False
+
+
+def _group_admissible(
+    group: UnifyGroup, members: list[dict[str, Any]], over_merged: frozenset[str]
+) -> tuple[bool, str]:
+    """Gate a resolved group. Returns (ok, reason) — reason is empty when admissible."""
+    distinct = {m.get("canonical_id") for m in members}
+    if len(distinct) < 2:
+        return False, "fewer than 2 distinct canonical nodes (already unified / not present)"
+
+    hit = sorted(
+        normalize_arabic(m.get("name_ar_normalized") or "")
+        for m in members
+        if normalize_arabic(m.get("name_ar_normalized") or "") in over_merged
+    )
+    if hit:
+        return False, f"member is a curated over-merged bare generic: {hit}"
+
+    conflict = _corroborated_death_conflict(members)
+    if conflict is not None:
+        return False, f"corroborated death-year conflict {conflict[0]} vs {conflict[1]} AH"
+
+    spread = _gross_death_spread(members)
+    if spread is not None:
+        return (
+            False,
+            f"gross death-year spread {spread[0]}-{spread[1]} AH (> {_UNIFY_MAX_DEATH_SPREAD})",
+        )
+
+    if _gender_conflict(members):
+        return False, "explicit gender conflict between members"
+
+    if not _evidence_corroborated(group, members):
+        return False, f"declared evidence {group.evidence!r} not corroborated in-corpus"
+
+    return True, ""
+
+
+def _survivor_row(members: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build the merged survivor row, preserving every canonical column.
+
+    :func:`~src.resolve.fuzzy_cluster._merge_cluster` sums mentions, unions aliases,
+    back-fills the scalar bio, and re-derives attestation. It does not touch the extra
+    canonical columns (date bounds/precision, ``death_year_provenance``, ``external_id``,
+    sect, over-merge flags), so those are back-filled here from the members
+    (representative first) so the survivor keeps the full biography rather than dropping it.
+    """
+    merged = _merge_cluster(members)
+    survivor_id = merged["canonical_id"]
+    rep = next((m for m in members if m.get("canonical_id") == survivor_id), members[0])
+    ordered = [rep, *[m for m in members if m is not rep]]
+    row: dict[str, Any] = {f.name: None for f in NARRATORS_CANONICAL_SCHEMA}
+    for name, value in merged.items():
+        row[name] = value
+    for field in NARRATORS_CANONICAL_SCHEMA:
+        if row.get(field.name) in (None, ""):
+            for m in ordered:
+                if m.get(field.name) not in (None, ""):
+                    row[field.name] = m.get(field.name)
+                    break
+    return row
+
+
+def apply_narrator_unification(output_dir: Path, *, seed_path: Path = _SEED_PATH) -> Path | None:
+    """Merge each admissible curated unify group; remap absorbed mentions (da#431/da#347).
+
+    Reads ``narrators_canonical.parquet`` from ``output_dir``, resolves + gates each seed
+    group, merges the admissible ones onto a single survivor, rewrites the canonical table
+    via :func:`write_canonical`, and remaps the absorbed mentions on
+    ``narrator_mentions_resolved.parquet``. Returns the canonical path when at least one
+    group merged, else ``None`` (no table, empty seed, or every group a no-op/refused).
+    Never fabricates a node; a refused group is logged loudly, never merged.
+    """
+    canonical_path = output_dir / "narrators_canonical.parquet"
+    if not canonical_path.exists():
+        logger.warning("narrator_unify_no_canonical", path=str(canonical_path))
+        return None
+
+    groups = load_unify_seed(seed_path)
+    if not groups:
+        return None
+
+    records: list[dict[str, Any]] = pq.read_table(canonical_path).to_pylist()
+    if not records:
+        return None
+
+    over_merged = _over_merged_norms()
+    by_id = {r["canonical_id"]: r for r in records if r.get("canonical_id")}
+    by_norm: dict[str, list[dict[str, Any]]] = {}
+    for r in records:
+        by_norm.setdefault(normalize_arabic(r.get("name_ar_normalized") or ""), []).append(r)
+
+    remap: dict[str, str] = {}
+    absorbed_ids: set[str] = set()
+    survivors: dict[str, dict[str, Any]] = {}
+    merged_groups = 0
+
+    for group in groups:
+        members = _resolve_members(group, by_norm, by_id)
+        ok, reason = _group_admissible(group, members, over_merged)
+        if not ok:
+            logger.warning(
+                "narrator_unify_group_refused",
+                group=group.primary_label,
+                issue=group.issue,
+                resolved=len(members),
+                reason=reason,
+            )
+            continue
+        survivor = _survivor_row(members)
+        survivor_id = survivor["canonical_id"]
+        survivors[survivor_id] = survivor
+        for m in members:
+            cid = m.get("canonical_id")
+            if cid and cid != survivor_id:
+                absorbed_ids.add(cid)
+            if cid:
+                remap[cid] = survivor_id
+        merged_groups += 1
+        logger.info(
+            "narrator_unify_group_merged",
+            group=group.primary_label,
+            issue=group.issue,
+            members=len(members),
+            survivor=survivor_id,
+            mentions=survivor.get("mention_count"),
+        )
+
+    if merged_groups == 0:
+        logger.info("narrator_unify_no_op", groups=len(groups))
+        return None
+
+    # Rebuild: drop absorbed rows, replace/insert survivors (dedupe on canonical_id so a
+    # survivor whose id already existed as a member is not duplicated).
+    rebuilt: list[dict[str, Any]] = []
+    emitted: set[str] = set()
+    for r in records:
+        cid = r.get("canonical_id")
+        if cid in absorbed_ids:
+            continue
+        if cid in survivors:
+            if cid in emitted:
+                continue
+            rebuilt.append(survivors[cid])
+            emitted.add(cid)
+        else:
+            rebuilt.append(r)
+    for sid, srow in survivors.items():
+        if sid not in emitted:
+            rebuilt.append(srow)
+            emitted.add(sid)
+
+    arrays = {f.name: [r.get(f.name) for r in rebuilt] for f in NARRATORS_CANONICAL_SCHEMA}
+    table = pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA)
+    write_canonical(table, canonical_path, stage="narrator_unify")
+
+    remapped = _remap_mention_canonical_ids(
+        output_dir / "narrator_mentions_resolved.parquet", remap
+    )
+
+    logger.info(
+        "narrator_unify_complete",
+        groups=len(groups),
+        merged=merged_groups,
+        absorbed=len(absorbed_ids),
+        canonical_before=len(records),
+        canonical_after=len(rebuilt),
+        mentions_remapped=remapped,
+    )
+    return canonical_path
+
+
+def unify_summary(groups: Iterable[UnifyGroup]) -> str:
+    """One-line human summary of the seed (for the run record / logs)."""
+    gs = tuple(groups)
+    return f"{len(gs)} curated unify group(s): " + "; ".join(g.primary_label for g in gs)

--- a/src/resolve/narrator_unify.py
+++ b/src/resolve/narrator_unify.py
@@ -118,6 +118,12 @@ class UnifyGroup:
     member_ids: tuple[str, ...] = ()
     kunya_norm: str | None = None
     ism_norm: str | None = None
+    # isnad_neighbor_overlap evidence: the bare ism and its qualified form, and the
+    # required chain-neighbour overlap (|top-K(bare) ∩ top-K(qualified)| / K).
+    bare_norm: str | None = None
+    qualified_norm: str | None = None
+    min_overlap: float = 0.5
+    top_k: int = 50
 
 
 def load_unify_seed(path: Path = _SEED_PATH) -> tuple[UnifyGroup, ...]:
@@ -151,6 +157,13 @@ def load_unify_seed(path: Path = _SEED_PATH) -> tuple[UnifyGroup, ...]:
                 f"unify group {row.get('primary_label')!r} evidence bio_kunya_ism_bridge "
                 "requires kunya_norm and ism_norm"
             )
+        bare = row.get("bare_norm")
+        qualified = row.get("qualified_norm")
+        if evidence == "isnad_neighbor_overlap" and not (bare and qualified):
+            raise ValueError(
+                f"unify group {row.get('primary_label')!r} evidence isnad_neighbor_overlap "
+                "requires bare_norm and qualified_norm"
+            )
         groups.append(
             UnifyGroup(
                 primary_label=row.get("primary_label") or (members[0] if members else "?"),
@@ -161,6 +174,10 @@ def load_unify_seed(path: Path = _SEED_PATH) -> tuple[UnifyGroup, ...]:
                 member_ids=member_ids,
                 kunya_norm=normalize_arabic(kunya) if kunya else None,
                 ism_norm=normalize_arabic(ism) if ism else None,
+                bare_norm=normalize_arabic(bare) if bare else None,
+                qualified_norm=normalize_arabic(qualified) if qualified else None,
+                min_overlap=float(row.get("min_overlap", 0.5)),
+                top_k=int(row.get("top_k", 50)),
             )
         )
     return tuple(groups)
@@ -236,13 +253,69 @@ def _gender_conflict(members: list[dict[str, Any]]) -> bool:
     return False
 
 
-def _evidence_corroborated(group: UnifyGroup, members: list[dict[str, Any]]) -> bool:
+def _chain_neighbor_overlap(mentions_path: Path, id_a: str, id_b: str, *, top_k: int) -> float:
+    """Overlap coefficient of the two canonical ids' top-``top_k`` chain neighbours.
+
+    Builds each id's multiset of isnad chain neighbours and returns the overlap
+    coefficient ``|top(id_a) ∩ top(id_b)| / min(|top(id_a)|, |top(id_b)|)`` over each id's
+    top-``top_k`` neighbours. This is the da#347 instrument that SEPARATES the classes: a
+    bare ism that is genuinely the same person as its qualified form transmits from/to the
+    same teachers and students, so their neighbourhoods overlap heavily (Anas: 0.68); a
+    distinct namesake's does not. The overlap coefficient (denominator = the SMALLER
+    neighbour set) is used rather than ``/top_k`` so the measure is not diluted when one
+    node has fewer than ``top_k`` distinct neighbours — on the real Anas nodes both sets are
+    full at 50 so the two agree.
+
+    Adjacency is the SHARED :func:`~src.resolve.narrator_split.resolved_chain_neighbours`
+    definition (da#346/da#439) — the immediately-preceding/-following RESOLVED mention in
+    the position-sorted ``(hadith_id, chain_index)`` chain, gap-bridging and self-loop
+    dropping — NOT an exact position ±1 test. This is the loader's ``TRANSMITTED_TO``
+    topology, so the gate measures the same neighbourhood the graph actually builds and
+    cannot drift from it (and does not under-count on gappy isnads). Bounded memory:
+    :func:`~src.resolve.narrator_split._build_chain_index` restricts the resident chains to
+    only those touching one of the two ids. Returns 0.0 when the file is absent or either
+    id has no neighbours (fail closed).
+    """
+    from collections import Counter
+
+    from src.resolve.narrator_split import _build_chain_index, resolved_chain_neighbours
+
+    if not mentions_path.exists():
+        return 0.0
+    chains, candidate_mentions = _build_chain_index(mentions_path, {id_a, id_b})
+
+    def _neighbours(cid: str) -> Counter[str]:
+        counts: Counter[str] = Counter()
+        for hid, cidx, pos, _mid in candidate_mentions.get(cid, []):
+            teacher, student = resolved_chain_neighbours(chains, hid, cidx, pos)
+            for neighbour in (teacher, student):
+                if neighbour is not None and neighbour != cid:
+                    counts[neighbour] += 1
+        return counts
+
+    na, nb = _neighbours(id_a), _neighbours(id_b)
+    top_a = {n for n, _ in na.most_common(top_k)}
+    top_b = {n for n, _ in nb.most_common(top_k)}
+    if not top_a or not top_b:
+        return 0.0
+    return len(top_a & top_b) / min(len(top_a), len(top_b))
+
+
+def _evidence_corroborated(
+    group: UnifyGroup, members: list[dict[str, Any]], mentions_path: Path
+) -> bool:
     """Confirm the group's declared evidence is attested in the resolved members.
 
     ``bio_kunya_ism_bridge``: a resolved member's normalized name must contain BOTH the
     declared kunya and the declared ism — the in-corpus full-name node that spells out the
-    kunya↔ism identity, so the bridge is attested, not asserted. Unknown evidence kinds are
-    treated as NOT corroborated (fail closed).
+    kunya↔ism identity, so the bridge is attested, not asserted.
+
+    ``isnad_neighbor_overlap``: the bare-ism member and the qualified member must both be
+    present and share at least ``min_overlap`` of their top-``top_k`` chain neighbours —
+    the isnad-neighbourhood instrument that separates a genuine same-person split (Anas b.
+    Mālik) from a distinct namesake.
+
+    Unknown evidence kinds are treated as NOT corroborated (fail closed).
     """
     if group.evidence == "bio_kunya_ism_bridge":
         kunya, ism = group.kunya_norm, group.ism_norm
@@ -253,11 +326,40 @@ def _evidence_corroborated(group: UnifyGroup, members: list[dict[str, Any]]) -> 
             and ism in (m.get("name_ar_normalized") or "")
             for m in members
         )
+    if group.evidence == "isnad_neighbor_overlap":
+        bare_n, qual_n = group.bare_norm, group.qualified_norm
+        if not (bare_n and qual_n):
+            return False
+        bare = next(
+            (m for m in members if normalize_arabic(m.get("name_ar_normalized") or "") == bare_n),
+            None,
+        )
+        qual = next(
+            (m for m in members if normalize_arabic(m.get("name_ar_normalized") or "") == qual_n),
+            None,
+        )
+        if bare is None or qual is None:
+            return False
+        overlap = _chain_neighbor_overlap(
+            mentions_path, bare["canonical_id"], qual["canonical_id"], top_k=group.top_k
+        )
+        if overlap < group.min_overlap:
+            logger.info(
+                "narrator_unify_isnad_overlap",
+                group=group.primary_label,
+                overlap=round(overlap, 3),
+                min_overlap=group.min_overlap,
+                top_k=group.top_k,
+            )
+        return overlap >= group.min_overlap
     return False
 
 
 def _group_admissible(
-    group: UnifyGroup, members: list[dict[str, Any]], over_merged: frozenset[str]
+    group: UnifyGroup,
+    members: list[dict[str, Any]],
+    over_merged: frozenset[str],
+    mentions_path: Path,
 ) -> tuple[bool, str]:
     """Gate a resolved group. Returns (ok, reason) — reason is empty when admissible."""
     distinct = {m.get("canonical_id") for m in members}
@@ -286,7 +388,7 @@ def _group_admissible(
     if _gender_conflict(members):
         return False, "explicit gender conflict between members"
 
-    if not _evidence_corroborated(group, members):
+    if not _evidence_corroborated(group, members, mentions_path):
         return False, f"declared evidence {group.evidence!r} not corroborated in-corpus"
 
     return True, ""
@@ -340,6 +442,7 @@ def apply_narrator_unification(output_dir: Path, *, seed_path: Path = _SEED_PATH
     if not records:
         return None
 
+    mentions_path = output_dir / "narrator_mentions_resolved.parquet"
     over_merged = _over_merged_norms()
     by_id = {r["canonical_id"]: r for r in records if r.get("canonical_id")}
     by_norm: dict[str, list[dict[str, Any]]] = {}
@@ -353,7 +456,7 @@ def apply_narrator_unification(output_dir: Path, *, seed_path: Path = _SEED_PATH
 
     for group in groups:
         members = _resolve_members(group, by_norm, by_id)
-        ok, reason = _group_admissible(group, members, over_merged)
+        ok, reason = _group_admissible(group, members, over_merged, mentions_path)
         if not ok:
             logger.warning(
                 "narrator_unify_group_refused",

--- a/src/resolve/narrator_unify.yaml
+++ b/src/resolve/narrator_unify.yaml
@@ -65,3 +65,36 @@ unify:
       - "ابو واءل شقيق بن سلمه الاسدي"     # bridging full name, mc 3
       - "شقيق بن سلمه بن واءل الاسدي"      # ism+nasab+nisba, mc 1
       - "شقيق ابو واءل بن سلمه الاسدي"     # bio-promoted rijāl node, mc 0, d.81
+
+  # da#347 — Anas b. Mālik, the Companion, split between his fully-qualified node
+  # `أنس بن مالك` (mc 17,820, d.91) and the bare ism `أنس` (mc 16,951, d.60 — the generic
+  # sahabi death-year default, not a real dating). They share ONE significant token, below
+  # fuzzy_cluster's _MIN_SHARED_TOKENS=2, so they never merge and his true centrality is
+  # roughly halved. Evidence is isnad-neighbourhood: the two nodes share 34/50 of their top
+  # chain neighbours (measured on bd133e6), both led by Anas's canonical students — Qatāda,
+  # Thābit al-Bunānī, Ḥumayd al-Ṭawīl, al-Zuhrī, Isḥāq b. Abī Ṭalḥa — so the bare node is
+  # overwhelmingly the same person. Bare `أنس` is NOT a curated over-merged generic (unlike
+  # `عبد الله`/`محمد`); the isnad-overlap gate is what separates it from a distinct namesake.
+  #
+  # NOT included here (deliberate, per da#347 secondary + da#443): `ابن عبس` is a
+  # dropped-alif OCR corruption of `ابن عباس`, NOT a diacritic fold — it must NOT be merged
+  # into Ibn ʿAbbās on a string subset; its low isnad overlap with the Ibn ʿAbbās hub would
+  # fail this gate anyway, and a real fix needs external evidence, not corpus-internal
+  # string surgery. `قتادة`/`قَتَادَةَ` already normalize to one node in #928 — no action.
+  - primary_label: "Anas b. Mālik, the Companion (bare ism ↔ qualified, d. ~91-93 AH)"
+    issue: "da#347"
+    evidence: isnad_neighbor_overlap
+    bare_norm: "انس"
+    qualified_norm: "انس بن مالك"
+    min_overlap: 0.5
+    top_k: 50
+    note: >-
+      Bare-ism↔qualified under-merge. `أنس` (bare, mc 16,951, d.60 generic default) and
+      `أنس بن مالك` (mc 17,820, d.91) are one Companion split across two nodes because they
+      share only one significant token (< _MIN_SHARED_TOKENS). Corroborated by isnad
+      neighbourhood: 34/50 shared top chain-neighbours on bd133e6, both dominated by Anas's
+      canonical students (Qatāda, Thābit al-Bunānī, Ḥumayd al-Ṭawīl, al-Zuhrī). Merge folds
+      the bare node into the qualified survivor, restoring his true centrality. da#347.
+    members:
+      - "انس"            # bare ism, mc 16,951
+      - "انس بن مالك"    # qualified ism+nasab, mc 17,820, d.91 (survivor)

--- a/src/resolve/narrator_unify.yaml
+++ b/src/resolve/narrator_unify.yaml
@@ -1,0 +1,67 @@
+# Curated narrator UNDER-merge unification seed (da#431 / da#347).
+#
+# The mirror of over_merged_narrators.yaml. Where that list names bare-generic nodes
+# that OVER-merge many people onto one id (and are only *annotated*, never split),
+# this list names surface forms that UNDER-merge ONE person across several canonical
+# nodes because the fuzzy-cluster precision guard (fuzzy_cluster._MIN_SHARED_TOKENS)
+# refuses to merge them: a kunya (`أبو وائل`) shares zero significant tokens with the
+# ism (`شقيق بن سلمة`), and a bare ism (`أنس`) shares only one with its qualified form
+# (`أنس بن مالك`). That guard is correct for the automatic clusterer — loosening it
+# would re-commit the da#423 over-merge — so we do NOT loosen it. Instead we supply
+# curated, corroborated external evidence for a hand-verified set of confirmed single
+# identities, and merge ONLY those, behind a bidirectional acceptance fixture
+# (tests/test_resolve/test_narrator_unify.py).
+#
+# We do NOT mint nodes. The `narrator_unify` stage MERGES the listed members onto one
+# survivor (fuzzy_cluster._merge_cluster: sums mentions, unions aliases, back-fills the
+# biography from the bio-bearing member, re-derives attestation) and remaps the
+# absorbed mentions — the exact merge fuzzy_cluster performs, applied to a curated set
+# the guard would not reach.
+#
+# Members are keyed by `name_ar_normalized` (the stored column), NOT by a recomputed
+# canonical_id: these nodes carry narrator_split-discriminated ids that are not
+# `make_canonical_id(norm)`, so a name→id recompute would miss them. The stage matches
+# canonical rows whose `name_ar_normalized` equals a listed member surface. An
+# explicit `canonical_id` MAY be given for a member and takes precedence.
+#
+# The gate (see narrator_unify._group_admissible) is the da#423 safety net, NOT the
+# decision — the curated list is the decision. A group is REFUSED (loudly, never
+# merged) if: (a) any member is a curated over-merged bare generic (over_merged
+# exclusion); (b) two members carry CORROBORATED death years that disagree beyond the
+# fuzzy_cluster tolerance; (c) two members' death years disagree grossly (> the unify
+# spread sanity band) regardless of provenance — this catches a distinct namesake
+# (e.g. the d.200 taba-tabiʿī bare `شقيق` is NOT this d.82 Companion-era Abū Wāʾil);
+# (d) two members carry explicit, differing gender; (e) the declared evidence is not
+# corroborated in-corpus.
+
+unify:
+  # da#431 — Abū Wāʾil (Shaqīq b. Salama al-Asadī), a prolific Kūfan tābiʿī. His
+  # ~3,500 mentions sit on the kunya node `أبو وائل` (mc 3,117) with NO biography,
+  # while his rijāl biography (d.81/82, ṭabaqa) sits on a mc=0 bio-promoted node. The
+  # kunya and ism never merge (0 shared significant tokens). Evidence: the corpus
+  # itself carries bridging full-name nodes (`أبو وائل شقيق بن سلمة`) that spell out the
+  # kunya↔ism identity — the bridge is attested, not asserted. Bare `شقيق` (mc 1,046,
+  # d.200) is DELIBERATELY EXCLUDED: it is partly other Shaqīqs and its gross death-year
+  # gap trips the sanity veto.
+  - primary_label: "Shaqīq b. Salama, Abū Wāʾil al-Asadī (Kūfan tābiʿī, d. ~82 AH)"
+    issue: "da#431"
+    evidence: bio_kunya_ism_bridge
+    kunya_norm: "ابو واءل"
+    ism_norm: "شقيق بن سلمه"
+    note: >-
+      Kunya↔ism↔bio under-merge. Kunya node `أبو وائل` holds ~3,117 mentions with no
+      biography; the rijāl bio node `شقيق، أبو وائل بن سلمة الأسدي` (d.81) holds the
+      biography with 0 mentions; the ism+nasab `شقيق بن سلمة` (d.82) and several
+      full-name fragments name the same Companion-era Kūfan. The fuzzy-cluster guard
+      never bridges kunya↔ism (0 shared significant tokens). Corroborated in-corpus by
+      the bridging full-name forms that carry BOTH kunya and ism. Merge unifies the
+      mentions onto one canonical bearing the biography. da#431.
+    members:
+      - "ابو واءل"                         # kunya node, mc 3,117 (holds the mentions)
+      - "شقيق بن سلمه"                     # ism+nasab, mc 364, d.82 sahabi
+      - "ابو واءل شقيق بن سلمه"            # bridging full name, mc 58
+      - "شقيق ابو واءل"                    # bridging fragment, mc 21
+      - "شقيق بن سلمه ابو واءل"            # bridging fragment, mc 17
+      - "ابو واءل شقيق بن سلمه الاسدي"     # bridging full name, mc 3
+      - "شقيق بن سلمه بن واءل الاسدي"      # ism+nasab+nisba, mc 1
+      - "شقيق ابو واءل بن سلمه الاسدي"     # bio-promoted rijāl node, mc 0, d.81

--- a/tests/test_parse/test_isnad_matn_split.py
+++ b/tests/test_parse/test_isnad_matn_split.py
@@ -1,0 +1,172 @@
+"""Tests for the da#366 matn-embedded isnad splitter.
+
+The splitter recovers an isnad embedded in the matn text of sanadset's
+"No SANAD" rows, across two conventions, WITHOUT the NER ``full_text`` fallback
+that mints matn sentences as narrators. Precision is paramount: the tests below
+lock both the positive recoveries and — just as important — the negative and
+fail-closed cases that keep matn out of the narrator index.
+
+No real corpus data ships in the repo (``data/raw`` is empty), so these fixtures
+reproduce both conventions plus the negative (pure-matn), bare-opener, and
+no-boundary classes. The full-corpus recovery magnitude (~122,000) is a re-run
+measurement, not a CI assertion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.parse.isnad_matn_split import detect_isnad, split_isnad_matn
+from src.parse.narrator_extraction import extract_narrator_mentions
+from src.utils.arabic import extract_transmission_phrases
+
+# --- positive recoveries --------------------------------------------------
+
+
+def test_opener_and_an_chain_is_both() -> None:
+    text = "حدثنا مالك عن نافع عن ابن عمر أن رسول الله صلى الله عليه وسلم نهى عن بيع الغرر"
+    result = split_isnad_matn(text)
+    assert result is not None
+    assert result.convention == "both"
+    # The isnad head is isolated; the ``أن …`` matn — including its own ``عن`` —
+    # is NOT pulled into the chain.
+    assert result.isnad_ar == "حدثنا مالك عن نافع عن ابن عمر"
+    assert result.matn_ar.startswith("أن رسول الله")
+    assert [s.name for s in result.spans] == extract_names(result.isnad_ar)
+    assert len(result.spans) == 3
+
+
+def test_bare_name_an_chain_convention() -> None:
+    # tusi/sanadset shape: a bare name, then ``عن`` links — no receipt-verb opener.
+    text = "علي بن إبراهيم عن أبيه عن ابن أبي عمير عن أبي عبد الله قال إذا صلى أحدكم فليتم"
+    result = split_isnad_matn(text)
+    assert result is not None
+    assert result.convention == "an_chain"
+    assert result.isnad_ar == "علي بن إبراهيم عن أبيه عن ابن أبي عمير عن أبي عبد الله"
+    assert result.matn_ar.startswith("قال")
+    # The leading bare name is recovered as the first narrator.
+    assert len(result.spans) == 4
+
+
+def test_qala_is_a_link_not_a_boundary_when_opener_follows() -> None:
+    # ``حدثنا مالك قال حدثنا نافع`` — the first ``قال`` connects two receipt
+    # verbs and must NOT cut the isnad; the boundary is the later ``أن``.
+    text = "حدثنا مالك قال حدثنا نافع عن ابن عمر أن النبي قال الطهور شطر الإيمان"
+    result = split_isnad_matn(text)
+    assert result is not None
+    assert result.isnad_ar == "حدثنا مالك قال حدثنا نافع عن ابن عمر"
+    assert result.matn_ar.startswith("أن النبي")
+    assert [s.name for s in result.spans] == ["مالك", "نافع", "ابن عمر"]
+
+
+# --- negatives: the detector must not fire --------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "text"),
+    [
+        ("pure matn", "إنما الأعمال بالنيات وإنما لكل امرئ ما نوى"),
+        ("qala-head matn", "قال النبي من كذب علي متعمدا فليتبوأ مقعده من النار"),
+        ("single-an prose", "باب ما جاء عن النبي في الصلاة"),
+    ],
+)
+def test_non_isnad_matn_recovers_nothing(label: str, text: str) -> None:
+    assert split_isnad_matn(text) is None, label
+
+
+def test_empty_and_blank_recover_nothing() -> None:
+    assert split_isnad_matn(None) is None
+    assert split_isnad_matn("") is None
+    assert split_isnad_matn("   ") is None
+
+
+# --- fail-closed: detected but unsafe to split ----------------------------
+
+
+def test_bare_opener_introducing_speech_recovers_nothing() -> None:
+    # ``حدثنا : "…"`` — an opener with no narrator named before the matn. The
+    # boundary is the colon, the isolated head is just the opener, and it
+    # segments to zero narrators, so nothing is recovered (da#366 §"bare openers").
+    text = 'حدثنا : " من لا يرحم الناس لا يرحمه الله "'
+    assert split_isnad_matn(text) is None
+
+
+def test_no_matn_boundary_marker_fails_closed() -> None:
+    # A clear isnad, but with no ``قال``/``أن``/punctuation to mark where the matn
+    # begins. Rather than guess (and risk absorbing matn into the last narrator),
+    # the splitter fails closed — the accepted lower-bound behaviour.
+    text = "حدثنا مالك عن نافع عن ابن عمر رضي الله عنه"
+    assert split_isnad_matn(text) is None
+
+
+# --- the whole point: no matn pollution -----------------------------------
+
+
+def test_splitter_does_not_pollute_like_the_ner_fallback() -> None:
+    # Feeding the WHOLE body to the segmenter (the da#369 fallback) glues matn
+    # onto the last narrator and mints a matn fragment as a narrator. The
+    # splitter isolates the isnad head first and yields only the real chain.
+    text = "حدثنا مالك عن نافع عن ابن عمر أن رسول الله صلى الله عليه وسلم نهى عن بيع الحصاة"
+    result = split_isnad_matn(text)
+    assert result is not None
+
+    naive = extract_narrator_mentions(text, "ar")
+    assert len(result.spans) < len(naive)
+    # No recovered span carries matn: none contains the Prophet-formula token
+    # ``رسول`` that the naive blob absorbs.
+    assert all("رسول" not in s.name for s in result.spans)
+    assert any("رسول" in s.name for s in naive)
+
+
+# --- detector unit behaviour ----------------------------------------------
+
+
+def test_detector_requires_two_an_without_an_opener() -> None:
+    one_an = "فلان بن فلان عن النبي في شيء ما"
+    assert detect_isnad(one_an, extract_transmission_phrases(one_an)) is None
+
+    two_an = "فلان عن علان عن فلان قال شيء"
+    assert detect_isnad(two_an, extract_transmission_phrases(two_an)) == "an_chain"
+
+
+def test_an_beyond_the_token_window_does_not_count() -> None:
+    # Two ``عن`` links, but only after 26 filler tokens — past the 25-token
+    # window — and no opener, so the detector does not fire.
+    text = " ".join(["حرف"] * 26) + " عن أ عن ب قال ج"
+    assert detect_isnad(text, extract_transmission_phrases(text)) is None
+
+
+# --- both-direction boundary fidelity -------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("isnad", "matn"),
+    [
+        (
+            "حدثنا مالك عن نافع عن ابن عمر",
+            "أن رسول الله صلى الله عليه وسلم نهى عن بيع الحصاة",
+        ),
+        (
+            "علي بن إبراهيم عن أبيه عن حماد عن أبي عبد الله",
+            "قال الصلاة عماد الدين",
+        ),
+    ],
+)
+def test_boundary_is_faithful_both_directions(isnad: str, matn: str) -> None:
+    # Concatenate a known isnad and a known matn (the shape of an untagged row),
+    # then require the splitter to reconstruct BOTH sides exactly: the recovered
+    # isnad's narrator set equals the isnad-only segmentation (nothing dropped),
+    # and the residual matn is the original matn (nothing of the matn pulled in).
+    result = split_isnad_matn(f"{isnad} {matn}")
+    assert result is not None
+    assert result.isnad_ar == isnad
+    assert result.matn_ar == matn
+    assert [s.name for s in result.spans] == extract_names(isnad)
+
+
+# --- helpers --------------------------------------------------------------
+
+
+def extract_names(isnad_text: str) -> list[str]:
+    """Oracle: the narrator names the shared segmenter yields for an isnad-only text."""
+    return [s.name for s in extract_narrator_mentions(isnad_text, "ar")]

--- a/tests/test_parse/test_provenance_conformance.py
+++ b/tests/test_parse/test_provenance_conformance.py
@@ -69,6 +69,10 @@ _NON_PARSER_MODULES = frozenset(
         # da#247: narrator name-quality cleaning/validation used BY the NER stage —
         # a pure string filter, emits no schema/parquet of its own.
         "name_quality",
+        # da#366: two-convention isnad/matn splitter used BY the sanadset parser to
+        # recover a matn-embedded isnad — a pure text function, emits no
+        # schema/parquet of its own.
+        "isnad_matn_split",
     }
 )
 

--- a/tests/test_parse/test_sanadset_parser.py
+++ b/tests/test_parse/test_sanadset_parser.py
@@ -146,6 +146,57 @@ class TestSanadsetParser:
         # Row 1 has 2 narrators, row 2 has 3, row 3 (No SANAD) has 0 => 5 total
         assert table.num_rows == 5
 
+    def test_matn_embedded_isnad_recovered(self, tmp_path: Path) -> None:
+        """da#366: a "No SANAD" row whose matn carries an isnad is recovered.
+
+        Row 1 (embedded isnad) → ``isnad_raw_ar`` recovered, matn reduced to the
+        residual body, 3 mentions. Row 2 (pure matn) stays chainless — the
+        splitter fails closed, exactly as the NER fallback must never do.
+        """
+        raw_dir = tmp_path / "raw" / "sanadset"
+        raw_dir.mkdir(parents=True)
+        staging_dir = tmp_path / "staging"
+
+        header = "Hadith,Book,Num_hadith,grade"
+        embedded = (
+            "<SANAD>No SANAD</SANAD><MATN>حدثنا مالك عن نافع عن ابن عمر أن "
+            "رسول الله صلى الله عليه وسلم نهى عن بيع الغرر</MATN>"
+        )
+        pure_matn = "<SANAD>No SANAD</SANAD><MATN>بعض المتن بلا إسناد</MATN>"
+        lines = [
+            header,
+            f'"{embedded}",{_BOOK_BUKHARI},1,Sahih',
+            f'"{pure_matn}",{_BOOK_BUKHARI},2,Hasan',
+        ]
+        (raw_dir / "hadiths.csv").write_text("\n".join(lines), encoding="utf-8")
+
+        with patch("src.parse.sanadset.get_settings") as mock_settings:
+            mock_settings.return_value.data_raw_dir = tmp_path / "raw"
+            mock_settings.return_value.data_staging_dir = staging_dir
+            parse_sanadset(raw_dir=raw_dir, staging_dir=staging_dir)
+
+        hadiths = pq.read_table(staging_dir / "hadiths_sanadset.parquet").to_pylist()
+        by_num = {h["hadith_number"]: h for h in hadiths}
+
+        recovered = by_num[1]
+        assert recovered["isnad_raw_ar"] == "حدثنا مالك عن نافع عن ابن عمر"
+        # The isnad text is moved out of matn_ar into isnad_raw_ar; the residual
+        # matn remains, and full_text_ar is preserved verbatim.
+        assert recovered["matn_ar"].startswith("أن رسول الله")
+        assert "حدثنا مالك" not in (recovered["matn_ar"] or "")
+        assert "حدثنا مالك" in recovered["full_text_ar"]
+
+        # The pure-matn "No SANAD" row is not "recovered" into a fake chain.
+        assert by_num[2]["isnad_raw_ar"] is None
+
+        mentions = pq.read_table(staging_dir / "narrator_mentions_sanadset.parquet").to_pylist()
+        hid = recovered["source_id"]
+        recovered_mentions = [m for m in mentions if m["source_hadith_id"] == hid]
+        assert [m["position_in_chain"] for m in recovered_mentions] == [0, 1, 2]
+        assert all(m["chain_index"] == 0 for m in recovered_mentions)
+        # No recovered narrator carries matn (the Prophet-formula token ``رسول``).
+        assert all("رسول" not in (m["name_ar"] or "") for m in recovered_mentions)
+
     def test_position_in_chain_sequential(self, tmp_path: Path) -> None:
         raw_dir = tmp_path / "raw" / "sanadset"
         raw_dir.mkdir(parents=True)

--- a/tests/test_resolve/test_contextual_disambiguation.py
+++ b/tests/test_resolve/test_contextual_disambiguation.py
@@ -1,0 +1,342 @@
+"""Tests for src.resolve.contextual_disambiguation — da#346 isnad-neighbour peel.
+
+The load-bearing property (feedback_silent_zero_is_not_a_measurement /
+feedback_drop_gate_bidirectional_ab): the peel is driven by a hand-verified signature
+seed, and the instrument MUST SEPARATE the classes — a signature fires on the genuine
+multi-referent mentions it names (bare ʿAbd Allāh ⟵Prophet ⟶Nāfiʿ ⇒ Ibn ʿUmar) and does
+NOT fire on the residual (a different ʿAbd Allāh) or on a partial-match (only one role).
+An unknown or ambiguous (≥2-signature) neighbour pair is never peeled; it stays on the
+bare primary, which over_merged_flag keeps flagged. Coverage:
+
+* signature loading + validation (an unconstrained signature is a hard error);
+* ``ContextualSignature.matches`` / ``match_signature`` role logic + ambiguity guard;
+* ``neighbour_pair_coverage`` blast-radius tally;
+* end-to-end stage over parquet fixtures — instrument separation (peel the matched class,
+  leave the control class AND the partial-match), residual stays, primary count reduced,
+  coverage report emitted, empty-seed / absent-primary no-op, and idempotence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
+from src.resolve.contextual_disambiguation import (
+    ContextualSignature,
+    apply_contextual_disambiguation,
+    load_contextual_signatures,
+    match_signature,
+    neighbour_pair_coverage,
+)
+from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
+from src.utils.arabic import normalize_arabic
+
+_ABDALLAH = normalize_arabic("عبد الله")
+_PROPHET = normalize_arabic("رسول الله")
+_NAFI = normalize_arabic("نافع")
+_ZUHRI = normalize_arabic("الزهري")
+_MALIK = normalize_arabic("مالك")
+
+_IBN_UMAR_SIG = ContextualSignature(
+    name_ar="عبد الله",
+    teacher_ar="رسول الله",
+    student_ar="نافع",
+    discriminator="ctx:ibn-umar",
+    name_en="Abd Allah ibn Umar",
+    note="Prophet -> Ibn Umar -> Nafi textbook isnad; hand-verified.",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Pure signature / match / coverage logic
+# --------------------------------------------------------------------------- #
+def test_signature_matches_requires_every_constrained_role() -> None:
+    both = _IBN_UMAR_SIG
+    assert both.matches(frozenset({_PROPHET}), frozenset({_NAFI})) is True
+    # Partial: teacher matches but student does not -> no match (both roles required).
+    assert both.matches(frozenset({_PROPHET}), frozenset({_MALIK})) is False
+    assert both.matches(frozenset({_ZUHRI}), frozenset({_NAFI})) is False
+    # Empty neighbour context never matches a constrained signature.
+    assert both.matches(frozenset(), frozenset()) is False
+
+
+def test_signature_single_role_matches_on_that_role_only() -> None:
+    teacher_only = ContextualSignature(
+        name_ar="عبد الله",
+        teacher_ar="رسول الله",
+        student_ar=None,
+        discriminator="ctx:t",
+        name_en=None,
+        note="n",
+    )
+    assert teacher_only.matches(frozenset({_PROPHET}), frozenset()) is True
+    assert teacher_only.matches(frozenset({_ZUHRI}), frozenset({_PROPHET})) is False
+
+
+def test_match_signature_zero_and_ambiguous_return_none() -> None:
+    teacher_only = ContextualSignature(
+        name_ar="عبد الله",
+        teacher_ar="رسول الله",
+        student_ar=None,
+        discriminator="ctx:t",
+        name_en=None,
+        note="n",
+    )
+    student_only = ContextualSignature(
+        name_ar="عبد الله",
+        teacher_ar=None,
+        student_ar="نافع",
+        discriminator="ctx:s",
+        name_en=None,
+        note="n",
+    )
+    sigs = [teacher_only, student_only]
+    # Exactly one matches -> that one.
+    assert match_signature(frozenset({_PROPHET}), frozenset({_MALIK}), sigs) is teacher_only
+    # Zero match -> None.
+    assert match_signature(frozenset({_ZUHRI}), frozenset({_MALIK}), sigs) is None
+    # BOTH match (ambiguous) -> None (never guess between curated referents).
+    assert match_signature(frozenset({_PROPHET}), frozenset({_NAFI}), sigs) is None
+
+
+def test_neighbour_pair_coverage_tally() -> None:
+    neighbours = {
+        "m1": (frozenset({_PROPHET}), frozenset({_NAFI})),  # matches Ibn Umar
+        "m2": (frozenset({_PROPHET}), frozenset({_MALIK})),  # partial, no match
+        "m3": (frozenset(), frozenset()),  # no neighbour at all
+        "m4": (frozenset({_ZUHRI}), frozenset()),  # teacher only, no match
+    }
+    cov = neighbour_pair_coverage(
+        _ABDALLAH, make_canonical_id(_ABDALLAH), neighbours, [_IBN_UMAR_SIG]
+    )
+    assert cov.total_mentions == 4
+    assert cov.with_any_neighbour == 3
+    assert cov.with_teacher == 3
+    assert cov.with_student == 2
+    assert cov.signature_matched == 1
+    assert cov.ambiguous_multimatch == 0
+
+
+def test_load_signatures_validation(tmp_path: Path) -> None:
+    assert load_contextual_signatures(tmp_path / "absent.yaml") == ()
+    good = tmp_path / "good.yaml"
+    good.write_text(
+        "signatures:\n"
+        '  - name_ar: "عبد الله"\n'
+        '    teacher_ar: "رسول الله"\n'
+        '    student_ar: "نافع"\n'
+        '    discriminator: "ctx:ibn-umar"\n'
+        '    note: "hand-verified"\n',
+        encoding="utf-8",
+    )
+    sigs = load_contextual_signatures(good)
+    assert len(sigs) == 1 and sigs[0].discriminator == "ctx:ibn-umar"
+
+    unconstrained = tmp_path / "bad.yaml"
+    unconstrained.write_text(
+        'signatures:\n  - name_ar: "عبد الله"\n    discriminator: "d"\n    note: "n"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="teacher_ar and/or student_ar"):
+        load_contextual_signatures(unconstrained)
+
+
+def test_ships_seed_is_loadable_and_bidirectionally_correct() -> None:
+    """The shipped seed loads, and its Ibn ʿUmar signature fires on the golden chain
+    while NOT firing on a genuine other-ʿAbd-Allāh pair (instrument separation)."""
+    sigs = load_contextual_signatures()
+    assert len(sigs) >= 1
+    ibn_umar = next(s for s in sigs if s.discriminator == "ctx:ibn-umar")
+    # Fires on Prophet -> Nafi (the multi-referent class it names)…
+    assert ibn_umar.matches(frozenset({_PROPHET}), frozenset({_NAFI})) is True
+    # …and does NOT fire on a different pair (the control class stays whole).
+    assert ibn_umar.matches(frozenset({_ZUHRI}), frozenset({_MALIK})) is False
+
+
+# --------------------------------------------------------------------------- #
+# Stage — apply_contextual_disambiguation over parquet fixtures
+# --------------------------------------------------------------------------- #
+def _canonical_row(cid: str, name_norm: str, mention_count: int, **over: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {f.name: None for f in NARRATORS_CANONICAL_SCHEMA}
+    base["canonical_id"] = cid
+    base["name_ar"] = name_norm
+    base["name_ar_normalized"] = name_norm
+    base["mention_count"] = mention_count
+    base["death_date_precision"] = "unknown"
+    base["birth_date_precision"] = "unknown"
+    base.update(over)
+    return base
+
+
+def _mention_row(
+    mention_id: str, hadith_id: str, position: int, cid: str, chain_index: int = 0
+) -> dict[str, Any]:
+    base: dict[str, Any] = {f.name: None for f in NARRATOR_MENTIONS_RESOLVED_SCHEMA}
+    base["mention_id"] = mention_id
+    base["hadith_id"] = hadith_id
+    base["source_corpus"] = "bukhari"
+    base["position_in_chain"] = position
+    base["canonical_narrator_id"] = cid
+    base["chain_index"] = chain_index
+    return base
+
+
+def _chain(
+    hid: str, teacher_id: str, cand_id: str, student_id: str, tag: str
+) -> list[dict[str, Any]]:
+    """A 3-narrator isnad: teacher (pos0) -> candidate (pos1) -> student (pos2)."""
+    return [
+        _mention_row(f"{tag}-t", hid, 0, teacher_id),
+        _mention_row(f"{tag}-c", hid, 1, cand_id),
+        _mention_row(f"{tag}-s", hid, 2, student_id),
+    ]
+
+
+def _write(out: Path, canonical: list[dict[str, Any]], mentions: list[dict[str, Any]]) -> None:
+    out.mkdir(parents=True, exist_ok=True)
+    c_arrays = {f.name: [r[f.name] for r in canonical] for f in NARRATORS_CANONICAL_SCHEMA}
+    pq.write_table(
+        pa.table(c_arrays, schema=NARRATORS_CANONICAL_SCHEMA), out / "narrators_canonical.parquet"
+    )
+    m_arrays = {f.name: [r[f.name] for r in mentions] for f in NARRATOR_MENTIONS_RESOLVED_SCHEMA}
+    pq.write_table(
+        pa.table(m_arrays, schema=NARRATOR_MENTIONS_RESOLVED_SCHEMA),
+        out / "narrator_mentions_resolved.parquet",
+    )
+
+
+def _seed(tmp_path: Path) -> Path:
+    p = tmp_path / "sig.yaml"
+    p.write_text(
+        "signatures:\n"
+        '  - name_ar: "عبد الله"\n'
+        '    teacher_ar: "رسول الله"\n'
+        '    student_ar: "نافع"\n'
+        '    name_en: "Abd Allah ibn Umar"\n'
+        '    discriminator: "ctx:ibn-umar"\n'
+        '    note: "hand-verified golden chain"\n',
+        encoding="utf-8",
+    )
+    return p
+
+
+def _read_canonical(out: Path) -> dict[str, dict[str, Any]]:
+    return {
+        r["canonical_id"]: r for r in pq.read_table(out / "narrators_canonical.parquet").to_pylist()
+    }
+
+
+def test_stage_peels_matched_class_leaves_control_and_partial(tmp_path: Path) -> None:
+    """Instrument separation: only Prophet->Nafi mentions peel to Ibn ʿUmar; a control
+    (Malik->Zuhri) and a partial-match (Prophet->Malik) both STAY on the bare primary."""
+    out = tmp_path / "curated"
+    bare = make_canonical_id(_ABDALLAH)
+    canonical = [
+        _canonical_row(bare, _ABDALLAH, 5),
+        _canonical_row(
+            make_canonical_id(_PROPHET), _PROPHET, 9, death_year_ah=11, death_date_precision="exact"
+        ),
+        _canonical_row(make_canonical_id(_NAFI), _NAFI, 9),
+        _canonical_row(make_canonical_id(_MALIK), _MALIK, 9),
+        _canonical_row(make_canonical_id(_ZUHRI), _ZUHRI, 9),
+    ]
+    mentions: list[dict[str, Any]] = []
+    # 3 golden-chain mentions (Prophet -> AbdAllah -> Nafi) => Ibn ʿUmar.
+    mentions += _chain("h1", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g1")
+    mentions += _chain("h2", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g2")
+    mentions += _chain("h3", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g3")
+    # 1 partial (Prophet -> AbdAllah -> Malik): teacher matches, student does not.
+    mentions += _chain("h4", make_canonical_id(_PROPHET), bare, make_canonical_id(_MALIK), "p1")
+    # 1 control (Malik -> AbdAllah -> Zuhri): a different ʿAbd Allāh, no role matches.
+    mentions += _chain("h5", make_canonical_id(_MALIK), bare, make_canonical_id(_ZUHRI), "c1")
+    _write(out, canonical, mentions)
+
+    result = apply_contextual_disambiguation(out, seed_path=_seed(tmp_path))
+    assert result is not None
+
+    by_id = _read_canonical(out)
+    target = make_discriminated_canonical_id(_ABDALLAH, "ctx:ibn-umar")
+    # The Ibn ʿUmar node was minted with exactly the 3 golden-chain mentions.
+    assert target in by_id
+    assert by_id[target]["mention_count"] == 3
+    assert by_id[target]["name_en"] == "Abd Allah ibn Umar"
+    assert by_id[target]["over_merged"] is False
+    # Primary reduced by 3 (5 recorded - 3 peeled = 2); partial + control stay.
+    assert by_id[bare]["mention_count"] == 2
+
+    m = {
+        r["mention_id"]: r
+        for r in pq.read_table(out / "narrator_mentions_resolved.parquet").to_pylist()
+    }
+    assert m["g1-c"]["canonical_narrator_id"] == target
+    assert m["g2-c"]["canonical_narrator_id"] == target
+    assert m["p1-c"]["canonical_narrator_id"] == bare  # partial NOT peeled
+    assert m["c1-c"]["canonical_narrator_id"] == bare  # control NOT peeled
+
+    # Coverage (blast-radius) report emitted with the right tally.
+    cov = {
+        r["primary_id"]: r for r in pq.read_table(out / "contextual_coverage.parquet").to_pylist()
+    }
+    assert cov[bare]["total_mentions"] == 5
+    assert cov[bare]["signature_matched"] == 3
+    assert cov[bare]["with_any_neighbour"] == 5
+
+    # Audit report: one row per peeled target.
+    audit = pq.read_table(out / "contextual_splits.parquet").to_pylist()
+    assert len(audit) == 1 and audit[0]["new_id"] == target and audit[0]["mention_count"] == 3
+
+
+def test_stage_idempotent(tmp_path: Path) -> None:
+    out = tmp_path / "curated"
+    bare = make_canonical_id(_ABDALLAH)
+    canonical = [
+        _canonical_row(bare, _ABDALLAH, 3),
+        _canonical_row(make_canonical_id(_PROPHET), _PROPHET, 5),
+        _canonical_row(make_canonical_id(_NAFI), _NAFI, 5),
+    ]
+    mentions = _chain("h1", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g1")
+    mentions += _chain("h2", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g2")
+    _write(out, canonical, mentions)
+    seed = _seed(tmp_path)
+
+    assert apply_contextual_disambiguation(out, seed_path=seed) is not None
+    first_c = pq.read_table(out / "narrators_canonical.parquet").to_pylist()
+    first_m = pq.read_table(out / "narrator_mentions_resolved.parquet").to_pylist()
+    # Second run: peeled mentions now point at the Ibn ʿUmar id, residual matches nothing.
+    assert apply_contextual_disambiguation(out, seed_path=seed) is None
+    assert pq.read_table(out / "narrators_canonical.parquet").to_pylist() == first_c
+    assert pq.read_table(out / "narrator_mentions_resolved.parquet").to_pylist() == first_m
+
+
+def test_stage_empty_seed_is_noop(tmp_path: Path) -> None:
+    out = tmp_path / "curated"
+    bare = make_canonical_id(_ABDALLAH)
+    _write(
+        out,
+        [_canonical_row(bare, _ABDALLAH, 3)],
+        _chain("h1", make_canonical_id(_PROPHET), bare, make_canonical_id(_NAFI), "g1"),
+    )
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("signatures: []\n", encoding="utf-8")
+    assert apply_contextual_disambiguation(out, seed_path=empty) is None
+    assert not (out / "contextual_coverage.parquet").exists()
+
+
+def test_stage_absent_primary_is_noop(tmp_path: Path) -> None:
+    """A seed whose bare name is not in the canonical table peels nothing and mints
+    nothing (the over_merged_flag no-fabricate discipline)."""
+    out = tmp_path / "curated"
+    other = make_canonical_id(_ZUHRI)
+    _write(out, [_canonical_row(other, _ZUHRI, 3)], [_mention_row("z", "h1", 0, other)])
+    assert apply_contextual_disambiguation(out, seed_path=_seed(tmp_path)) is None
+
+
+def test_stage_no_canonical_is_noop(tmp_path: Path) -> None:
+    out = tmp_path / "curated"
+    out.mkdir(parents=True, exist_ok=True)
+    assert apply_contextual_disambiguation(out, seed_path=_seed(tmp_path)) is None

--- a/tests/test_resolve/test_contextual_disambiguation.py
+++ b/tests/test_resolve/test_contextual_disambiguation.py
@@ -324,6 +324,19 @@ def test_stage_gappy_chain_still_matches_signature(tmp_path: Path) -> None:
     target = make_discriminated_canonical_id(_ABDALLAH, "ctx:ibn-umar")
     assert m["g-c"]["canonical_narrator_id"] == target  # peeled across both gaps
 
+    # Oyunbileg's point: the old exact-±1 walk under-counted the NAMED blast-radius
+    # measurement, not just the peel. The gappy mention must now be counted as having a
+    # resolvable teacher AND student AND a signature match in contextual_coverage.parquet.
+    cov = {
+        r["primary_id"]: r for r in pq.read_table(out / "contextual_coverage.parquet").to_pylist()
+    }
+    bare_cov = cov[bare]
+    assert bare_cov["total_mentions"] == 1
+    assert bare_cov["with_any_neighbour"] == 1
+    assert bare_cov["with_teacher"] == 1
+    assert bare_cov["with_student"] == 1
+    assert bare_cov["signature_matched"] == 1
+
 
 def test_stage_idempotent(tmp_path: Path) -> None:
     out = tmp_path / "curated"

--- a/tests/test_resolve/test_contextual_disambiguation.py
+++ b/tests/test_resolve/test_contextual_disambiguation.py
@@ -291,6 +291,40 @@ def test_stage_peels_matched_class_leaves_control_and_partial(tmp_path: Path) ->
     assert len(audit) == 1 and audit[0]["new_id"] == target and audit[0]["mention_count"] == 3
 
 
+def test_stage_gappy_chain_still_matches_signature(tmp_path: Path) -> None:
+    """da#439 shared-helper: a golden chain with dropped interior positions still peels.
+
+    Chain: Prophet(pos0) -> [null pos1] -> ʿAbd Allāh(pos2) -> [null pos3] -> Nāfiʿ(pos4).
+    Under the pre-da#439 exact-``position ± 1`` neighbour read, the candidate at pos2 saw
+    only the (dropped) positions 1 and 3, found neither the Prophet nor Nāfiʿ, and the Ibn
+    ʿUmar signature did NOT fire — silently under-peeling a confident identity. With the
+    shared consecutive-resolved adjacency helper the teacher/student bridge the gaps and
+    the signature matches (GREEN)."""
+    out = tmp_path / "curated"
+    bare = make_canonical_id(_ABDALLAH)
+    canonical = [
+        _canonical_row(bare, _ABDALLAH, 1),
+        _canonical_row(make_canonical_id(_PROPHET), _PROPHET, 5),
+        _canonical_row(make_canonical_id(_NAFI), _NAFI, 5),
+    ]
+    mentions = [
+        _mention_row("g-t", "h1", 0, make_canonical_id(_PROPHET)),
+        _mention_row("g-x1", "h1", 1, None),  # unresolved → dropped from chains
+        _mention_row("g-c", "h1", 2, bare),
+        _mention_row("g-x3", "h1", 3, None),  # unresolved → dropped
+        _mention_row("g-s", "h1", 4, make_canonical_id(_NAFI)),
+    ]
+    _write(out, canonical, mentions)
+
+    assert apply_contextual_disambiguation(out, seed_path=_seed(tmp_path)) is not None
+    m = {
+        r["mention_id"]: r
+        for r in pq.read_table(out / "narrator_mentions_resolved.parquet").to_pylist()
+    }
+    target = make_discriminated_canonical_id(_ABDALLAH, "ctx:ibn-umar")
+    assert m["g-c"]["canonical_narrator_id"] == target  # peeled across both gaps
+
+
 def test_stage_idempotent(tmp_path: Path) -> None:
     out = tmp_path / "curated"
     bare = make_canonical_id(_ABDALLAH)

--- a/tests/test_resolve/test_narrator_split.py
+++ b/tests/test_resolve/test_narrator_split.py
@@ -23,7 +23,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
-from src.models.enums import DatePrecision
+from src.models.enums import DatePrecision, NarratorGeneration
 from src.parse.identity import make_canonical_id, make_discriminated_canonical_id
 from src.resolve import MissingInputError
 from src.resolve.generic_name import is_generic_name
@@ -35,6 +35,7 @@ from src.resolve.narrator_split import (
     DatableMention,
     _band_midpoint,
     _cut_bands,
+    _generation_for_year,
     plan_split,
     split_generic_narrators,
 )
@@ -127,8 +128,11 @@ def test_removed_gate3_separation_is_dead_code() -> None:
     #     they do their adjacent midpoints are always > SPLIT_BAND_GAP apart (never <=50);
     #   * the only two outcomes are a single-band abstain (Gate 1) or a clean split —
     #     a separation-based abstain never occurs.
+    # Both bands are held inside the ṭabaqa window (120..400) so the da#452 Gate 0
+    # coherence prune never fires here — an out-of-window separation is Gate 0's domain,
+    # covered by test_gate0_out_of_window_band_abstains_no_phantom_twin, not this sweep.
     n = SPLIT_MIN_SUPPORT + 5
-    for sep in range(0, 301):
+    for sep in range(0, 281):
         datable = _dm(120, n, "early") + _dm(120 + sep, n, "late")
         qual = [b for b in _cut_bands(datable) if len(b) >= SPLIT_MIN_SUPPORT]
         plan = plan_split(_ABU_ABDALLAH, datable)
@@ -139,6 +143,39 @@ def test_removed_gate3_separation_is_dead_code() -> None:
             assert plan.is_split  # two well-supported separated bands always peel
         else:
             assert not plan.is_split  # collapsed to one band → Gate 1 abstain
+
+
+def test_gate0_out_of_window_band_abstains_no_phantom_twin() -> None:
+    # da#452 — instrument separation (out-of-window side): a big in-window band (d.150)
+    # plus a well-supported band whose midpoint is impossibly late (d.600, outside every
+    # ṭabaqa window → NarratorGeneration.UNKNOWN). WITHOUT Gate 0 this splits and mints a
+    # phantom twin dated 600 AH with gen=unknown (the da#452 defect). WITH Gate 0 the
+    # incoherent band is dropped, leaving one qualifying band → Gate 1 abstains → the node
+    # stays whole and NO phantom twin is minted (its mentions stay on the primary).
+    assert _generation_for_year(600) is NarratorGeneration.UNKNOWN  # the fixture is real
+    datable = _dm(150, 30, "early") + _dm(600, 15, "late")
+    plan = plan_split(_ABU_ABDALLAH, datable)
+    assert not plan.is_split
+    # And no peeled band could ever carry an UNKNOWN-generation midpoint.
+    assert all(
+        _generation_for_year(b.midpoint_ah) is not NarratorGeneration.UNKNOWN for b in plan.peeled
+    )
+
+
+def test_gate0_in_window_later_band_still_peels() -> None:
+    # da#452 — instrument separation (in-window side): the gate must NOT false-abstain a
+    # genuine late-but-plausible narrator. A big band (d.150) + an in-window LATER band
+    # (d.340 ∈ the 280–400 window) → still splits, peeling the d.340 band onto its own
+    # node with a REAL generation (never unknown). Pairs with the out-of-window test above
+    # to prove the gate separates the coherent from the incoherent late band.
+    assert _generation_for_year(340) is NarratorGeneration.LATER
+    datable = _dm(150, 30, "early") + _dm(340, 15, "late")
+    plan = plan_split(_ABU_ABDALLAH, datable)
+    assert plan.is_split
+    assert len(plan.peeled) == 1
+    band = plan.peeled[0]
+    assert band.midpoint_ah == 340
+    assert _generation_for_year(band.midpoint_ah) is NarratorGeneration.LATER
 
 
 def test_same_band_label_collision_tiebreak_by_anchor() -> None:

--- a/tests/test_resolve/test_narrator_split.py
+++ b/tests/test_resolve/test_narrator_split.py
@@ -6,7 +6,8 @@ the recall-first ``is_generic_name`` screen admits genuinely-single people
 evidence — ≥2 well-separated, well-supported bands — never on the screen alone. A
 single-band name abstains and its node is left whole. Coverage:
 
-* pure ``plan_split`` band logic (abstain vs peel, every gate);
+* pure ``plan_split`` band logic (abstain vs peel, both live gates — Gate 1 single-band
+  and Gate 2 too-many-bands; the old Gate 3 separation guard was dead code, removed da#444);
 * the ``سفيان الثوري`` case Ivana flagged — screens IN, death-band gate ABSTAINS;
 * end-to-end stage over parquet fixtures — peel-not-partition, undatable remainder
   stays, registered-mononym deferral, remap correctness, idempotence, and a
@@ -28,9 +29,12 @@ from src.resolve import MissingInputError
 from src.resolve.generic_name import is_generic_name
 from src.resolve.narrator_split import (
     MID_GAP,
+    SPLIT_BAND_GAP,
     SPLIT_MAX_CLUSTERS,
     SPLIT_MIN_SUPPORT,
     DatableMention,
+    _band_midpoint,
+    _cut_bands,
     plan_split,
     split_generic_narrators,
 )
@@ -111,6 +115,30 @@ def test_within_band_gap_estimates_stay_one_band() -> None:
     # ordinary within-person estimate scatter must not fragment a node.
     datable = _dm(200, 15) + _dm(240, 15, "b2")
     assert not plan_split(_ABU_ABDALLAH, datable).is_split
+
+
+def test_removed_gate3_separation_is_dead_code() -> None:
+    # da#444: the old Gate 3 (`SPLIT_MIN_SEPARATION = 50`, "adjacent qualifying midpoints
+    # too close ⇒ abstain") was structurally unreachable and is removed. `_cut_bands`
+    # starts a new band only on a consecutive gap > SPLIT_BAND_GAP (80 AH), so ANY two
+    # bands it emits are already > 80 AH apart — well beyond any <=50 contemporaries
+    # threshold. Sweep two well-supported bands across every separation 0..300 and assert:
+    #   * two bands ever form only when the requested separation > SPLIT_BAND_GAP, and when
+    #     they do their adjacent midpoints are always > SPLIT_BAND_GAP apart (never <=50);
+    #   * the only two outcomes are a single-band abstain (Gate 1) or a clean split —
+    #     a separation-based abstain never occurs.
+    n = SPLIT_MIN_SUPPORT + 5
+    for sep in range(0, 301):
+        datable = _dm(120, n, "early") + _dm(120 + sep, n, "late")
+        qual = [b for b in _cut_bands(datable) if len(b) >= SPLIT_MIN_SUPPORT]
+        plan = plan_split(_ABU_ABDALLAH, datable)
+        if len(qual) >= 2:
+            mids = sorted(_band_midpoint(b) for b in qual)
+            adj = min(b - a for a, b in zip(mids, mids[1:], strict=False))
+            assert adj > SPLIT_BAND_GAP  # never in the removed gate's <=50 range
+            assert plan.is_split  # two well-supported separated bands always peel
+        else:
+            assert not plan.is_split  # collapsed to one band → Gate 1 abstain
 
 
 def test_same_band_label_collision_tiebreak_by_anchor() -> None:

--- a/tests/test_resolve/test_narrator_split.py
+++ b/tests/test_resolve/test_narrator_split.py
@@ -611,3 +611,103 @@ def test_multi_isnad_no_cross_chain_neighbour(tmp_path: Path) -> None:
     # …with no cross-chain leak in either direction (the load-bearing assertion).
     assert not (set(by_mention["m-c-0"].anchor_names) & chain1_anchors)
     assert not (set(by_mention["m-c-1"].anchor_names) & chain0_anchors)
+
+
+def test_gappy_chain_datable_across_dropped_position(tmp_path: Path) -> None:
+    """da#439: a position gap (from a dropped unresolved mention) must NOT hide a neighbour.
+
+    Chain positions 0..4, but positions 1 and 3 are **unresolved** (null
+    ``canonical_narrator_id``) and so are dropped from ``chains`` in
+    ``_build_chain_index``. The candidate sits at position 2; its only resolved
+    neighbours are the teacher at position 0 and the student at position 4 — each two
+    positions away.
+
+    The loader (``load_edges._build_chain_pairs``) pairs *consecutive resolved*
+    mentions, so it emits ``teacher -> candidate`` and ``candidate -> student`` across
+    those gaps. The old exact-``position ± 1`` window looked only at positions 1 and 3
+    (both dropped), found nothing, and left the candidate **undatable** — a systematic
+    under-count relative to the loaded graph (RED). Reading the immediate resolved
+    neighbours in the position-sorted chain recovers both adjacencies (GREEN).
+    """
+    from src.resolve.narrator_split import _build_chain_index, _collect_datable
+
+    cand = make_canonical_id(_ABU_ABDALLAH)
+    teacher = _anchor_row("nar:teacher", 100)  # pos 0 → dies earlier → sign +1
+    student = _anchor_row("nar:student", 180)  # pos 4 → dies later → sign −1
+    canonical = [_canonical_row(cand, _ABU_ABDALLAH, 1), teacher, student]
+    mentions = [
+        _mention_row("m-teacher", "h1", 0, "nar:teacher", chain_index=0),
+        _mention_row("m-gap1", "h1", 1, None, chain_index=0),  # unresolved → dropped
+        _mention_row("m-cand", "h1", 2, cand, chain_index=0),
+        _mention_row("m-gap3", "h1", 3, None, chain_index=0),  # unresolved → dropped
+        _mention_row("m-student", "h1", 4, "nar:student", chain_index=0),
+    ]
+    out = tmp_path / "curated"
+    _write(out, canonical, mentions)
+
+    attested_by_id = {r["canonical_id"]: r["death_year_ah"] for r in (teacher, student)}
+    name_by_id = {r["canonical_id"]: r["name_ar_normalized"] for r in canonical}
+
+    chains, candidate_mentions = _build_chain_index(
+        out / "narrator_mentions_resolved.parquet", {cand}
+    )
+    datable = _collect_datable(candidate_mentions[cand], chains, attested_by_id, name_by_id)
+
+    # The candidate is datable ACROSS the gaps — the exact-±1 window would have left
+    # `datable` empty (the divergence da#439 fixes).
+    assert len(datable) == 1
+    dm = datable[0]
+    assert set(dm.anchor_names) == {
+        name_by_id["nar:teacher"],
+        name_by_id["nar:student"],
+    }
+    # Estimate folds both neighbours with the loader-consistent sign convention:
+    # teacher (earlier position) + MID_GAP, student (later position) − MID_GAP.
+    assert dm.estimate == round(((100 + MID_GAP) + (180 - MID_GAP)) / 2)
+
+
+def test_split_adjacency_matches_loader_transmitted_to(tmp_path: Path) -> None:
+    """da#439: the split's neighbour set == the loader's TRANSMITTED_TO edges (same chain).
+
+    The reconciliation this issue asks for is *agreement* between two definitions of
+    "adjacent". This test runs BOTH on the same gappy fixture and asserts the candidate's
+    splitter neighbours are exactly the narrators the loader connects it to — the
+    cross-function invariant, not just a splitter-internal fixture.
+    """
+    from src.graph.load_edges import _build_chain_pairs
+    from src.resolve.narrator_split import _build_chain_index, _collect_datable
+
+    cand = make_canonical_id(_ABU_ABDALLAH)
+    teacher = _anchor_row("nar:teacher", 100)
+    student = _anchor_row("nar:student", 180)
+    canonical = [_canonical_row(cand, _ABU_ABDALLAH, 1), teacher, student]
+    # Same single (hadith_id, chain_index) chain with two interior gaps.
+    mention_rows = [
+        _mention_row("m-teacher", "hdt:bukhari:1", 0, "nar:teacher", chain_index=0),
+        _mention_row("m-gap1", "hdt:bukhari:1", 1, None, chain_index=0),
+        _mention_row("m-cand", "hdt:bukhari:1", 2, cand, chain_index=0),
+        _mention_row("m-gap3", "hdt:bukhari:1", 3, None, chain_index=0),
+        _mention_row("m-student", "hdt:bukhari:1", 4, "nar:student", chain_index=0),
+    ]
+    out = tmp_path / "curated"
+    _write(out, canonical, mention_rows)
+
+    # Loader side: TRANSMITTED_TO edges incident to the candidate → the other endpoints.
+    loader_pairs = _build_chain_pairs(mention_rows)
+    loader_neighbours = {p["to_id"] for p in loader_pairs if p["from_id"] == cand} | {
+        p["from_id"] for p in loader_pairs if p["to_id"] == cand
+    }
+    assert loader_neighbours == {"nar:teacher", "nar:student"}
+
+    # Splitter side: the anchors it derived for the candidate, mapped back to ids.
+    attested_by_id = {r["canonical_id"]: r["death_year_ah"] for r in (teacher, student)}
+    name_by_id = {r["canonical_id"]: r["name_ar_normalized"] for r in canonical}
+    id_by_name = {v: k for k, v in name_by_id.items()}
+    chains, candidate_mentions = _build_chain_index(
+        out / "narrator_mentions_resolved.parquet", {cand}
+    )
+    datable = _collect_datable(candidate_mentions[cand], chains, attested_by_id, name_by_id)
+    split_neighbours = {id_by_name[n] for d in datable for n in d.anchor_names}
+
+    # The two notions of adjacency AGREE (the da#439 invariant).
+    assert split_neighbours == loader_neighbours

--- a/tests/test_resolve/test_narrator_unify.py
+++ b/tests/test_resolve/test_narrator_unify.py
@@ -1,0 +1,256 @@
+"""Tests for src.resolve.narrator_unify — the da#431/da#347 curated under-merge fix.
+
+The load-bearing test is the **bidirectional acceptance gate**
+(:class:`TestBidirectionalAcceptance`): a golden group of surface forms that are ONE
+person MUST merge onto a single survivor bearing the summed mentions and the
+biography, and every distinct-narrator control MUST NOT be swept in. The exclude
+direction is sacred — merging two distinct narrators is the da#423 failure that
+deleted the Prophet's daughter/son/Abū Bakr, each time with green CI. This mechanism
+supplies curated external evidence to bypass fuzzy_cluster's precision guard ONLY for
+the golden set; the gate (over-merge exclusion, corroborated-death veto, gross-spread
+sanity band, gender veto, in-corpus evidence) refuses any group that fails, so a
+curation error cannot silently over-merge.
+
+Synthetic-only: no real corpus. The Arabic surfaces mirror the real Abū Wāʾil cluster
+(da#431) so the golden case exercises the true kunya↔ism↔bio topology, but every row
+is fabricated here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.resolve import narrator_unify as nu
+from src.resolve.schemas import (
+    NARRATOR_MENTIONS_RESOLVED_SCHEMA,
+    NARRATORS_CANONICAL_SCHEMA,
+)
+
+# --- Synthetic canonical rows (the real Abū Wāʾil cluster shape, fabricated) ----------
+
+_KUNYA = "ابو واءل"
+_ISM = "شقيق بن سلمه"
+_BRIDGE = "ابو واءل شقيق بن سلمه"  # in-corpus full name carrying BOTH kunya and ism
+_BIO = "شقيق ابو واءل بن سلمه الاسدي"  # rijāl bio node, 0 mentions
+_BARE_SHAQIQ = "شقيق"  # a DIFFERENT Shaqīq (d.200) — must never merge in
+
+
+def _canon(
+    cid: str,
+    norm: str,
+    *,
+    mc: int,
+    death: int | None = None,
+    prov: str | None = None,
+    gender: str | None = None,
+    corpus: str = "itqan",
+) -> dict[str, Any]:
+    row: dict[str, Any] = {f.name: None for f in NARRATORS_CANONICAL_SCHEMA}
+    row.update(
+        canonical_id=cid,
+        name_ar=norm,
+        name_ar_normalized=norm,
+        aliases=[],
+        death_year_ah=death,
+        death_year_provenance=prov,
+        gender=gender,
+        mention_count=mc,
+        source_ids=[f"{corpus}:x:{cid}"],
+        source_corpus=corpus,
+        source_corpora=[corpus],
+    )
+    return row
+
+
+def _write_canonical(output_dir: Path, rows: list[dict[str, Any]]) -> None:
+    arrays = {f.name: [r.get(f.name) for r in rows] for f in NARRATORS_CANONICAL_SCHEMA}
+    pq.write_table(
+        pa.table(arrays, schema=NARRATORS_CANONICAL_SCHEMA),
+        output_dir / "narrators_canonical.parquet",
+    )
+
+
+def _write_mentions(output_dir: Path, pairs: list[tuple[str, str]]) -> None:
+    """pairs = (mention_id, canonical_narrator_id)."""
+    n = len(pairs)
+    tbl = pa.table(
+        {
+            "mention_id": [m for m, _ in pairs],
+            "hadith_id": [f"hdt:x:{i}" for i in range(n)],
+            "source_corpus": ["itqan"] * n,
+            "position_in_chain": [0] * n,
+            "chain_index": [0] * n,
+            "name_raw": [None] * n,
+            "name_normalized": [None] * n,
+            "canonical_narrator_id": [c for _, c in pairs],
+            "transmission_method": [None] * n,
+            "confidence": [None] * n,
+        },
+        schema=NARRATOR_MENTIONS_RESOLVED_SCHEMA,
+    )
+    pq.write_table(tbl, output_dir / "narrator_mentions_resolved.parquet")
+
+
+def _abu_wail_rows() -> list[dict[str, Any]]:
+    return [
+        _canon("nar:kunya", _KUNYA, mc=3117),  # holds the mentions, no bio
+        _canon("nar:ism", _ISM, mc=364, death=82, gender="male"),  # ism+nasab
+        _canon("nar:bridge", _BRIDGE, mc=58),  # bridging full name
+        _canon("nar:bio", _BIO, mc=0, death=81),  # rijāl bio, 0 mentions
+    ]
+
+
+def _seed(tmp_path: Path, *, members: list[str]) -> Path:
+    lines = [
+        "unify:",
+        '  - primary_label: "Abū Wāʾil (test)"',
+        '    issue: "da#431"',
+        "    evidence: bio_kunya_ism_bridge",
+        f'    kunya_norm: "{_KUNYA}"',
+        f'    ism_norm: "{_ISM}"',
+        '    note: "synthetic test group"',
+        "    members:",
+        *[f'      - "{m}"' for m in members],
+    ]
+    path = tmp_path / "seed.yaml"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+# --- Golden: the merge MUST happen -----------------------------------------------------
+
+
+class TestGoldenMerge:
+    def test_kunya_ism_bio_merge_into_one(self, tmp_path: Path) -> None:
+        out = tmp_path
+        _write_canonical(out, _abu_wail_rows())
+        _write_mentions(
+            out,
+            [("m1", "nar:kunya"), ("m2", "nar:kunya"), ("m3", "nar:ism"), ("m4", "nar:bridge")],
+        )
+        seed = _seed(tmp_path, members=[_KUNYA, _ISM, _BRIDGE, _BIO])
+
+        result = nu.apply_narrator_unification(out, seed_path=seed)
+        assert result is not None
+
+        rows = pq.read_table(out / "narrators_canonical.parquet").to_pylist()
+        # 4 nodes collapse to 1 survivor.
+        assert len(rows) == 1
+        survivor = rows[0]
+        # Mentions summed (3117 + 364 + 58 + 0).
+        assert survivor["mention_count"] == 3117 + 364 + 58 + 0
+        # Biography preserved from the bio/ism members despite the kunya being the rep.
+        assert survivor["death_year_ah"] in (81, 82)
+        # Every absorbed surface survives as an alias — no spelling lost.
+        aliases = set(survivor["aliases"] or [])
+        assert {_ISM, _BRIDGE, _BIO} <= aliases
+        # attestation lifts off "biographical_only" (summed mc > 0).
+        assert survivor["attestation"] == "isnad_attested"
+
+    def test_mentions_remapped_to_survivor(self, tmp_path: Path) -> None:
+        out = tmp_path
+        _write_canonical(out, _abu_wail_rows())
+        _write_mentions(out, [("m1", "nar:kunya"), ("m3", "nar:ism"), ("m4", "nar:bridge")])
+        seed = _seed(tmp_path, members=[_KUNYA, _ISM, _BRIDGE, _BIO])
+
+        nu.apply_narrator_unification(out, seed_path=seed)
+        survivor_id = pq.read_table(out / "narrators_canonical.parquet").to_pylist()[0][
+            "canonical_id"
+        ]
+        mention_ids = set(
+            pq.read_table(out / "narrator_mentions_resolved.parquet")
+            .column("canonical_narrator_id")
+            .to_pylist()
+        )
+        # All mentions now point at the single survivor; no absorbed id remains.
+        assert mention_ids == {survivor_id}
+
+    def test_idempotent_second_run_is_noop(self, tmp_path: Path) -> None:
+        out = tmp_path
+        _write_canonical(out, _abu_wail_rows())
+        _write_mentions(out, [("m1", "nar:kunya"), ("m3", "nar:ism")])
+        seed = _seed(tmp_path, members=[_KUNYA, _ISM, _BRIDGE, _BIO])
+
+        assert nu.apply_narrator_unification(out, seed_path=seed) is not None
+        first = pq.read_table(out / "narrators_canonical.parquet").to_pylist()
+        # Second run: only the survivor matches a member surface -> < 2 nodes -> no-op.
+        assert nu.apply_narrator_unification(out, seed_path=seed) is None
+        second = pq.read_table(out / "narrators_canonical.parquet").to_pylist()
+        assert first == second
+
+
+# --- Bidirectional: the merge MUST NOT happen for a distinct narrator ------------------
+
+
+class TestMustNotMerge:
+    def _run(self, tmp_path: Path, rows: list[dict[str, Any]], members: list[str]) -> Path | None:
+        out = tmp_path
+        _write_canonical(out, rows)
+        _write_mentions(out, [(f"m{i}", r["canonical_id"]) for i, r in enumerate(rows)])
+        seed = _seed(tmp_path, members=members)
+        return nu.apply_narrator_unification(out, seed_path=seed)
+
+    def test_gross_death_spread_refuses_distinct_namesake(self, tmp_path: Path) -> None:
+        # Bare Shaqīq d.200 (a different, taba-tabiʿī person) shares no gross-spread
+        # tolerance with the d.82 Abū Wāʾil cluster: the group is refused wholesale.
+        rows = _abu_wail_rows() + [_canon("nar:bare", _BARE_SHAQIQ, mc=1046, death=200)]
+        assert self._run(tmp_path, rows, [_KUNYA, _ISM, _BRIDGE, _BIO, _BARE_SHAQIQ]) is None
+        # nothing merged: all 5 nodes intact.
+        assert len(pq.read_table(tmp_path / "narrators_canonical.parquet").to_pylist()) == 5
+
+    def test_corroborated_death_conflict_refuses(self, tmp_path: Path) -> None:
+        # Two members with CORROBORATED, conflicting death years within the sanity band
+        # (82 vs 90, both corroborated) — still refused: a corroborated conflict is hard.
+        rows = _abu_wail_rows()
+        rows[1] = _canon("nar:ism", _ISM, mc=364, death=82, prov="corroborated", gender="male")
+        rows.append(_canon("nar:bridge2", _BRIDGE, mc=10, death=90, prov="corroborated"))
+        assert self._run(tmp_path, rows, [_KUNYA, _ISM, _BRIDGE, _BIO]) is None
+
+    def test_over_merged_bare_generic_member_refuses(self, tmp_path: Path) -> None:
+        # A member that is a curated over-merged bare generic (real seed: عبد الله) can
+        # never be a unify member — the whole group is refused.
+        rows = _abu_wail_rows() + [_canon("nar:generic", "عبد الله", mc=17752)]
+        assert self._run(tmp_path, rows, [_KUNYA, _ISM, _BRIDGE, _BIO, "عبد الله"]) is None
+
+    def test_gender_conflict_refuses(self, tmp_path: Path) -> None:
+        rows = _abu_wail_rows()
+        rows[0] = _canon("nar:kunya", _KUNYA, mc=3117, gender="male")
+        rows.append(_canon("nar:fem", _BRIDGE, mc=5, gender="female"))
+        assert self._run(tmp_path, rows, [_KUNYA, _ISM, _BRIDGE, _BIO]) is None
+
+    def test_missing_bridge_is_uncorroborated_and_refuses(self, tmp_path: Path) -> None:
+        # No member spells out BOTH kunya and ism (drop the bridge + bio) -> the
+        # kunya↔ism identity is not attested in-corpus -> refused.
+        rows = [
+            _canon("nar:kunya", _KUNYA, mc=3117),
+            _canon("nar:ism", _ISM, mc=364, death=82),
+        ]
+        assert self._run(tmp_path, rows, [_KUNYA, _ISM]) is None
+
+
+# --- Seed parsing --------------------------------------------------------------------
+
+
+class TestSeedParsing:
+    def test_fewer_than_two_members_rejected(self, tmp_path: Path) -> None:
+        seed = _seed(tmp_path, members=[_KUNYA])
+        with pytest.raises(ValueError, match="2 members"):
+            nu.load_unify_seed(seed)
+
+    def test_bridge_evidence_requires_kunya_and_ism(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text(
+            'unify:\n  - primary_label: "x"\n    evidence: bio_kunya_ism_bridge\n'
+            '    note: "n"\n    members: ["a", "b"]\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="kunya_norm and ism_norm"):
+            nu.load_unify_seed(path)
+
+    def test_missing_seed_file_is_empty(self, tmp_path: Path) -> None:
+        assert nu.load_unify_seed(tmp_path / "nope.yaml") == ()

--- a/tests/test_resolve/test_narrator_unify.py
+++ b/tests/test_resolve/test_narrator_unify.py
@@ -233,6 +233,120 @@ class TestMustNotMerge:
         assert self._run(tmp_path, rows, [_KUNYA, _ISM]) is None
 
 
+# --- da#347: bare-ism ↔ qualified via isnad-neighbour overlap -------------------------
+
+_BARE_ANAS = "انس"
+_QUAL_ANAS = "انس بن مالك"
+
+
+def _write_chain_mentions(output_dir: Path, chains: list[list[str]]) -> None:
+    """Write resolved mentions as isnad sequences (one chain = one ordered id list)."""
+    rows: list[tuple[str, int, int, str]] = []  # (hadith_id, chain_index, position, cid)
+    for ci, chain in enumerate(chains):
+        for pos, cid in enumerate(chain):
+            rows.append((f"hdt:x:{ci}", 0, pos, cid))
+    n = len(rows)
+    tbl = pa.table(
+        {
+            "mention_id": [f"m{i}" for i in range(n)],
+            "hadith_id": [r[0] for r in rows],
+            "source_corpus": ["itqan"] * n,
+            "position_in_chain": [r[2] for r in rows],
+            "chain_index": [r[1] for r in rows],
+            "name_raw": [None] * n,
+            "name_normalized": [None] * n,
+            "canonical_narrator_id": [r[3] for r in rows],
+            "transmission_method": [None] * n,
+            "confidence": [None] * n,
+        },
+        schema=NARRATOR_MENTIONS_RESOLVED_SCHEMA,
+    )
+    pq.write_table(tbl, output_dir / "narrator_mentions_resolved.parquet")
+
+
+def _anas_rows() -> list[dict[str, Any]]:
+    return [
+        _canon("nar:bare_anas", _BARE_ANAS, mc=16951, death=60),  # bare ism, generic d.60
+        _canon("nar:qual_anas", _QUAL_ANAS, mc=17820, death=91, gender="male"),  # survivor
+    ]
+
+
+def _anas_seed(tmp_path: Path, *, min_overlap: float = 0.5, top_k: int = 50) -> Path:
+    lines = [
+        "unify:",
+        '  - primary_label: "Anas b. Mālik (test)"',
+        '    issue: "da#347"',
+        "    evidence: isnad_neighbor_overlap",
+        f'    bare_norm: "{_BARE_ANAS}"',
+        f'    qualified_norm: "{_QUAL_ANAS}"',
+        f"    min_overlap: {min_overlap}",
+        f"    top_k: {top_k}",
+        '    note: "synthetic isnad-overlap group"',
+        "    members:",
+        f'      - "{_BARE_ANAS}"',
+        f'      - "{_QUAL_ANAS}"',
+    ]
+    path = tmp_path / "anas_seed.yaml"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+class TestIsnadOverlapMerge:
+    def test_shared_neighbours_merge(self, tmp_path: Path) -> None:
+        # Both nodes transmit with the same six teachers/students (Anas's canonical
+        # students) -> overlap 1.0 >= 0.5 -> merge into the qualified survivor.
+        teachers = [f"nar:t{i}" for i in range(6)]
+        chains = [[t, "nar:bare_anas"] for t in teachers] + [[t, "nar:qual_anas"] for t in teachers]
+        _write_canonical(tmp_path, _anas_rows())
+        _write_chain_mentions(tmp_path, chains)
+        assert nu.apply_narrator_unification(tmp_path, seed_path=_anas_seed(tmp_path)) is not None
+        rows = pq.read_table(tmp_path / "narrators_canonical.parquet").to_pylist()
+        assert len(rows) == 1
+        survivor = rows[0]
+        assert survivor["mention_count"] == 16951 + 17820
+        # survivor is the QUALIFIED node (higher mention_count) and keeps its dating.
+        assert survivor["name_ar_normalized"] == _QUAL_ANAS
+        assert survivor["death_year_ah"] == 91
+        # every bare mention now points at the survivor; no absorbed bare id remains
+        # (teacher/neighbour nodes are untouched).
+        mids = set(
+            pq.read_table(tmp_path / "narrator_mentions_resolved.parquet")
+            .column("canonical_narrator_id")
+            .to_pylist()
+        )
+        assert "nar:bare_anas" not in mids
+        assert survivor["canonical_id"] in mids
+
+    def test_disjoint_neighbours_refuse_distinct_namesake(self, tmp_path: Path) -> None:
+        # A namesake: the bare node and the qualified node transmit with entirely
+        # different circles -> overlap 0.0 < 0.5 -> refused (the da#423 exclude direction).
+        chains = [[f"nar:a{i}", "nar:bare_anas"] for i in range(6)] + [
+            [f"nar:b{i}", "nar:qual_anas"] for i in range(6)
+        ]
+        _write_canonical(tmp_path, _anas_rows())
+        _write_chain_mentions(tmp_path, chains)
+        assert nu.apply_narrator_unification(tmp_path, seed_path=_anas_seed(tmp_path)) is None
+        assert len(pq.read_table(tmp_path / "narrators_canonical.parquet").to_pylist()) == 2
+
+    def test_no_mentions_file_fails_closed(self, tmp_path: Path) -> None:
+        # No mentions -> no neighbours -> overlap 0.0 -> refused (never merge without the
+        # instrument).
+        _write_canonical(tmp_path, _anas_rows())
+        assert nu.apply_narrator_unification(tmp_path, seed_path=_anas_seed(tmp_path)) is None
+
+    def test_overlap_below_threshold_refuses(self, tmp_path: Path) -> None:
+        # Partial overlap (2 of 6 shared) = 0.33 < 0.5 -> refused.
+        shared = [f"nar:s{i}" for i in range(2)]
+        bare_only = [f"nar:a{i}" for i in range(4)]
+        qual_only = [f"nar:q{i}" for i in range(4)]
+        chains = [[t, "nar:bare_anas"] for t in shared + bare_only] + [
+            [t, "nar:qual_anas"] for t in shared + qual_only
+        ]
+        _write_canonical(tmp_path, _anas_rows())
+        _write_chain_mentions(tmp_path, chains)
+        assert nu.apply_narrator_unification(tmp_path, seed_path=_anas_seed(tmp_path)) is None
+
+
 # --- Seed parsing --------------------------------------------------------------------
 
 

--- a/tests/test_scripts/test_da366_measure.py
+++ b/tests/test_scripts/test_da366_measure.py
@@ -1,0 +1,45 @@
+"""Tests for the da#366 recovery-measurement harness (``scripts/da366_measure_recovery.py``).
+
+The harness's full run needs the real corpus (data-gated), but its pure
+summarisers are exercised here on synthetic rows so the measurement logic itself
+is covered — a report that miscounts is worse than no report.
+"""
+
+from __future__ import annotations
+
+from scripts.da366_measure_recovery import boundary_precision, summarize_recovery
+
+
+def test_summarize_recovery_counts_by_convention() -> None:
+    texts = [
+        # both (opener + >=2 عن)
+        "حدثنا مالك عن نافع عن ابن عمر أن النبي قال شيء",
+        # an_chain (bare name + >=2 عن)
+        "فلان بن فلان عن أبيه عن جده قال شيء",
+        # negative: pure matn
+        "إنما الأعمال بالنيات",
+        # negative: single عن prose
+        "باب ما جاء عن النبي",
+    ]
+    stats = summarize_recovery(texts)
+    assert stats.total == 4
+    assert stats.recovered == 2
+    assert stats.by_convention == {"both": 1, "an_chain": 1}
+    assert stats.rate == 0.5
+
+
+def test_summarize_recovery_empty() -> None:
+    stats = summarize_recovery([])
+    assert stats.total == 0
+    assert stats.recovered == 0
+    assert stats.rate == 0.0
+
+
+def test_boundary_precision_all_clean_when_boundary_faithful() -> None:
+    pairs = [
+        ("حدثنا مالك عن نافع عن ابن عمر", "أن رسول الله صلى الله عليه وسلم نهى عن بيع الحصاة"),
+        ("علي بن إبراهيم عن أبيه عن حماد", "قال الصلاة عماد الدين"),
+    ]
+    clean, recovered = boundary_precision(pairs)
+    assert recovered == 2
+    assert clean == 2  # no matn narrator leaked into either recovered isnad


### PR DESCRIPTION
Final wave merge for `noorinalabs-data-acquisition` — Phase 9 Wave 25 (Narrator disambiguation & split correctness).

All 7 per-issue PRs reviewed (2-reviewer gate) and merged to `deployments/phase-9/wave-25`.

## Issues resolved
- **da#444** (#449) — remove unreachable Gate-3 (SPLIT_MIN_SEPARATION) dead code
- **da#439** (#450) — reconcile narrator_split adjacency with loader TRANSMITTED_TO
- **da#346** (#451) — contextual (isnad-neighbour) disambiguation of over-merged bare names
- **da#431** (#455) — curated evidence-gated narrator unification (kunya↔ism↔bio)
- **da#366** (#456) — recover matn-embedded isnads for sanadset "No SANAD" rows (two-convention splitter)
- **da#452** (#458) — date-coherence abstain gate on narrator_split peels (UNKNOWN-gen)
- **da#347** (#459) — unify Anas b. Mālik bare↔qualified via isnad-neighbour gate

## Notes
- Merge model: wave-branch (per-issue PRs → wave branch → main). Merge with `--merge` (NOT squash, NOT --delete-branch — wave branches retained per owner directive).
- These are **resolve/parse mechanism** changes; their effect on the corpus is realized at the owner-gated resolve re-run (Phase 9 cutover milestone #978), not at this merge.
- da#443 (external-evidence bare-name split) is a wave-27 follow-up, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
