### PR TITLE
fix(#380): weight fuzzy_cluster death-year veto by death_year_provenance

### DIFF
--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -115,6 +115,16 @@ _CLUSTER_RATIO_THRESHOLD = 90.0
 # are not the same person). One source rounding a death year by a year is fine.
 _DEATH_YEAR_TOLERANCE = 2
 
+# Discounted band for a death year tagged ``uncorroborated`` (da#380). A weak
+# Stage-2 fuzzy bio match persists its year on the record but marks it
+# ``uncorroborated`` because it "may not steer the ... identities" of other
+# narrators (disambiguate.py, da#356). An OCR-corrupt uncorroborated year off by
+# a handful of AH years must therefore NOT veto a merge at the tight
+# ``_DEATH_YEAR_TOLERANCE``; only a gross, generations-apart spread still blocks.
+# Mirrors ``narrator_unify._gross_death_spread``'s da#431 sanity band (=50) so the
+# resolve stage weighs an uncorroborated year the same way everywhere.
+_UNCORROBORATED_DEATH_SPREAD = 50
+
 # Minimum number of *shared* significant (non-connector) name tokens required to
 # merge. token_set_ratio scores a bare given name as a perfect (100) subset of
 # every fuller name carrying it (``محمد`` ⊂ ``محمد بن اسماعيل البخاري``), and a
@@ -394,11 +404,27 @@ def _name_match(keys_a: list[str], keys_b: list[str], *, threshold: float) -> bo
 
 
 def _death_years_conflict(a: dict[str, Any], b: dict[str, Any]) -> bool:
-    """True when both carry a death year that disagree beyond the tolerance."""
+    """True when both carry a death year that disagree beyond the tolerance.
+
+    da#380 — the veto is provenance-weighted. Two *trusted* years (``corroborated``
+    or untagged ``None``) conflict at the tight :data:`_DEATH_YEAR_TOLERANCE`, as
+    before. But when EITHER year is tagged ``uncorroborated`` — a weak Stage-2 fuzzy
+    bio year that disambiguate persists yet excludes from steering identity
+    (da#356) — a small disagreement (e.g. an OCR-corrupt year off by a few) must NOT
+    veto a real merge; only a gross, generations-apart spread beyond
+    :data:`_UNCORROBORATED_DEATH_SPREAD` still blocks. This keeps corroborated-year
+    precision intact while stopping an uncorroborated year from vetoing at full
+    authority. Mirrors ``narrator_unify``'s corroborated-vs-gross-spread split.
+    """
     da, db = a.get("death_year_ah"), b.get("death_year_ah")
-    if isinstance(da, int) and isinstance(db, int):
-        return abs(da - db) > _DEATH_YEAR_TOLERANCE
-    return False
+    if not (isinstance(da, int) and isinstance(db, int)):
+        return False
+    uncorroborated = (
+        a.get("death_year_provenance") == "uncorroborated"
+        or b.get("death_year_provenance") == "uncorroborated"
+    )
+    tolerance = _UNCORROBORATED_DEATH_SPREAD if uncorroborated else _DEATH_YEAR_TOLERANCE
+    return abs(da - db) > tolerance
 
 
 def _genders_conflict(a: dict[str, Any], b: dict[str, Any]) -> bool:

--- a/tests/test_resolve/test_fuzzy_cluster.py
+++ b/tests/test_resolve/test_fuzzy_cluster.py
@@ -130,6 +130,72 @@ def test_conflicting_death_years_block_merge() -> None:
     assert sorted(len(g) for g in clusters) == [1, 1]  # stayed apart
 
 
+# ---------------------------------------------------------------------------
+# da#380 — the death-year veto is weighted by `death_year_provenance`. An
+# `uncorroborated` year (a weak Stage-2 fuzzy bio year, persisted but excluded
+# from steering identity — disambiguate.py da#356) must NOT veto a real merge at
+# the tight `_DEATH_YEAR_TOLERANCE`; only a gross spread still blocks it. These
+# guards go RED if the provenance tag is ignored (the pre-da#380 behaviour).
+# ---------------------------------------------------------------------------
+def test_uncorroborated_death_year_does_not_veto_small_spread() -> None:
+    """A small disagreement with one `uncorroborated` year still merges.
+
+    Spread = 5 AH — beyond `_DEATH_YEAR_TOLERANCE` (2) but far under
+    `_UNCORROBORATED_DEATH_SPREAD` (50). Ignoring the provenance tag (the old
+    year-blind veto) would split this real pair — this assertion is the guard.
+    """
+    a = _rec("محمد بن عبد الله", source_corpora=["itqan"], death_year_ah=150)
+    b = _rec(
+        "محمد بن عبد الله",
+        source_corpora=["sanadset"],
+        death_year_ah=155,
+        death_year_provenance="uncorroborated",
+    )
+    # Predicate-level guard: the discount is what clears the veto.
+    assert fc._death_years_conflict(a, b) is False
+    assert fc._death_years_conflict(b, a) is False  # symmetric
+    # End-to-end: the pair merges into one cluster.
+    clusters = cluster_records([a, b])
+    assert sorted(len(g) for g in clusters) == [2]
+
+
+def test_uncorroborated_gross_death_spread_still_blocks() -> None:
+    """A generations-apart namesake still blocks even when a year is uncorroborated."""
+    a = _rec("محمد بن عبد الله", source_corpora=["itqan"], death_year_ah=150)
+    b = _rec(
+        "محمد بن عبد الله",
+        source_corpora=["sanadset"],
+        death_year_ah=320,  # spread 170 > _UNCORROBORATED_DEATH_SPREAD (50)
+        death_year_provenance="uncorroborated",
+    )
+    assert fc._death_years_conflict(a, b) is True
+    clusters = cluster_records([a, b])
+    assert sorted(len(g) for g in clusters) == [1, 1]  # stayed apart
+
+
+def test_corroborated_death_years_keep_tight_tolerance() -> None:
+    """Two `corroborated` years 5 AH apart still conflict — the tight band is preserved.
+
+    Same spread (5) as the merging uncorroborated case above; here BOTH years are
+    corroborated, so the discount must NOT apply and the veto must still fire.
+    """
+    a = _rec(
+        "محمد بن عبد الله",
+        source_corpora=["itqan"],
+        death_year_ah=150,
+        death_year_provenance="corroborated",
+    )
+    b = _rec(
+        "محمد بن عبد الله",
+        source_corpora=["sanadset"],
+        death_year_ah=155,
+        death_year_provenance="corroborated",
+    )
+    assert fc._death_years_conflict(a, b) is True
+    clusters = cluster_records([a, b])
+    assert sorted(len(g) for g in clusters) == [1, 1]  # stayed apart
+
+
 def test_conflicting_gender_blocks_merge() -> None:
     """Similar names with explicit differing gender must NOT merge."""
     a = _rec("عبد الله بن محمد", source_corpora=["itqan"], gender="male")


### PR DESCRIPTION
## Summary

`death_year_provenance` was written by `_upsert_canonical` and schema-declared, but **no production code read it**. As a result `fuzzy_cluster._death_years_conflict` (`src/resolve/fuzzy_cluster.py:396`) weighed an `uncorroborated` death year with exactly the same full authority as a `corroborated` one — an OCR-corrupt year attached by a weak Stage-2 fuzzy match could veto a genuine merge.

This adds the missing **consumer**: the death-year veto is now weighted by provenance.

## What I verified at wave-branch HEAD (`f3edd06`)

- The premise **still holds**: `_death_years_conflict` read only `death_year_ah`, provenance-blind. `_can_merge` / `_can_merge_cached` / `_stateless_merge_ok` all route through it, so it is the single fix point.
- `disambiguate.py:1441-1444` already documents the design intent I'm honoring: an uncorroborated bio year "is still PERSISTED ... tagged `uncorroborated` — it just may not steer the ... identities" of other narrators (da#356).
- A **sibling consumer already exists** — `narrator_unify.py` (da#431, added after the issue's PR #363 review) uses a two-band model: `_corroborated_death_conflict` (tight, corroborated-only) + `_gross_death_spread` (loose band, any provenance). The issue's "no production code reads it" is now narrowly out of date, but the reported defect in `fuzzy_cluster` is real and unaddressed. I mirrored narrator_unify's model rather than invent new semantics.

## The fix

`_death_years_conflict` is now two-band:
- **Both years trusted** (`corroborated` or untagged `None`) → conflict at the tight `_DEATH_YEAR_TOLERANCE` (=2), i.e. **unchanged** from today.
- **Either year `uncorroborated`** → only a gross, generations-apart spread beyond the new `_UNCORROBORATED_DEATH_SPREAD` (=50, mirrors `narrator_unify._gross_death_spread`) blocks.

**Precision-safe:** this only *relaxes* a veto (fewer false blocks), never causes a merge. Corroborated-year behavior is preserved. Untagged (`None`) years keep today's full-authority veto, so nothing regresses for records the provenance column doesn't cover.

## Consumer vs removal

The issue offered removal (dropping the column) as an alternative. Removal is **not** viable: `narrator_unify` (da#431) already reads the column as a load-bearing safety-net input, so dropping it would regress that stage. Adding the `fuzzy_cluster` consumer is the correct direction.

## Instrument + mutation check

- New tests: `test_uncorroborated_death_year_does_not_veto_small_spread` (the RED-on-mutation guard), `test_uncorroborated_gross_death_spread_still_blocks`, `test_corroborated_death_years_keep_tight_tolerance`. Both predicate-level and end-to-end `cluster_records`.
- **Mutation check:** reverted the discount (`tolerance = _DEATH_YEAR_TOLERANCE` unconditionally) → the small-spread guard **failed** (`assert True is False`); restored → all green.
- Full parity green: `tests/test_resolve/` 611 passed / 6 skipped; ruff-format + ruff-lint + mypy(strict) clean; commit- and push-stage pre-commit hooks passed; sync-drift gate OK.

Closes #380