### PR TITLE
fix(da#446): scrub implausible attested death years off the date axis

### DIFF
--- a/src/resolve/narrator_split.py
+++ b/src/resolve/narrator_split.py
@@ -49,6 +49,15 @@ Algorithm (per eligible canonical id ``C``, name ``N``)
    death estimate is ``neighbour_death ± MID_GAP`` (``MID_GAP`` the midpoint of
    :data:`~src.resolve.mononym_split._MIN_GAP`/``_MAX_GAP``), averaged over the
    mention's attested neighbours. A mention with no attested neighbour is *undatable*.
+   **da#446 — implausible-attested scrub.** A neighbour's attested death is used as
+   evidence only when it is plausible for an isnad narrator
+   (:func:`~src.resolve.tabaqa_dates.is_plausible_narrator_death_ah`): the universal
+   date-axis pollution is late collectors/commentators (d. ~700–780 AH) welded onto
+   early nodes, whose real-but-impossible death year would drive this estimate to
+   nonsense (−44 / 805 AH). Such a neighbour is dropped from the pool (so the mention
+   is undated rather than mis-dated), and the averaged estimate is clamped to the
+   plausibility envelope (:func:`~src.resolve.tabaqa_dates.clamp_death_ah`) so the
+   boundary ±MID_GAP shift cannot underflow/overflow it out of range either.
 3. **Cluster** the per-mention estimates 1-D, gap-based: sort and cut wherever a
    consecutive gap exceeds :data:`SPLIT_BAND_GAP` (~one generation).
 4. **ABSTAIN — leave ``C`` as ONE node — UNLESS ALL hold** (the over-split guard):
@@ -150,7 +159,12 @@ from src.resolve.attestation import derive_attestation
 from src.resolve.generic_name import is_generic_name
 from src.resolve.mononym_split import _MAX_GAP, _MIN_GAP, is_registered_mononym
 from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
-from src.resolve.tabaqa_dates import _GENERATION_DEATH_WINDOW_AH
+from src.resolve.tabaqa_dates import (
+    _GENERATION_DEATH_WINDOW_AH,
+    clamp_death_ah,
+    generation_from_value,
+    is_plausible_narrator_death_ah,
+)
 from src.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -447,17 +461,29 @@ def _as_int(value: Any) -> int | None:
 
 
 def _attested_death(rec: dict[str, Any]) -> int | None:
-    """A record's death year iff it is *attested* (present, precision not an estimate).
+    """A record's death year iff it is *attested* AND plausible for an isnad narrator.
 
     An estimated window — the ṭabaqa layer's ``tabaqa_estimate`` OR a prior isnad-split
     peel's ``isnad_estimate`` (da#340), i.e. any precision in
     :data:`_ESTIMATED_PRECISIONS` — is never used as evidence, keeping the pass
     cascade-free and re-runs a strict no-op.
+
+    da#446 — implausible-attested scrub. An attested death that is impossible for a
+    narrator standing in an isnad (:func:`~src.resolve.tabaqa_dates.is_plausible_narrator_death_ah`,
+    generation-aware on the record's own ``generation``) is dropped from the
+    neighbour-death evidence pool: the universal date-axis pollution is late
+    collectors/commentators (d. ~700–780 AH) mislabelled onto early nodes, whose
+    real-but-impossible death year would otherwise drive a mention's
+    ``neighbour_death ± MID_GAP`` estimate to nonsense (−44 / 805 AH). A neighbour
+    with no *plausible* attested death simply contributes no adjacency evidence — the
+    mention it neighbours is treated as undatable, never dated off a corrupt anchor.
     """
     year = _as_int(rec.get("death_year_ah"))
     if year is None:
         return None
     if rec.get("death_date_precision") in _ESTIMATED_PRECISIONS:
+        return None
+    if not is_plausible_narrator_death_ah(year, generation_from_value(rec.get("generation"))):
         return None
     return year
 
@@ -703,10 +729,15 @@ def _collect_datable(
             if nname:
                 anchors.append(nname)
         if estimates:
+            # da#446: clamp the per-mention estimate to the plausibility envelope. The
+            # neighbour-death pool is already implausibility-scrubbed (_attested_death),
+            # but the ±MID_GAP transmission-gap shift still underflows/overflows at the
+            # boundary (a student of an 11 AH Companion → 11 − 47 = −36), so the axis is
+            # bounded here to stop it emitting −44 / 805 AH.
             datable.append(
                 DatableMention(
                     mention_id=mention_id,
-                    estimate=round(sum(estimates) / len(estimates)),
+                    estimate=clamp_death_ah(round(sum(estimates) / len(estimates))),
                     anchor_names=tuple(sorted(set(anchors))),
                 )
             )
@@ -798,6 +829,7 @@ def split_generic_narrators(output_dir: Path, *, staging_dir: Path | None = None
     attested_by_id: dict[str, int] = {}
     record_by_id: dict[str, dict[str, Any]] = {}
     candidate_ids: set[str] = set()
+    scrubbed_deaths = 0  # da#446: attested deaths dropped as implausible for an isnad narrator
     for rec in records:
         cid = safe_str(rec.get("canonical_id"))
         if cid is None:
@@ -809,6 +841,13 @@ def split_generic_narrators(output_dir: Path, *, staging_dir: Path | None = None
         attested = _attested_death(rec)
         if attested is not None:
             attested_by_id[cid] = attested
+        elif (
+            _as_int(rec.get("death_year_ah")) is not None
+            and rec.get("death_date_precision") not in _ESTIMATED_PRECISIONS
+        ):
+            # A present, non-estimate death that _attested_death rejected can only be the
+            # da#446 implausibility scrub — count it for the audit log.
+            scrubbed_deaths += 1
         mention_count = _as_int(rec.get("mention_count")) or 0
         if (
             name_norm is not None
@@ -816,6 +855,14 @@ def split_generic_narrators(output_dir: Path, *, staging_dir: Path | None = None
             and not is_registered_mononym(name_norm)
         ):
             candidate_ids.add(cid)
+
+    if scrubbed_deaths:
+        logger.info(
+            "narrator_split_implausible_deaths_scrubbed",
+            scrubbed=scrubbed_deaths,
+            attested_pool=len(attested_by_id),
+            canonical_total=len(records),
+        )
 
     if not candidate_ids:
         logger.info("narrator_split_no_candidates", canonical_total=len(records))

--- a/src/resolve/tabaqa_dates.py
+++ b/src/resolve/tabaqa_dates.py
@@ -65,10 +65,15 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 __all__ = [
+    "DEATH_PLAUSIBILITY_MARGIN_AH",
+    "NARRATOR_DEATH_MAX_AH",
+    "NARRATOR_DEATH_MIN_AH",
     "TabaqaEstimate",
     "apply_tabaqa_fallback",
+    "clamp_death_ah",
     "estimate_death_window",
     "generation_from_value",
+    "is_plausible_narrator_death_ah",
 ]
 
 # Generation (ṭabaqa) → approximate Hijri (AH) death-year window.
@@ -99,6 +104,75 @@ _GENERATION_DEATH_WINDOW_AH: dict[NarratorGeneration, tuple[int, int]] = {
     NarratorGeneration.ATBA_TABA_TABIIN: (220, 300),
     NarratorGeneration.LATER: (280, 400),
 }
+
+# Plausibility envelope for a hadith-isnad narrator's *attested* death year (AH),
+# da#446. This is NOT ``src.parse.narrator_dates``' ``[MIN_PLAUSIBLE_AH,
+# MAX_PLAUSIBLE_AH]`` = ``[1, 1500]`` band — THAT is a "is this token even a year"
+# noise filter that drops page refs / hadith numbers leaking into a free-text date
+# field. THIS bounds what death year is historically *possible* for a narrator
+# standing in an isnad. The universal −44 / 805 AH date-axis pollution (da#446) is
+# late collectors/commentators (d. ~700–780 AH) welded onto early isnad nodes: their
+# attested death is a genuine number well inside ``[1, 1500]``, so the noise filter
+# passes it, and it then poisons the neighbour-death evidence that
+# :mod:`~src.resolve.narrator_split` turns into a per-mention death estimate — an
+# 8th-century-AH "narrator death" makes the ±MID_GAP axis emit nonsense.
+#
+# Floor = the Prophet's death (11 AH), the earliest an isnad-bearing narrator could
+# die — a hard historical bound with NO downward margin. Ceiling = the last (LATER)
+# ṭabaqa window's high (400 AH) plus a margin, because a genuinely long-lived
+# post-canonical transmitter can sit a little past the rounded window edge. Both are
+# DERIVED from :data:`_GENERATION_DEATH_WINDOW_AH` so the envelope and the ṭabaqa
+# periodization can never drift apart.
+DEATH_PLAUSIBILITY_MARGIN_AH = 50
+NARRATOR_DEATH_MIN_AH = min(lo for lo, _hi in _GENERATION_DEATH_WINDOW_AH.values())
+NARRATOR_DEATH_MAX_AH = (
+    max(hi for _lo, hi in _GENERATION_DEATH_WINDOW_AH.values()) + DEATH_PLAUSIBILITY_MARGIN_AH
+)
+
+
+def is_plausible_narrator_death_ah(
+    year: int, generation: NarratorGeneration = NarratorGeneration.UNKNOWN
+) -> bool:
+    """Is ``year`` (AH) a historically-possible death year for an isnad narrator? (da#446)
+
+    Two tiers:
+
+    * **Absolute envelope.** Every isnad-bearing narrator died within
+      ``[NARRATOR_DEATH_MIN_AH, NARRATOR_DEATH_MAX_AH]`` (the union of the ṭabaqa
+      generation windows — Prophet's-death floor to LATER-window ceiling + margin).
+      A death outside it — the d. 700–780 AH late-collector pollution, or a stray
+      sub-11 value — is implausible regardless of any label.
+    * **Generation-aware tightening.** When a *known* ``generation`` is given, the
+      year must ALSO fall inside that generation's window ± the margin: a row
+      labelled ``sahabi`` carrying an attested death of 300 AH is impossible for a
+      Companion even though 300 sits inside the loose absolute envelope. An
+      ``UNKNOWN`` / unmapped generation applies the absolute envelope only — the
+      common case for the bio-only late entries that dominate the pollution.
+
+    Pure; no IO. The scrub decision (drop / flag) belongs to the caller.
+    """
+    if not (NARRATOR_DEATH_MIN_AH <= year <= NARRATOR_DEATH_MAX_AH):
+        return False
+    window = _GENERATION_DEATH_WINDOW_AH.get(generation)
+    if window is not None:
+        lo, hi = window
+        if not (lo - DEATH_PLAUSIBILITY_MARGIN_AH <= year <= hi + DEATH_PLAUSIBILITY_MARGIN_AH):
+            return False
+    return True
+
+
+def clamp_death_ah(year: int) -> int:
+    """Clamp an AH death-year *estimate* to the absolute plausibility envelope (da#446).
+
+    Applied to the isnad-adjacency ``neighbour_death ± MID_GAP`` estimate so the date
+    axis can never emit a value below the Prophet's death or past the last ṭabaqa
+    window (the −44 / 805 AH the issue reports). Even after the neighbour-death pool
+    is plausibility-scrubbed, the ±MID_GAP arithmetic underflows/overflows at the
+    boundary — a student of a Companion who died 11 AH estimates 11 − 47 = −36, which
+    is not a real death year but an artifact of the transmission-gap shift — so it is
+    clamped to ``NARRATOR_DEATH_MIN_AH`` / ``NARRATOR_DEATH_MAX_AH``.
+    """
+    return max(NARRATOR_DEATH_MIN_AH, min(NARRATOR_DEATH_MAX_AH, year))
 
 
 @dataclass(frozen=True)

--- a/tests/test_resolve/test_narrator_split.py
+++ b/tests/test_resolve/test_narrator_split.py
@@ -33,13 +33,16 @@ from src.resolve.narrator_split import (
     SPLIT_MAX_CLUSTERS,
     SPLIT_MIN_SUPPORT,
     DatableMention,
+    _attested_death,
     _band_midpoint,
+    _collect_datable,
     _cut_bands,
     _generation_for_year,
     plan_split,
     split_generic_narrators,
 )
 from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
+from src.resolve.tabaqa_dates import NARRATOR_DEATH_MAX_AH, NARRATOR_DEATH_MIN_AH
 from src.utils.arabic import normalize_arabic
 
 _ABU_ABDALLAH = normalize_arabic("أبو عبد الله")
@@ -201,6 +204,85 @@ def test_same_band_label_collision_tiebreak_by_anchor() -> None:
     assert {b.discriminator for b in plan.peeled} == {"d:280-400|aaa", "d:280-400|bbb"}
     ids = {b.new_id for b in plan.peeled}
     assert len(ids) == len(plan.peeled)  # every peeled id distinct
+
+
+# --------------------------------------------------------------------------- #
+# da#446 — implausible-attested scrub + estimate clamp on the date axis
+# --------------------------------------------------------------------------- #
+def _rec(death: Any, precision: str, generation: str | None = None) -> dict[str, Any]:
+    return {
+        "death_year_ah": death,
+        "death_date_precision": precision,
+        "generation": generation,
+    }
+
+
+def test_attested_death_keeps_plausible() -> None:
+    # A genuine attested isnad-narrator death is used as evidence unchanged.
+    assert _attested_death(_rec(256, "exact")) == 256
+    assert _attested_death(_rec(11, "exact")) == 11
+    assert _attested_death(_rec(NARRATOR_DEATH_MAX_AH, "range")) == NARRATOR_DEATH_MAX_AH
+
+
+def test_attested_death_scrubs_implausible_late_collector() -> None:
+    # The da#446 pollution: a late collector/commentator (d. 754 AH) mislabelled onto
+    # an early node. Its attested death is real but impossible for an isnad narrator, so
+    # it is dropped from the evidence pool (would otherwise drive the axis to 754+47=801).
+    assert _attested_death(_rec(754, "exact")) is None
+    assert _attested_death(_rec(859, "exact")) is None  # observed prod max
+    assert _attested_death(_rec(5, "exact")) is None  # before the Prophet's death
+
+
+def test_attested_death_generation_aware() -> None:
+    # A Companion (sahabi) carrying an attested death of 300 AH is impossible for that
+    # ṭabaqa even though 300 sits inside the loose [11, 450] envelope — dropped.
+    assert _attested_death(_rec(300, "exact", "sahabi")) is None
+    # …but a plausible-for-its-generation death is kept.
+    assert _attested_death(_rec(105, "exact", "sahabi")) == 105
+    assert _attested_death(_rec(300, "exact", "later")) == 300
+
+
+def test_attested_death_estimate_precision_still_excluded() -> None:
+    # The pre-existing da#340 rule holds: an estimated window is never evidence,
+    # independent of plausibility.
+    assert _attested_death(_rec(256, "tabaqa_estimate")) is None
+    assert _attested_death(_rec(256, "isnad_estimate")) is None
+    assert _attested_death(_rec(None, "exact")) is None
+
+
+def _one_chain(
+    candidate_id: str, anchor_id: str, cand_pos: int, anchor_pos: int
+) -> tuple[
+    list[tuple[str, int, int, str]],
+    dict[tuple[str, int], list[tuple[int, str]]],
+]:
+    """A single two-narrator chain (hadith ``h``, chain 0) with the candidate at
+    ``cand_pos`` and one attested anchor at ``anchor_pos`` — the minimal input for
+    :func:`_collect_datable`."""
+    chain = sorted([(cand_pos, candidate_id), (anchor_pos, anchor_id)])
+    chains = {("h", 0): chain}
+    mentions = [("h", 0, cand_pos, "m0")]
+    return mentions, chains
+
+
+def test_collect_datable_clamps_overflow_estimate() -> None:
+    # Teacher anchor at the maximum plausible death (450) → 450 + MID_GAP overflows the
+    # envelope; the per-mention estimate is clamped to NARRATOR_DEATH_MAX_AH, never 497.
+    mentions, chains = _one_chain("cand", "anc", cand_pos=1, anchor_pos=0)
+    datable = _collect_datable(mentions, chains, {"anc": NARRATOR_DEATH_MAX_AH}, {"anc": "anchor"})
+    assert len(datable) == 1
+    assert 450 + MID_GAP > NARRATOR_DEATH_MAX_AH  # the raw estimate really does overflow
+    assert datable[0].estimate == NARRATOR_DEATH_MAX_AH
+
+
+def test_collect_datable_clamps_underflow_estimate() -> None:
+    # Student anchor at the Prophet's-death floor (11) → 11 − MID_GAP underflows to −36;
+    # clamped to NARRATOR_DEATH_MIN_AH so the axis never emits a negative death year.
+    mentions, chains = _one_chain("cand", "anc", cand_pos=0, anchor_pos=1)
+    datable = _collect_datable(mentions, chains, {"anc": NARRATOR_DEATH_MIN_AH}, {"anc": "anchor"})
+    assert len(datable) == 1
+    assert NARRATOR_DEATH_MIN_AH - MID_GAP < NARRATOR_DEATH_MIN_AH  # raw estimate underflows
+    assert datable[0].estimate == NARRATOR_DEATH_MIN_AH
 
 
 # --------------------------------------------------------------------------- #
@@ -387,6 +469,54 @@ def test_stage_splits_two_bands_and_peels(tmp_path: Path) -> None:
     assert len(audit) == 1
     assert audit[0]["primary_id"] == cand
     assert audit[0]["new_id"] == peeled[0]["canonical_id"]
+
+
+def test_stage_da446_scrub_prevents_phantom_from_polluted_anchor(tmp_path: Path) -> None:
+    # da#446 — the scrub must prevent a phantom twin that da#452's coherence gate does
+    # NOT catch. A hub has one genuine band (candidate estimate ≈150) plus a spurious
+    # band that exists ONLY because a late collector (d.253 AH) is mislabelled ``sahabi``
+    # and welded in as a teacher — candidate estimate 253 + MID_GAP = 300 AH. That 300
+    # estimate is date-COHERENT (∈ the atbāʿ window 220–300), so Gate 0 (da#452) would
+    # keep it and the node would split into a phantom twin. da#446's generation-aware
+    # scrub drops the sahabi-d253 anchor from the evidence pool (253 ≫ 110+50), so the
+    # spurious mentions go undatable, leaving one band → the node abstains, whole.
+    out = tmp_path / "curated"
+    cand = make_canonical_id(_ABU_ABDALLAH)
+    legit_death = 150 - MID_GAP  # plausible anchor, generation unknown → estimate ≈150
+    polluted_death = 300 - MID_GAP  # 253 AH — coherent estimate, but impossible sahabi
+    canonical = [
+        _canonical_row(cand, _ABU_ABDALLAH, 55),
+        _anchor_row("nar:legit", legit_death),
+        # A late collector mislabelled sahabi: absolute-plausible (<=450) and its induced
+        # estimate is window-coherent, so ONLY the generation-aware scrub removes it.
+        _canonical_row(
+            "nar:poll",
+            normalize_arabic("راو متاخر مؤرخ"),
+            5,
+            death_year_ah=polluted_death,
+            death_date_precision="exact",
+            generation="sahabi",
+        ),
+    ]
+    mentions = _hadiths_against_anchor(cand, "nar:legit", 40, 0, "g")
+    mentions += _hadiths_against_anchor(cand, "nar:poll", 15, 0, "p")
+    _write(out, canonical, mentions)
+
+    # Sanity: the polluted anchor really would induce a coherent, qualifying second band
+    # were it not scrubbed — so this test bites on da#446, not da#452.
+    assert _generation_for_year(300) is not NarratorGeneration.UNKNOWN
+
+    result = split_generic_narrators(out)
+    assert result is None  # abstained — no phantom twin minted
+
+    by_id = _read_canonical(out)
+    twins = [
+        r
+        for r in by_id.values()
+        if r["name_ar_normalized"] == _ABU_ABDALLAH and r["canonical_id"] != cand
+    ]
+    assert twins == []
+    assert not (out / "narrator_splits.parquet").exists()
 
 
 def test_stage_peel_re_derives_attestation(tmp_path: Path) -> None:

--- a/tests/test_resolve/test_tabaqa_dates.py
+++ b/tests/test_resolve/test_tabaqa_dates.py
@@ -20,10 +20,15 @@ from src.models.enums import DatePrecision, NarratorGeneration
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
 from src.resolve.tabaqa_dates import (
     _GENERATION_DEATH_WINDOW_AH,
+    DEATH_PLAUSIBILITY_MARGIN_AH,
+    NARRATOR_DEATH_MAX_AH,
+    NARRATOR_DEATH_MIN_AH,
     TabaqaEstimate,
     apply_tabaqa_fallback,
+    clamp_death_ah,
     estimate_death_window,
     generation_from_value,
+    is_plausible_narrator_death_ah,
 )
 from src.utils.hijri import ah_year_to_ce_range
 
@@ -92,6 +97,60 @@ def test_estimate_unknown_generation_yields_none() -> None:
 def test_estimate_dataclass_default_precision() -> None:
     est = TabaqaEstimate(150, 100, 200, 700, 800)
     assert est.precision is DatePrecision.TABAQA_ESTIMATE
+
+
+# --------------------------------------------------------------------------- #
+# da#446 — isnad-narrator death-year plausibility envelope + clamp
+# --------------------------------------------------------------------------- #
+def test_plausibility_envelope_derives_from_generation_windows() -> None:
+    # The envelope is DERIVED from _GENERATION_DEATH_WINDOW_AH so the two cannot drift:
+    # floor = the Prophet's death (min generation low, no downward margin); ceiling =
+    # the last window's high + margin.
+    assert NARRATOR_DEATH_MIN_AH == min(lo for lo, _ in _GENERATION_DEATH_WINDOW_AH.values())
+    assert NARRATOR_DEATH_MIN_AH == 11
+    assert NARRATOR_DEATH_MAX_AH == (
+        max(hi for _, hi in _GENERATION_DEATH_WINDOW_AH.values()) + DEATH_PLAUSIBILITY_MARGIN_AH
+    )
+    assert NARRATOR_DEATH_MAX_AH == 450
+
+
+def test_plausible_absolute_envelope_no_generation() -> None:
+    # In-envelope attested deaths pass; the boundaries are inclusive.
+    assert is_plausible_narrator_death_ah(11) is True
+    assert is_plausible_narrator_death_ah(256) is True
+    assert is_plausible_narrator_death_ah(450) is True
+    # The da#446 pollution — late collectors/commentators d. ~700–780 AH, and the
+    # observed prod max of 859 AH — is impossible for an isnad narrator.
+    for polluted in (451, 754, 780, 805, 859):
+        assert is_plausible_narrator_death_ah(polluted) is False
+    # Sub-11 (before the Prophet's death) and negative axis artifacts are impossible.
+    for early in (-44, 0, 10):
+        assert is_plausible_narrator_death_ah(early) is False
+
+
+def test_plausible_generation_aware_tightening() -> None:
+    # A KNOWN generation tightens to its own window ± margin: a Companion (11–110)
+    # dated 300 AH sits inside the loose [11, 450] envelope but is impossible for a
+    # sahabi, so the generation-aware check rejects it.
+    assert is_plausible_narrator_death_ah(300, NarratorGeneration.SAHABI) is False
+    # …while a death just past the rounded window edge, within the margin, is kept
+    # (110 + 50 = 160) — the margin protects genuine boundary narrators.
+    assert is_plausible_narrator_death_ah(160, NarratorGeneration.SAHABI) is True
+    assert is_plausible_narrator_death_ah(161, NarratorGeneration.SAHABI) is False
+    # A genuine LATER narrator (280–400) at 390 stays plausible; an UNKNOWN generation
+    # falls back to the absolute envelope only.
+    assert is_plausible_narrator_death_ah(390, NarratorGeneration.LATER) is True
+    assert is_plausible_narrator_death_ah(300, NarratorGeneration.UNKNOWN) is True
+
+
+def test_clamp_death_ah_bounds_axis_estimates() -> None:
+    # The −44 / 805 AH the issue reports clamp back into the envelope; an in-range
+    # value is returned unchanged.
+    assert clamp_death_ah(-44) == NARRATOR_DEATH_MIN_AH == 11
+    assert clamp_death_ah(-36) == 11  # student-of-Companion boundary underflow
+    assert clamp_death_ah(805) == NARRATOR_DEATH_MAX_AH == 450
+    assert clamp_death_ah(497) == 450  # student-of-latest-plausible boundary overflow
+    assert clamp_death_ah(256) == 256
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #446

## Problem
The `narrator_split` date axis emits nonsense death-year estimates (−44 / 805 AH) because attested-neighbour deaths are polluted by **late collectors/commentators (d. ~700–780 AH) mislabelled onto early isnad nodes**. Their death year is a real number inside the `[1, 1500]` "is this even a year" noise band (`src/parse/narrator_dates.py`), so that filter passes it, and it then drives a mention's `neighbour_death ± MID_GAP` estimate out of range. Confirmed universal, not isolated chimeras.

## Change
An isnad-narrator death-plausibility envelope, **derived from the ṭabaqa generation windows** (`_GENERATION_DEATH_WINDOW_AH`) so the two cannot drift: floor = the Prophet's death (11 AH, no downward margin), ceiling = the last (LATER) window's high (400) + 50 margin = 450.

- **`src/resolve/tabaqa_dates.py`** — `is_plausible_narrator_death_ah(year, generation)` (absolute envelope, tightened to the generation window ± margin when a *known* generation is supplied) + `clamp_death_ah()`; `NARRATOR_DEATH_MIN_AH` / `NARRATOR_DEATH_MAX_AH` / `DEATH_PLAUSIBILITY_MARGIN_AH`.
- **`src/resolve/narrator_split.py`** — `_attested_death` drops an implausible attested neighbour death from the evidence pool (generation-aware on the row's own `generation`), so a mislabelled late collector can no longer poison the axis; the neighboured mention goes *undatable* rather than mis-dated. `_collect_datable` clamps the averaged per-mention estimate to the envelope so the boundary ±MID_GAP shift cannot underflow/overflow it. An aggregate scrub count is logged.

### Relationship to da#452
Distinct and complementary. da#452's Gate 0 drops an *incoherent band* after it forms; this scrubs the corrupt attested *input* — catching cases da#452 cannot, e.g. a generation-implausible anchor (a `sahabi` dated 253 AH) whose induced estimate (300 AH) is window-coherent. A dedicated stage test proves da#452 alone still mints a phantom twin there while da#446 abstains.

## Verification (real prod data — 107,951-narrator curated canonical table)
Measured with the patched code:

| | evidence-pool size | per-mention estimate span |
|---|---|---|
| before (pre-da446) | 34,654 | `[−46, 906]` (the −44/805 pollution) |
| after scrub | 24,016 (dropped **10,638 / 30.7%**) | `[−36, 497]` |
| after scrub + clamp | — | `[11, 450]` |

The axis can no longer emit a death year before the Prophet's death or past the last ṭabaqa window.

## Tests
`tests/test_resolve/test_tabaqa_dates.py` (envelope derivation, absolute + generation-aware plausibility, clamp) and `tests/test_resolve/test_narrator_split.py` (`_attested_death` scrub incl. generation-aware, `_collect_datable` clamp under/overflow, and a stage test that a polluted anchor mints no phantom twin). All bite — verified failing without the change. Full suite green: 2342 passed / 10 skipped (`uv run pytest -m "not integration"`), mypy-strict clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgdLmU3rttSQVewA45km6L