### PR TITLE
fix(#295): informed blocking-token retention under the cap (name-first + corpus IDF)

### DIFF
--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -65,7 +65,8 @@ from __future__ import annotations
 import itertools
 import os
 import time
-from collections import defaultdict
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from pathlib import Path
@@ -221,13 +222,25 @@ _MAX_MATCH_KEYS_PER_RECORD: int | None = 64
 # ``C(t, 2)`` token pairs per record for its ``t`` significant tokens; a pollution
 # record with a 1,000-token "name" contributes ~500k posting entries and joins
 # that many blocks, which is what made the blocking build itself balloon to
-# multi-GB. Only the first ``_MAX_BLOCKING_TOKENS_PER_RECORD`` significant tokens
-# (deterministic sorted order) generate blocking pairs; the record is still fully
-# scored inside whatever blocks it does join, and the precision guards still read
-# its full token set. At 64 this affects <1% of records (the same pathological
-# tail) and never a normal name (p99 significant-token count is 34). ``None``
-# disables the cap.
+# multi-GB. Only ``_MAX_BLOCKING_TOKENS_PER_RECORD`` significant tokens generate
+# blocking pairs; the record is still fully scored inside whatever blocks it does
+# join, and the precision guards still read its full token set. At 64 this affects
+# 0.71% of records (771/107,951, da#295 corpus measure) and never a normal name
+# (p99 significant-token count is 55). ``None`` disables the cap. WHICH tokens survive
+# the cap is decided by :func:`_select_blocking_tokens` (da#295), not alphabetical
+# order.
 _MAX_BLOCKING_TOKENS_PER_RECORD: int | None = 64
+
+# Blocking-token *selection* strategy under the cap (da#295). The da#270 cap
+# originally kept ``sorted(tokens)[:cap]`` — the alphabetically-first tokens — so a
+# >cap-token record whose *name* tokens sort late could lose its name block
+# entirely (a genuine under-merge variant). :func:`_select_blocking_tokens` instead
+# keeps name tokens first, then the rarest (highest-IDF) tokens — the most
+# discriminative. This marker is folded into the resume fingerprint: block-list
+# membership depends on the selection rule, and the checkpoint skip-set is
+# POSITIONAL block indices, so any change to the rule MUST invalidate an in-flight
+# checkpoint (the da#303 misalignment class). Bump the version on any change here.
+_BLOCKING_TOKEN_SELECTION = "name-first-idf-v1"
 
 # Crash-resume for the multi-day block-scoring pass (da#272, PR2). The
 # checkpointed state is the union-find parent array + the set of applied block
@@ -349,6 +362,55 @@ def _significant_tokens(keys: list[str]) -> set[str]:
             if len(tok) >= 2 and tok not in _CONNECTOR_TOKENS:
                 tokens.add(tok)
     return tokens
+
+
+def _blocking_token_doc_freq(tok_caches: Iterable[set[str]]) -> Counter[str]:
+    """Corpus document frequency of every significant token (da#295).
+
+    ``df(token)`` = the number of records whose significant-token set contains it.
+    Computed once per run from the existing ``tok_cache`` (no extra tokenization);
+    the inverse (IDF) ranks tokens rarest-first for :func:`_select_blocking_tokens`,
+    so the most discriminative tokens survive the blocking-token cap.
+    """
+    df: Counter[str] = Counter()
+    for toks in tok_caches:
+        df.update(toks)
+    return df
+
+
+def _select_blocking_tokens(
+    name_tokens: set[str],
+    all_tokens: set[str],
+    doc_freq: Mapping[str, int],
+    cap: int,
+) -> set[str]:
+    """The ≤``cap`` significant tokens a record blocks on under the cap (da#295).
+
+    Selection order — **name tokens first, then rarest-first by corpus document
+    frequency** (highest IDF = most discriminative). Equal-df ties break
+    alphabetically so the choice is deterministic across runs (a resume
+    requirement). The full ``combinations`` fan-out is what the cap bounds; *which*
+    tokens feed it is decided here.
+
+    Rationale over the da#270 ``sorted(tokens)[:cap]`` default: alphabetical
+    truncation could drop a >cap-token record's *name* tokens when they sort late,
+    losing its name block entirely (a genuine under-merge variant, issue #295).
+    Keeping name tokens first guarantees the name block survives; ranking the
+    remainder rarest-first keeps the tokens that actually discriminate.
+
+    Returns ``all_tokens`` unchanged when the record is at or under the cap, so the
+    generated blocking pairs are byte-for-byte identical to the pre-da#295
+    behaviour for every record under the cap (the PR #277 invariant). Callers still
+    canonicalize the emitted pair by sorting, so pair keys stay consistent across
+    records regardless of selection.
+    """
+    if len(all_tokens) <= cap:
+        return all_tokens
+    names = name_tokens & all_tokens
+    others = all_tokens - names
+    ordered = sorted(names, key=lambda t: (doc_freq.get(t, 0), t))
+    ordered += sorted(others, key=lambda t: (doc_freq.get(t, 0), t))
+    return set(ordered[:cap])
 
 
 def count_unblockable(records: list[dict[str, Any]]) -> int:
@@ -816,17 +878,28 @@ def cluster_records(
     # ``_MAX_BLOCKING_TOKENS_PER_RECORD`` (da#270) caps t per record before the
     # C(t, 2) fan-out: a pollution record whose "name" is a captured isnad fragment
     # can carry >1,000 significant tokens, and its ~500k posting entries were what
-    # ballooned this build to multi-GB. Taking the first N sorted tokens is
-    # deterministic and bounds the fan-out; the record is still fully scored inside
-    # whatever blocks it joins, and the precision guards below read its full token
-    # set (``tok_cache``), so only the *reach* of the pathological tail is trimmed.
+    # ballooned this build to multi-GB. The cap bounds the fan-out; the record is
+    # still fully scored inside whatever blocks it joins, and the precision guards
+    # below read its full token set (``tok_cache``), so only the *reach* of the
+    # pathological tail is trimmed. WHICH tokens survive the cap is chosen by
+    # :func:`_select_blocking_tokens` (da#295) — name tokens first, then rarest-first
+    # by corpus IDF — so a >cap record keeps its name block instead of the
+    # alphabetically-first tokens. Under-cap records are returned unchanged, so their
+    # blocking pairs are identical to the pre-cap build (PR #277 invariant). The
+    # emitted pair is always canonicalized (``sorted``) so pair keys are consistent
+    # across records regardless of each record's selection.
     max_block_tokens = _MAX_BLOCKING_TOKENS_PER_RECORD
+    doc_freq = _blocking_token_doc_freq(tok_cache) if max_block_tokens is not None else Counter()
     pair_index: dict[tuple[str, str], list[int]] = defaultdict(list)
     for i in range(n):
-        block_tokens = sorted(tok_cache[i])
-        if max_block_tokens is not None:
-            block_tokens = block_tokens[:max_block_tokens]
-        for key in itertools.combinations(block_tokens, 2):
+        block_tokens = tok_cache[i]
+        if max_block_tokens is not None and len(block_tokens) > max_block_tokens:
+            name = safe_str(records[i].get("name_ar_normalized"))
+            name_tokens = _significant_tokens([name]) if name else set()
+            block_tokens = _select_blocking_tokens(
+                name_tokens, block_tokens, doc_freq, max_block_tokens
+            )
+        for key in itertools.combinations(sorted(block_tokens), 2):
             pair_index[key].append(i)
 
     # Apply the common-name cap: drop over-dense blocks up front so neither the
@@ -1353,13 +1426,16 @@ def cluster_canonical_narrators(
             canonical_path, {"content": _FINGERPRINT_CANONICAL_COLS}
         )
         # The da#270 caps (_MAX_MATCH_KEYS_PER_RECORD / _MAX_BLOCKING_TOKENS_PER_RECORD)
+        # AND the da#295 blocking-token selection strategy (_BLOCKING_TOKEN_SELECTION)
         # are module constants, not threaded params, but they shape the block
-        # UNIVERSE — the match-key cap feeds keys_cache/tok_cache and the
-        # blocking-token cap feeds pair_index → the `blocks` list membership,
+        # UNIVERSE — the match-key cap feeds keys_cache/tok_cache, the blocking-token
+        # cap bounds pair_index, and the selection rule decides WHICH tokens a
+        # >cap record contributes → all three change the `blocks` list membership,
         # order, and count. Because the resume skip-set is POSITIONAL block indices,
-        # a resume across a cap change would otherwise match the fingerprint yet
-        # restore indices pointing at different blocks. Hashing the caps discards
-        # the checkpoint on any cap change (da#303).
+        # a resume across any of these would otherwise match the fingerprint yet
+        # restore indices pointing at different blocks. Hashing them discards the
+        # checkpoint on any change (da#303). (_CONNECTOR_TOKENS is a known missing
+        # input, stable today; the da#271 track-3 PR that mutates it owns adding it.)
         fingerprint = hash_strings(
             digests["content"],
             round(threshold, 6),
@@ -1367,6 +1443,7 @@ def cluster_canonical_narrators(
             len(records),
             _MAX_MATCH_KEYS_PER_RECORD,
             _MAX_BLOCKING_TOKENS_PER_RECORD,
+            _BLOCKING_TOKEN_SELECTION,
         )
 
     clusters = cluster_records(

--- a/tests/test_resolve/test_cluster_resume.py
+++ b/tests/test_resolve/test_cluster_resume.py
@@ -203,6 +203,34 @@ def test_cap_change_across_resume_discards_checkpoint(
     assert metrics.merged_records == 0, "cap change must discard the checkpoint (cold re-cluster)"
 
 
+def test_blocking_selection_strategy_is_in_the_fingerprint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The da#295 selection marker (`_BLOCKING_TOKEN_SELECTION`) must be hashed.
+
+    The strategy decides WHICH tokens a >cap record contributes → it changes the
+    `blocks` list membership just like the caps do, and the skip-set is positional
+    block indices. So a resume across a strategy change must not match the
+    fingerprint. Assert the marker's value flows into the stored fingerprint:
+    two cold checkpoints that differ ONLY in the marker get different fingerprints
+    (this fails if the marker is dropped from the `hash_strings` call).
+    """
+    monkeypatch.setattr(fuzzy_cluster, "_CLUSTER_CHECKPOINT_SCORED_INTERVAL", 1)
+
+    def _fingerprint_at(strategy: str, name: str) -> str:
+        staging, canonical = _setup(tmp_path, name)
+        monkeypatch.setattr(fuzzy_cluster, "_BLOCKING_TOKEN_SELECTION", strategy)
+        with pytest.raises(StopAfterReached):
+            fuzzy_cluster.cluster_canonical_narrators(canonical, staging_dir=staging, stop_after=1)
+        ckpt = _checkpoint.load_checkpoint(_checkpoint.checkpoint_dir(staging, "cluster"))
+        assert ckpt is not None
+        return str(ckpt["fingerprint"])
+
+    fp_a = _fingerprint_at("name-first-idf-v1", "strat_a")
+    fp_b = _fingerprint_at("alphabetical-legacy", "strat_b")
+    assert fp_a != fp_b, "changing the selection strategy must change the resume fingerprint"
+
+
 def test_no_resume_ignores_checkpoint(tmp_path: Path) -> None:
     staging, canonical = _setup(tmp_path, "noresume")
     _checkpoint.save_checkpoint(

--- a/tests/test_resolve/test_fuzzy_cluster.py
+++ b/tests/test_resolve/test_fuzzy_cluster.py
@@ -541,6 +541,83 @@ def test_blocking_token_cap_bounds_reach(monkeypatch: pytest.MonkeyPatch) -> Non
     assert sorted(len(g) for g in capped) == [1, 1], "cap drops the late-token block"
 
 
+# ---------------------------------------------------------------------------
+# da#295: informed blocking-token retention under the cap (name-first + IDF)
+# ---------------------------------------------------------------------------
+def test_select_blocking_tokens_keeps_name_tokens_first() -> None:
+    """The cap keeps a record's NAME tokens even when they sort alphabetically last.
+
+    This is the da#295 fix: alphabetical ``sorted(tokens)[:cap]`` would drop
+    late-sorting name tokens in favour of early-sorting alias/pollution tokens,
+    losing the record's name block. Name-first retention keeps them.
+    """
+    name_tokens = {"يمم", "ينن"}  # sort AFTER every ب-initial token below
+    padding = {"ببا", "ببب", "ببت", "ببج"}
+    all_tokens = name_tokens | padding
+    # Uniform df so ONLY the name-first rule (not IDF) decides — isolates the axis.
+    doc_freq = dict.fromkeys(all_tokens, 1)
+    kept = fc._select_blocking_tokens(name_tokens, all_tokens, doc_freq, cap=2)
+    assert kept == name_tokens, "name tokens must survive the cap despite sorting last"
+
+
+def test_select_blocking_tokens_fills_remainder_rarest_first() -> None:
+    """After name tokens, the cap fills from the rarest (highest-IDF) tokens."""
+    name_tokens = {"nم"}
+    # df: rare=1 (most discriminative) ... common=9. Rarest should win the slots.
+    others = {"rare1": 1, "rare2": 2, "midxx": 5, "common": 9}
+    all_tokens = name_tokens | set(others)
+    doc_freq = {"nم": 3, **others}
+    kept = fc._select_blocking_tokens(name_tokens, all_tokens, doc_freq, cap=3)
+    # name token always in; the two remaining slots go to the two rarest others.
+    assert kept == {"nم", "rare1", "rare2"}
+
+
+def test_select_blocking_tokens_ties_break_alphabetically() -> None:
+    """Equal-df ties break alphabetically so selection is deterministic on resume."""
+    name_tokens: set[str] = set()
+    all_tokens = {"bbb", "aaa", "ccc"}
+    doc_freq = dict.fromkeys(all_tokens, 4)  # all tied
+    kept = fc._select_blocking_tokens(name_tokens, all_tokens, doc_freq, cap=2)
+    assert kept == {"aaa", "bbb"}, "ties keep the alphabetically-first tokens"
+
+
+def test_select_blocking_tokens_under_cap_returns_all_unchanged() -> None:
+    """PR #277 invariant: a record at or under the cap is returned unchanged.
+
+    Identity (``is``) matters — the caller then emits ``combinations(sorted(...))``
+    exactly as the pre-da#295 build did, so under-cap blocking is byte-identical.
+    """
+    all_tokens = {"aa", "bb", "cc"}
+    kept = fc._select_blocking_tokens({"aa"}, all_tokens, dict.fromkeys(all_tokens, 1), cap=3)
+    assert kept is all_tokens
+
+
+def test_blocking_cap_retains_late_sorting_name_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: a >cap record still merges on its late-sorting name (da#295).
+
+    ``poll`` carries its two real name tokens (يمم/ينن, which sort LAST) plus four
+    alias tokens that sort first. Under the old alphabetical cap of 2 the alias
+    tokens would evict the name tokens and ``poll`` would never co-block with its
+    genuine name variant. Name-first retention keeps the name block, so they merge.
+
+    Mutation check: reverting the selection to ``sorted(tok_cache[i])[:cap]`` makes
+    both records land in singleton clusters (``[1, 1]``) — this asserts ``[2]``.
+    """
+    poll = _rec(
+        "يمم ينن",
+        source_corpora=["x"],
+        aliases=["ببا", "ببب", "ببت", "ببج"],
+    )
+    variant = _rec("يمم ينن", source_corpora=["y"])
+
+    monkeypatch.setattr(fc, "_MAX_BLOCKING_TOKENS_PER_RECORD", 2)
+    clusters = cluster_records([poll, variant])
+
+    assert sorted(len(g) for g in clusters) == [2], (
+        "the late-sorting name block must survive the cap and merge the variant"
+    )
+
+
 def test_unset_precision_defaults_to_unknown(tmp_path: Path) -> None:
     """da#239: records carrying no precision key must round-trip through the
     builder with both precision columns defaulted to UNKNOWN — never null."""


### PR DESCRIPTION
## What & why

Follow-up from PR #277 (da#270 fuzzy_cluster caps), recorded as TechDebt by both reviewers. The blocking-token cap kept `sorted(tok_cache)[:cap]` — the **alphabetically-first** tokens — so a >cap-token record whose *name* tokens sort late could lose its name block entirely (a genuine under-merge variant, distinct from the accepted worst-block pair-drop).

## Change

- **`_select_blocking_tokens` (new):** truncation order is now **name tokens first, then rarest-first by corpus document frequency (IDF)**. IDF (`_blocking_token_doc_freq`) is computed once per run from the existing `tok_cache` — no extra tokenization. Equal-df ties break alphabetically for deterministic (resume-safe) selection.
- **Invariant preserved (PR #277):** a record at or under the cap is returned unchanged, and the emitted pair is always canonicalized (`sorted`), so under-cap blocking is byte-for-byte identical to the pre-da#295 build. `None` disables the cap → both strategies coincide.
- **Resume fingerprint:** `_BLOCKING_TOKEN_SELECTION` is folded into the cluster fingerprint. The selection rule changes `blocks`-list membership just like the caps do, and the checkpoint skip-set is **positional block indices**, so a resume across a strategy change MUST discard the checkpoint (the da#303 misalignment class the owner flagged). `_CONNECTOR_TOKENS` remains a known-missing fingerprint input (stable today; the da#271 track-3 PR that mutates it owns adding it — noted inline).

## Cap-sensitivity (blocking layer, real 107,951-record curated corpus)

`max_sig_tokens=439`, `p99=55`.

| cap | >cap recs | name-loss (alpha) | blocks (alpha) | cand-pairs (alpha) | blocks (idf) | cand-pairs (idf) |
|----:|----------:|------------------:|---------------:|-------------------:|-------------:|-----------------:|
| 32  | 3,178 (2.9%) | 2,005 | 2,528,454 | 69,403,076 | 2,849,959 | 60,278,719 |
| **64** | **771 (0.71%)** | **476** | 3,235,221 | 98,203,075 | 3,540,728 | 88,104,909 |
| 128 | 143 | 78 | 3,893,354 | 121,545,057 | 4,117,803 | 114,489,110 |
| 256 | 14 | 5 | 4,431,074 | 133,929,111 | 4,511,650 | 132,342,875 |
| None | 0 | 0 | 4,673,018 | 136,161,819 | 4,673,018 | 136,161,819 |

- **name-loss** = records whose alphabetical truncation drops >=1 *name* token that name-first retains. At the default **cap 64, 476 records** recover their name block.
- Name-first+IDF also **reduces** the candidate-pair estimate at every finite cap (88.1M vs 98.2M at 64) — it keeps rarer, higher-IDF tokens that land in smaller blocks.
- At `None`, both strategies are identical (invariant confirmed).
- **Default 64 re-confirmed:** it touches <1% of records and sits at the knee (32 -> 2.9% touched / 2,005 name-losses; 128 adds ~23M candidate pairs for only 65 fewer name-losses).
- **Deferred:** the full *merges-changed / pairs-kept* aggregate needs the multi-day 1.7B-pair scoring pass (not feasible in this environment) — left for a corpus scoring run so the reviewer/owner can decide if the merge-delta warrants revisiting the default.

## Tests (all mutation-checked)

- `_select_blocking_tokens`: name-first retention, rarest-first fill, alphabetical tie-break, under-cap returns full set unchanged.
- `test_blocking_cap_retains_late_sorting_name_block`: end-to-end — a late-sorting name block survives cap 2 and merges its variant (revert to alphabetical -> `[1,1]`).
- `test_blocking_selection_strategy_is_in_the_fingerprint`: the strategy marker changes the resume fingerprint (drop it -> test fails).

## Gate

`ruff format` + `ruff check` clean; `mypy src/` (109 files) clean; full `tests/test_resolve/` suite **617 passed, 6 skipped**.

Refs #270. Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z
