### PR TITLE
fix(#373): repair dead canonical_matn_identity gate + make edge loader see it

### DIFF
--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import pyarrow.parquet as pq
 
+from src.graph.load_nodes import build_loaded_hadith_ids
 from src.parse.composition import is_canonical_hadith_id
 from src.parse.identity import (
     DoubledCorpusPrefixError,
@@ -141,6 +142,52 @@ def _chain_index(row: dict[str, Any]) -> int:
     return int(v) if v is not None else 0
 
 
+def _staging_loaded_hadith_ids(staging_dir: Path) -> set[str] | None:
+    """The ``Hadith.id`` node ids the node loader loads from *staging_dir* (da#373).
+
+    Builds the set from the SAME ``hadiths_*.parquet`` the node loader reads, via
+    :func:`src.graph.load_nodes.build_loaded_hadith_ids`, so the chain-edge gate
+    sees the node loader's real kept set — composition AND cross-edition matn
+    dedup — not just the id-grammar composition slice ``is_canonical_hadith_id``
+    can re-derive. Returns ``None`` when *staging_dir* holds no hadith files, in
+    which case the caller falls back to the id-grammar gate (pre-da#373 behavior)
+    — there are no Hadith nodes to orphan against anyway.
+    """
+    files = _parquet_files(staging_dir, "hadiths_")
+    if not files:
+        return None
+    return build_loaded_hadith_ids(files)
+
+
+def _mention_hadith_survives(hid: str, loaded_hadith_ids: set[str] | None) -> bool:
+    """True if a mention's hadith should still yield a chain edge (da#333 + da#373).
+
+    Drops exactly the mentions whose hadith the node loader did NOT load, so a
+    TRANSMITTED_TO / NARRATED edge is never emitted against a missing Hadith node:
+
+    * ``loaded_hadith_ids`` is the node loader's real kept set (da#373). A
+      well-formed id absent from it — a non-canonical edition (da#333, the ~196k
+      fawaz six-books chains) OR a cross-edition-deduped sanadset tradition — is
+      dropped. The cross-edition half is the one ``is_canonical_hadith_id``
+      structurally could not see: the matn dedup decision is not recoverable from
+      the id string.
+    * ``None`` means no staging hadith files were available to consult, so fall
+      back to the id-grammar composition gate (:func:`is_canonical_hadith_id`).
+
+    **Total** — a malformed id returns ``True`` (survives here) and is deferred to
+    the per-group malformed quarantine that counts it (da#355); it is never
+    silently reclassified as a non-canonical drop, mirroring the totality of
+    ``is_canonical_hadith_id``.
+    """
+    if loaded_hadith_ids is None:
+        return is_canonical_hadith_id(hid)
+    try:
+        node_id = hadith_node_id(hid)
+    except DoubledCorpusPrefixError:
+        return True  # defer to the da#355 malformed quarantine
+    return node_id in loaded_hadith_ids
+
+
 # ---------------------------------------------------------------------------
 # 1. TRANSMITTED_TO — consecutive narrator pairs in each chain
 # ---------------------------------------------------------------------------
@@ -252,8 +299,16 @@ def _load_transmitted_to(
     curated_dir: Path | None = None,
     strict: bool = True,
     batch_size: int = DEFAULT_BATCH_SIZE,
+    loaded_hadith_ids: set[str] | None = None,
 ) -> EdgeLoadResult:
-    """Load TRANSMITTED_TO edges from narrator_mentions_resolved.parquet."""
+    """Load TRANSMITTED_TO edges from narrator_mentions_resolved.parquet.
+
+    *loaded_hadith_ids* is the node loader's real kept set (da#373); when the
+    caller does not supply it, it is derived from *staging_dir*'s hadith files.
+    See :func:`_mention_hadith_survives`.
+    """
+    if loaded_hadith_ids is None:
+        loaded_hadith_ids = _staging_loaded_hadith_ids(staging_dir)
     files = _resolved_mentions_files(staging_dir, curated_dir)
     if not files:
         if strict:
@@ -288,7 +343,7 @@ def _load_transmitted_to(
             hid = row.get("hadith_id") or row.get("source_hadith_id")
             if not hid:
                 continue
-            if not is_canonical_hadith_id(hid):
+            if not _mention_hadith_survives(hid, loaded_hadith_ids):
                 # da#333: a mention whose hadith is NOT a canonical node — e.g.
                 # fawaz's six-books chains, deduplicated to the lk spine — must not
                 # produce a TRANSMITTED_TO edge, mirroring the node dedup
@@ -403,8 +458,15 @@ def _load_narrated(
     curated_dir: Path | None = None,
     strict: bool = True,
     batch_size: int = DEFAULT_BATCH_SIZE,
+    loaded_hadith_ids: set[str] | None = None,
 ) -> EdgeLoadResult:
-    """Load NARRATED edges — first narrator (position 0) in each chain -> hadith."""
+    """Load NARRATED edges — first narrator (position 0) in each chain -> hadith.
+
+    *loaded_hadith_ids* is the node loader's real kept set (da#373); derived from
+    *staging_dir* when not supplied. See :func:`_mention_hadith_survives`.
+    """
+    if loaded_hadith_ids is None:
+        loaded_hadith_ids = _staging_loaded_hadith_ids(staging_dir)
     files = _resolved_mentions_files(staging_dir, curated_dir)
     if not files:
         if strict:
@@ -432,7 +494,7 @@ def _load_narrated(
             pos = row.get("position_in_chain", 0)
             if not hid or not nid:
                 continue
-            if not is_canonical_hadith_id(hid):
+            if not _mention_hadith_survives(hid, loaded_hadith_ids):
                 # da#333: mirror the node dedup — a mention whose hadith is not a
                 # canonical node (fawaz six-books, deduped to lk) yields no NARRATED
                 # edge. Such an edge would otherwise be a guaranteed missing-endpoint
@@ -1028,14 +1090,31 @@ def load_all_edges(
     """
     results: list[EdgeLoadResult] = []
 
+    # Compute the node loader's real kept set ONCE (da#373) and share it with both
+    # chain-edge loaders, so they gate on the same set the node loader loaded —
+    # composition AND cross-edition matn dedup — instead of re-deriving a partial
+    # gate from the id string. This is what stops a repaired matn key from
+    # re-orphaning ~196k dangling chains.
+    loaded_hadith_ids = _staging_loaded_hadith_ids(staging_dir)
+
     results.append(
         _load_transmitted_to(
-            client, staging_dir, curated_dir=curated_dir, strict=strict, batch_size=batch_size
+            client,
+            staging_dir,
+            curated_dir=curated_dir,
+            strict=strict,
+            batch_size=batch_size,
+            loaded_hadith_ids=loaded_hadith_ids,
         )
     )
     results.append(
         _load_narrated(
-            client, staging_dir, curated_dir=curated_dir, strict=strict, batch_size=batch_size
+            client,
+            staging_dir,
+            curated_dir=curated_dir,
+            strict=strict,
+            batch_size=batch_size,
+            loaded_hadith_ids=loaded_hadith_ids,
         )
     )
     results.append(_load_appears_in(client, staging_dir, strict=strict, batch_size=batch_size))

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -54,7 +54,7 @@ from src.utils.neo4j_client import Neo4jClient
 
 logger = get_logger(__name__)
 
-__all__ = ["load_all_nodes", "LoadResult"]
+__all__ = ["load_all_nodes", "build_loaded_hadith_ids", "LoadResult"]
 
 
 @dataclass(frozen=True)
@@ -181,6 +181,80 @@ def _build_curated_identity_index(files: list[Path]) -> set[str]:
             if identity is not None:
                 index.add(identity)
     return index
+
+
+# Drop-reason codes for the single hadith keep-decision (da#373). ``_load_hadiths``
+# uses them to count each drop under its own cause; ``build_loaded_hadith_ids``
+# ignores the reason and keeps only the id.
+_KEEP = "keep"
+_DROP_INVALID_SID = "invalid_source_id"
+_DROP_NONCANONICAL = "noncanonical"
+_DROP_CROSS_EDITION = "cross_edition_dedup"
+_DROP_MALFORMED = "malformed"
+
+# Columns the loaded-id set needs: the identity columns plus the source_id that
+# becomes the Hadith node id.
+_LOADED_ID_COLUMNS = ["source_id", *_IDENTITY_COLUMNS]
+
+
+def _hadith_load_outcome(
+    row: dict[str, Any], curated_identities: set[str]
+) -> tuple[str | None, str]:
+    """(node_id, reason) for a staging hadith row — THE single keep-decision (da#373).
+
+    ``node_id`` is the ``hdt:`` Hadith.id when ``reason == _KEEP``, else ``None``;
+    ``reason`` is one of the ``_KEEP`` / ``_DROP_*`` codes. This is the one place
+    the kept set is decided, shared by two callers so they can never disagree —
+    which is the whole da#373 defect: the node loader dropped a cross-edition
+    duplicate the edge loader could not see and re-orphaned its chain.
+
+    Applies, in order, exactly the gates ``_load_hadiths`` applies: a blank /
+    non-str ``source_id``; the per-source/collection composition gate (da#191);
+    the cross-edition matn-identity dedup for a dedup-source row whose tradition a
+    curated edition already occupies (da#220); and id well-formedness.
+
+    **Total** — a malformed id yields ``(None, _DROP_MALFORMED)`` rather than
+    raising: membership is all the edge gate needs, and ``_load_hadiths`` keeps its
+    own strict re-check for the da#355 abort path, so this never decides strictness.
+    """
+    sid = row.get("source_id")
+    if not sid or not isinstance(sid, str):
+        return None, _DROP_INVALID_SID
+    source_corpus = _val(row, "source_corpus", "")
+    if not is_canonical_hadith(source_corpus, _val(row, "collection_name", "")):
+        return None, _DROP_NONCANONICAL
+    if is_cross_edition_dedup_source(source_corpus):
+        identity = canonical_matn_identity(_effective_matn_ar(row), _val(row, "matn_en"))
+        if identity is not None and identity in curated_identities:
+            return None, _DROP_CROSS_EDITION
+    try:
+        return hadith_node_id(sid), _KEEP
+    except DoubledCorpusPrefixError:
+        return None, _DROP_MALFORMED
+
+
+def build_loaded_hadith_ids(files: list[Path]) -> set[str]:
+    """Set of ``Hadith.id`` node ids :func:`_load_hadiths` loads from *files* (da#373).
+
+    Replays the node loader's keep-decision (:func:`_hadith_load_outcome`) over
+    every ``hadiths_*.parquet`` — composition gate + cross-edition matn dedup + id
+    well-formedness — and returns the ``hdt:`` ids that survive. The chain-edge
+    loader consults THIS set instead of re-deriving a gate from the id string
+    (``is_canonical_hadith_id``), which can see the composition decision but NOT
+    the cross-edition matn dedup — a source_id carries no matn. Reading the SAME
+    files through the SAME decision is what keeps the node loader and edge loader
+    from disagreeing about the kept set; that disagreement's size is exactly the
+    cross-edition dedup, and it re-orphans ~196k dangling chains the moment the
+    matn key is repaired.
+    """
+    curated_identities = _build_curated_identity_index(files)
+    loaded: set[str] = set()
+    for fp in files:
+        for row in _read_parquet_columns(fp, _LOADED_ID_COLUMNS):
+            node_id, _reason = _hadith_load_outcome(row, curated_identities)
+            if node_id is not None:
+                loaded.add(node_id)
+    return loaded
 
 
 def _narrator_name_en(row: dict[str, Any]) -> str:
@@ -386,52 +460,49 @@ def _load_hadiths(
         rows = _read_parquet_rows(fp)
         batch: list[dict[str, Any]] = []
         for i, row in enumerate(rows):
-            sid = row.get("source_id")
-            if not sid or not isinstance(sid, str):
-                all_errors.append(f"{fp.name} row {i}: invalid source_id={sid!r}")
+            # ONE keep-decision, shared with build_loaded_hadith_ids so the edge
+            # loader can never disagree about the kept set (da#373). It applies the
+            # same gates in the same order — composition (da#191), cross-edition
+            # matn dedup (da#220), id well-formedness — and reports which fired so
+            # each drop is still counted under its own cause.
+            hid, reason = _hadith_load_outcome(row, curated_identities)
+            if reason == _DROP_INVALID_SID:
+                all_errors.append(f"{fp.name} row {i}: invalid source_id={row.get('source_id')!r}")
                 total_skipped += 1
                 total_invalid_sid += 1
                 continue
-            source_corpus = _val(row, "source_corpus", "")
-            # Canonical corpus composition (da#191): skip Hadith whose
-            # (source_corpus, collection) duplicates the chosen canonical edition
-            # — halimbahae/fawaz non-unique books, the mis Sahih Muslim matn copy.
-            # One enforcement point so a fresh run_all (the production path) yields
-            # the deduped graph without manual surgery.
-            if not is_canonical_hadith(source_corpus, _val(row, "collection_name", "")):
+            if reason == _DROP_NONCANONICAL:
+                # (source_corpus, collection) duplicates the chosen canonical
+                # edition — halimbahae/fawaz non-unique books, the mis Sahih Muslim
+                # matn copy — so no Hadith node loads for it (da#191).
                 total_skipped += 1
                 continue
-            # Fall back to the raw full text when a source supplies no separated
-            # matn: halimbahae / open_hadith / bihar populate ``full_text_ar``
-            # only (they do not split isnad from matn). The loader persists
-            # matn_ar — not full_text_ar — so without this the Hadith node lands
-            # textless on the graph (da#190).
-            matn_ar = _effective_matn_ar(row)
-            # Cross-edition canonical-identity dedup (da#220): drop a dedup-source
-            # hadith whose normalized matn already exists from a curated edition —
-            # curated wins (richer metadata). Curated rows and dedup-source rows
-            # with no curated twin fall straight through.
-            if is_cross_edition_dedup_source(source_corpus):
-                identity = canonical_matn_identity(matn_ar, _val(row, "matn_en"))
-                if identity is not None and identity in curated_identities:
-                    total_skipped += 1
-                    total_deduped += 1
-                    continue
-            # Quarantine, never abort (da#355). ``strict`` governs missing *files*,
-            # so it cannot be relied on to make a malformed row fatal-or-not; the
-            # production path (``cli._cmd_load``) passes strict=False. A single bad
-            # id must not kill a multi-hour, non-atomic load — the batches already
-            # committed would stay in Neo4j. Mirrors the null-``source_id`` handling
-            # five lines up: record it, count it, keep going.
-            try:
-                hid = hadith_node_id(sid)
-            except DoubledCorpusPrefixError as exc:
+            if reason == _DROP_CROSS_EDITION:
+                # da#220: a dedup-source (sanadset) hadith whose normalized matn
+                # already exists from a curated edition — curated wins (richer
+                # metadata). This is the drop the da#373 matn-key repair makes live.
+                total_skipped += 1
+                total_deduped += 1
+                continue
+            if reason == _DROP_MALFORMED:
+                # Quarantine, never abort (da#355) — but strict still makes a
+                # malformed id fatal. Re-mint under strict so the original
+                # DoubledCorpusPrefixError (with its message) propagates unchanged;
+                # otherwise record it, count it, keep going.
                 if strict:
-                    raise
-                all_errors.append(f"{fp.name} row {i}: {exc}")
+                    hadith_node_id(row["source_id"])  # re-raises DoubledCorpusPrefixError
+                all_errors.append(
+                    f"{fp.name} row {i}: malformed source_id={row.get('source_id')!r}"
+                )
                 total_skipped += 1
                 total_malformed += 1
                 continue
+            # KEEP. Fall back to the raw full text when a source supplies no
+            # separated matn: halimbahae / open_hadith / bihar populate
+            # ``full_text_ar`` only (they do not split isnad from matn). The loader
+            # persists matn_ar — not full_text_ar — so without this the Hadith node
+            # lands textless on the graph (da#190).
+            matn_ar = _effective_matn_ar(row)
             batch.append(
                 {
                     "id": hid,

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -486,14 +486,19 @@ def _load_hadiths(
                 continue
             if reason == _DROP_MALFORMED:
                 # Quarantine, never abort (da#355) — but strict still makes a
-                # malformed id fatal. Re-mint under strict so the original
-                # DoubledCorpusPrefixError (with its message) propagates unchanged;
-                # otherwise record it, count it, keep going.
-                if strict:
-                    hadith_node_id(row["source_id"])  # re-raises DoubledCorpusPrefixError
-                all_errors.append(
-                    f"{fp.name} row {i}: malformed source_id={row.get('source_id')!r}"
-                )
+                # malformed id fatal. Re-mint so the original DoubledCorpusPrefixError
+                # propagates unchanged under strict, and is recorded VERBATIM under
+                # non-strict (the production ``_cmd_load`` path): the quarantine must
+                # still say WHY — its message carries the ``doubled leading corpus``
+                # marker — or da#355's "stop guessing, start recording" contract
+                # silently degrades to a bare "malformed" tag (the exact diagnostic
+                # loss #373 is about).
+                try:
+                    hadith_node_id(row["source_id"])
+                except DoubledCorpusPrefixError as exc:
+                    if strict:
+                        raise
+                    all_errors.append(f"{fp.name} row {i}: {exc}")
                 total_skipped += 1
                 total_malformed += 1
                 continue

--- a/src/parse/composition.py
+++ b/src/parse/composition.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 import hashlib
 
 from src.parse.identity import HADITH_ID_PREFIX, ID_DELIMITER
-from src.utils.arabic import is_arabic, normalize_arabic
+from src.utils.arabic import is_arabic, normalize_arabic, strip_to_letters
 
 # source_corpus -> allowed collection slugs.
 #   None           = load all collections for this source. Equivalent to the
@@ -190,17 +190,28 @@ def canonical_matn_identity(matn_ar: str | None, matn_en: str | None) -> str | N
 
     The Arabic matn is preferred and normalized via
     :func:`src.utils.arabic.normalize_arabic` (diacritics / alif / hamza / taa
-    marbuta / tatweel folded, whitespace collapsed) so spelling variants between
-    editions converge; the English matn (lowercased) is the fallback when no
-    Arabic matn is present. The normalization mirrors ``src.resolve.parallels``'s
-    tokenizer so the dedup gate and the PARALLEL_OF detector agree on what the
-    "same text" is. The digest (not the raw matn) is returned so the loader's
-    identity index stays compact for the full ~650k-row corpus.
+    marbuta / tatweel folded, whitespace collapsed), then reduced to letters and
+    single spaces by :func:`src.utils.arabic.strip_to_letters`; the English matn
+    (lowercased) is stripped the same way and is the fallback when no Arabic matn
+    is present.
+
+    Stripping punctuation is what makes this gate actually FIRE (da#373). Two
+    editions of one tradition differ only by commas, editorial dashes and
+    quotation marks, and ``normalize_arabic`` folds orthography but keeps
+    punctuation — so an *exact* hash over its output almost never collided (it
+    dropped 3 rows of 853,218), silently admitting every cross-edition duplicate
+    it was built to remove. Punctuation is not part of the matn, so stripping it
+    only ever merges genuine textual twins, never distinct traditions.
+    ``src.resolve.parallels`` still tokenizes on ``normalize_arabic`` output
+    alone, but it compares token *sets* by Jaccard, which tolerates the odd
+    punctuation-bearing token; an exact hash cannot, which is why the strip lives
+    here. The digest (not the raw matn) is returned so the loader's identity
+    index stays compact for the full ~650k-row corpus.
     """
     if matn_ar and is_arabic(matn_ar):
-        normalized = normalize_arabic(matn_ar)
+        normalized = strip_to_letters(normalize_arabic(matn_ar))
     elif matn_en and matn_en.strip():
-        normalized = matn_en.lower()
+        normalized = strip_to_letters(matn_en.lower())
     else:
         return None
     tokens = normalized.split()

--- a/src/utils/arabic.py
+++ b/src/utils/arabic.py
@@ -16,6 +16,7 @@ __all__ = [
     "normalize_taa_marbuta",
     "normalize_arabic",
     "clean_whitespace",
+    "strip_to_letters",
     "is_arabic",
     "extract_transmission_phrases",
     "contains_transmission_marker",
@@ -200,6 +201,26 @@ def normalize_taa_marbuta(text: str) -> str:
 def clean_whitespace(text: str) -> str:
     """Collapse multiple whitespace characters to a single space and strip edges."""
     return _MULTI_WS_RE.sub(" ", text).strip()
+
+
+def strip_to_letters(text: str) -> str:
+    """Reduce *text* to Unicode letters and single spaces (da#373).
+
+    Every character that is neither a letter nor whitespace — punctuation,
+    digits, editorial dashes, quotation marks — is replaced by a space, and
+    runs of whitespace are then collapsed. Replacing (not deleting) means a
+    mark sitting *between* two words never fuses them, with or without an
+    adjacent space (``"متن،متن"`` and ``"متن، متن"`` both yield ``"متن متن"``).
+
+    This is the punctuation invariance :func:`normalize_arabic` deliberately
+    omits (it folds orthography but keeps punctuation): two editions of one
+    tradition differ by commas / dashes / quotes, so an *exact* matn hash must
+    strip them or it never collides. Unicode-letter aware, so it also serves
+    the English matn path. Idempotent — its output is only letters and single
+    spaces, both fixed points.
+    """
+    stripped = "".join(ch if ch.isalpha() or ch.isspace() else " " for ch in text)
+    return _MULTI_WS_RE.sub(" ", stripped).strip()
 
 
 def normalize_arabic(text: str) -> str:

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -1493,3 +1493,142 @@ class TestCompositionGateOnChainEdges:
         # ... and the mis network-edge file is routed by relation (skipped off
         # STUDIED_UNDER, da#133) without error — the gate did not perturb it.
         assert studied.created == 0
+
+
+class TestCrossEditionDedupVisibleToEdges:
+    """da#373 — the chain-edge loader gates on the node loader's REAL kept set, so a
+    cross-edition-deduped sanadset hadith yields no TRANSMITTED_TO / NARRATED edge.
+
+    Without this the edge loader re-derived only the composition gate from the id
+    string (``is_canonical_hadith_id`` keeps every sanadset id — the matn dedup is
+    invisible to it), so a repaired matn key would emit ~196k chain edges against
+    Hadith nodes the node loader dropped — the da#333 orphan bug on the axis nobody
+    had closed. Endpoints are set to exist, so the ONLY reason an edge is not
+    created is the da#373 drop: that is what makes these tests bite.
+    """
+
+    _SHARED_MATN = "انما الاعمال بالنيات"
+    _UNIQUE_MATN = "لا ضرر ولا ضرار"
+
+    def _write_curated_plus_dup(self, staging_dir: Path) -> None:
+        # lk curated edition occupies the identity; the sanadset copy shares its matn
+        # and is therefore cross-edition-deduped away by the node loader.
+        write_hadiths(
+            staging_dir,
+            [{"source_id": "lk:bukhari:1", "source_corpus": "lk", "matn_ar": self._SHARED_MATN}],
+            suffix="lk",
+        )
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "sanadset:1:dup",
+                    "source_corpus": "sanadset",
+                    "matn_ar": self._SHARED_MATN,
+                }
+            ],
+            suffix="sanadset_dup",
+        )
+
+    def test_deduped_sanadset_mention_drops_transmitted_to(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        self._write_curated_plus_dup(staging_dir)
+        write_narrator_mentions_resolved(
+            curated_dir,
+            [
+                {
+                    "mention_id": "m1",
+                    "hadith_id": "sanadset:1:dup",
+                    "source_corpus": "sanadset",
+                    "position_in_chain": 0,
+                    "canonical_narrator_id": "nar:1",
+                },
+                {
+                    "mention_id": "m2",
+                    "hadith_id": "sanadset:1:dup",
+                    "source_corpus": "sanadset",
+                    "position_in_chain": 1,
+                    "canonical_narrator_id": "nar:2",
+                },
+            ],
+        )
+        # Both narrator endpoints exist — so a pair, if built, WOULD create an edge.
+        mock_client.set_read_results(
+            [{"from_id": "nar:1", "to_id": "nar:2", "from_exists": True, "to_exists": True}]
+        )
+        results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        tt = next(r for r in results if r.edge_type == "TRANSMITTED_TO")
+        assert tt.created == 0
+        assert not any(
+            "[:TRANSMITTED_TO" in str(q) and "MERGE" in str(q) for q, _ in mock_client.calls
+        )
+
+    def test_deduped_sanadset_mention_drops_narrated(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        self._write_curated_plus_dup(staging_dir)
+        write_narrator_mentions_resolved(
+            curated_dir,
+            [
+                {
+                    "mention_id": "m1",
+                    "hadith_id": "sanadset:1:dup",
+                    "source_corpus": "sanadset",
+                    "position_in_chain": 0,
+                    "canonical_narrator_id": "nar:1",
+                },
+            ],
+        )
+        mock_client.set_read_results([{"narrator_exists": True, "hadith_exists": True}])
+        results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        narrated = next(r for r in results if r.edge_type == "NARRATED")
+        assert narrated.created == 0
+        assert not any("[r:NARRATED]" in str(q) for q, _ in mock_client.calls)
+
+    def test_non_deduped_sanadset_mention_keeps_transmitted_to(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        # A sanadset hadith with a UNIQUE matn (no curated twin) IS loaded, so its
+        # chain MUST survive — the fix must not over-drop legitimately-loaded chains.
+        write_hadiths(
+            staging_dir,
+            [{"source_id": "lk:bukhari:1", "source_corpus": "lk", "matn_ar": self._SHARED_MATN}],
+            suffix="lk",
+        )
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "sanadset:1:uniq",
+                    "source_corpus": "sanadset",
+                    "matn_ar": self._UNIQUE_MATN,
+                }
+            ],
+            suffix="sanadset_uniq",
+        )
+        write_narrator_mentions_resolved(
+            curated_dir,
+            [
+                {
+                    "mention_id": "m1",
+                    "hadith_id": "sanadset:1:uniq",
+                    "source_corpus": "sanadset",
+                    "position_in_chain": 0,
+                    "canonical_narrator_id": "nar:1",
+                },
+                {
+                    "mention_id": "m2",
+                    "hadith_id": "sanadset:1:uniq",
+                    "source_corpus": "sanadset",
+                    "position_in_chain": 1,
+                    "canonical_narrator_id": "nar:2",
+                },
+            ],
+        )
+        mock_client.set_read_results(
+            [{"from_id": "nar:1", "to_id": "nar:2", "from_exists": True, "to_exists": True}]
+        )
+        results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        tt = next(r for r in results if r.edge_type == "TRANSMITTED_TO")
+        assert tt.created == 1

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -1154,3 +1154,46 @@ class TestBuildLoadedHadithIds:
         ids = _hadith_ids_written(mock_client)
         assert "hdt:lk:bukhari:1" in ids
         assert "hdt:sanadset:1:dup" not in ids
+
+
+class TestMalformedIdDiagnostic:
+    """da#373 follow-up / da#355 — a quarantined double-prefixed staging row must
+    record WHY (the ``doubled leading corpus`` marker), not a bare ``malformed`` tag.
+
+    Unit-tier guard for the same contract the live
+    ``tests/integration/test_source_id_collision.py`` asserts against a real Neo4j.
+    The shared keep-decision (``_hadith_load_outcome``) swallows the
+    ``DoubledCorpusPrefixError``, so ``_load_hadiths`` must re-mint and record its
+    message verbatim in the non-strict (production ``_cmd_load``) path — a bare
+    generic string would silently degrade da#355's "stop guessing, start recording"
+    diagnostic, which is exactly the axis #373 is repairing.
+    """
+
+    def test_double_prefixed_row_records_marker_and_quarantines(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "sunnah:sunnah:bukhari:1:1:1",
+                    "collection_name": "bukhari",
+                    "source_corpus": "sunnah",
+                },
+                {
+                    "source_id": "lk:bukhari:1:1",
+                    "collection_name": "bukhari",
+                    "source_corpus": "lk",
+                },
+            ],
+            suffix="streaming",
+        )
+        results = load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        hadith_result = next(r for r in results if r.node_type == "Hadith")
+        assert hadith_result.skipped >= 1
+        assert hadith_result.malformed_ids >= 1
+        assert any("doubled leading corpus" in e for e in hadith_result.validation_errors), (
+            hadith_result.validation_errors
+        )
+        # Only the well-formed row loads; the doubled id never becomes a node.
+        assert _hadith_ids_written(mock_client) == {"hdt:lk:bukhari:1:1"}

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -1051,3 +1051,106 @@ class TestLoadAllNodes:
 
         results = load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
         assert all(r.created + r.merged > 0 or r.node_type in ("Chain",) for r in results)
+
+
+def _hadith_ids_written(client: MockNeo4jClient) -> set[str]:
+    """The set of Hadith node ids the loader actually wrote (from the MERGE batches)."""
+    ids: set[str] = set()
+    for query, batch in client.calls:
+        if isinstance(batch, list) and "MERGE (n:Hadith {id: row.id})" in str(query):
+            ids.update(item["id"] for item in batch)
+    return ids
+
+
+class TestBuildLoadedHadithIds:
+    """da#373 — build_loaded_hadith_ids reproduces EXACTLY the Hadith.id set the node
+    loader loads, so the edge loader can gate chain edges on the same kept set."""
+
+    _SHARED_MATN = "انما الاعمال بالنيات"
+    _UNIQUE_MATN = "لا ضرر ولا ضرار"
+
+    def test_matches_node_loader_kept_set(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        from src.graph.load_nodes import build_loaded_hadith_ids
+
+        write_hadiths(
+            staging_dir,
+            [{"source_id": "lk:bukhari:1", "source_corpus": "lk", "matn_ar": self._SHARED_MATN}],
+            suffix="lk",
+        )
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "sanadset:1:dup",
+                    "source_corpus": "sanadset",
+                    "matn_ar": self._SHARED_MATN,
+                },
+                {
+                    "source_id": "sanadset:1:uniq",
+                    "source_corpus": "sanadset",
+                    "matn_ar": self._UNIQUE_MATN,
+                },
+            ],
+            suffix="sanadset",
+        )
+        # fawaz six-books duplicate — dropped by the composition gate (da#191).
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "fawaz:bukhari:1",
+                    "source_corpus": "fawaz",
+                    "collection_name": "bukhari",
+                    "matn_ar": self._UNIQUE_MATN,
+                }
+            ],
+            suffix="fawaz",
+        )
+
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        loaded_by_loader = _hadith_ids_written(mock_client)
+
+        files = sorted(staging_dir.glob("hadiths_*.parquet"))
+        built = build_loaded_hadith_ids(files)
+
+        # The set the edge loader will consult is exactly the set the node loader loaded.
+        assert built == loaded_by_loader
+        assert "hdt:lk:bukhari:1" in built
+        assert "hdt:sanadset:1:uniq" in built
+        assert "hdt:sanadset:1:dup" not in built  # cross-edition deduped (da#220)
+        assert "hdt:fawaz:bukhari:1" not in built  # composition-dropped (da#191)
+
+    def test_punctuation_only_duplicate_is_deduped(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        # The sanadset copy differs from the curated lk edition ONLY by punctuation;
+        # da#373's strip makes the matn identities collide, so it is dropped. Before
+        # the strip it survived — this is the dead-gate defect at the loader level.
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "lk:bukhari:1",
+                    "source_corpus": "lk",
+                    "matn_ar": "انما الاعمال بالنيات",
+                }
+            ],
+            suffix="lk",
+        )
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "sanadset:1:dup",
+                    "source_corpus": "sanadset",
+                    "matn_ar": "«انما الاعمال بالنيات».",
+                }
+            ],
+            suffix="sanadset",
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        ids = _hadith_ids_written(mock_client)
+        assert "hdt:lk:bukhari:1" in ids
+        assert "hdt:sanadset:1:dup" not in ids

--- a/tests/test_parse/test_composition.py
+++ b/tests/test_parse/test_composition.py
@@ -206,3 +206,44 @@ class TestCanonicalMatnIdentity:
         with_en_a = canonical_matn_identity(self._MATN_PLAIN, "gloss one")
         with_en_b = canonical_matn_identity(self._MATN_PLAIN, "a different gloss")
         assert with_en_a == with_en_b
+
+
+class TestCanonicalMatnIdentityPunctuation:
+    """da#373 — punctuation is stripped before hashing, so two editions that differ
+    only by commas / dashes / quotes converge to ONE identity.
+
+    This is what makes the cross-edition gate actually fire: with the raw
+    ``normalize_arabic`` output (punctuation kept) it dropped 3 rows of 853,218,
+    silently admitting the duplicates it was built to remove.
+    """
+
+    _PLAIN = "انما الاعمال بالنيات"
+    _PUNCTUATED = "«انما»، الاعمال — بالنيات."
+
+    def test_arabic_punctuation_variants_collapse(self) -> None:
+        plain = canonical_matn_identity(self._PLAIN, None)
+        punct = canonical_matn_identity(self._PUNCTUATED, None)
+        assert plain is not None
+        assert plain == punct
+
+    def test_english_punctuation_stripped(self) -> None:
+        plain = canonical_matn_identity(None, "actions are by intentions")
+        punct = canonical_matn_identity(None, "Actions, are by intentions!")
+        assert plain is not None
+        assert plain == punct
+
+    def test_distinct_matn_still_distinct_after_strip(self) -> None:
+        # Stripping punctuation must not collapse genuinely different traditions.
+        a = canonical_matn_identity("انما الاعمال بالنيات", None)
+        b = canonical_matn_identity("لا ضرر ولا ضرار", None)
+        assert a is not None and b is not None
+        assert a != b
+
+    def test_non_letter_run_becomes_a_space_not_a_join(self) -> None:
+        # A non-letter char between two words becomes a SPACE, so it never fuses
+        # them into one token (which would corrupt the min-token gate). "متن3متن"
+        # keys the same as "متن متن", not as a single fused token.
+        fused = canonical_matn_identity("انما3الاعمال بالنيات", None)
+        spaced = canonical_matn_identity("انما الاعمال بالنيات", None)
+        assert fused is not None
+        assert fused == spaced


### PR DESCRIPTION
Closes #373

## Two defects, one PR (fixing either alone makes the graph worse)

### 1. `canonical_matn_identity` was a dead gate
It hashed `normalize_arabic(matn)`, which folds orthography but **keeps punctuation**. Editions of one tradition differ only by commas / editorial dashes / quotation marks, so the exact hash almost never collided — the cross-edition dedup dropped **3 of 853,218** staged rows and was effectively dead.

**Fix:** new `src.utils.arabic.strip_to_letters` reduces the matn to Unicode letters + single spaces before hashing (non-letter runs → a space, so a mark between two words never fuses them). `canonical_matn_identity` applies it to both the Arabic and English paths. Punctuation is not part of the matn, so this only ever merges genuine textual twins, never distinct traditions.

### 2. The edge loader could not see the dedup
The chain-edge loaders gated mentions with `is_canonical_hadith_id(hid)`, which re-derives only the **composition** slice from the id string and **structurally cannot see the matn dedup** (a `source_id` carries no matn). So node and edge loaders disagreed about the kept set by exactly the size of the cross-edition dedup — and repairing (1) alone would emit `TRANSMITTED_TO` / `NARRATED` edges against Hadith nodes the node loader dropped, re-creating the ~196k `fawaz:<book>:<n>`-class orphan-chain bug (da#333) on the axis nobody had closed.

**Fix:** the node loader now publishes its **real kept set** via `build_loaded_hadith_ids`, which replays a **single** keep-decision (`_hadith_load_outcome` — composition + cross-edition matn dedup + id well-formedness) over the same staging hadith files that `_load_hadiths` consumes. Both `_load_transmitted_to` and `_load_narrated` gate on that set (`_mention_hadith_survives`), computed once per `load_all_edges` and shared. Because both loaders route the keep-decision through one function, they can never drift. When no staging hadith files are present the gate falls back to `is_canonical_hadith_id` (pre-existing behavior; nothing to orphan against).

The existing `transmitted_to_hadith_ref.cypher` post-load invariant (da#325 — every `TRANSMITTED_TO.hadith_id` must resolve to a Hadith node) already asserts this for the dangling-property edge type.

## Tests bite (mutation-verified)
- **Defect 1:** reverting the strip zeroes `cross_edition_deduped` and fails `TestCanonicalMatnIdentityPunctuation` + `test_punctuation_only_duplicate_is_deduped`.
- **Defect 2:** reverting the edge gate back to `is_canonical_hadith_id` re-creates the orphan edge — `TestCrossEditionDedupVisibleToEdges` fails with NARRATED `created=1` against a deduped hadith.
- `test_matches_node_loader_kept_set` pins `build_loaded_hadith_ids == the node loader's written Hadith ids`.
- A keep-guard test (`test_non_deduped_sanadset_mention_keeps_transmitted_to`) ensures legitimately-loaded sanadset chains are **not** over-dropped.

## Verification
Full local⇄CI parity green: `ruff-format`, `ruff-lint`, `mypy-strict` (whole `src/`), full `pytest` suite (1932 passed / 6 skipped), gitleaks, actionlint, cspell — all via `pre-commit --hook-stage pre-push`.

Reviewers: @Kavitha Sundaramurthy (peer), @Alejandra Reyes-Fuentes (secondary). 2-reviewer + Opus merge-gate applies; do not merge until satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgdLmU3rttSQVewA45km6L