### PR TITLE
fix(#299): fold Urdu letterforms + extract Arabic span from kaggle rijāl bios

### DIFF
--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -167,6 +167,27 @@ __all__ = [
 # no markup character can survive into a canonical name (da#247 acceptance).
 _MARKUP_RE = re.compile(r"<[^>]*>")
 
+# Latin / English benediction abbreviations (da#299). English-gloss sources store
+# a romanized name carrying a parenthesized benediction — "Prophet Muhammad(saw)",
+# "Abu Hurayra (r.a.)", "Ali (as)". normalize_arabic leaves Latin untouched, so
+# the Arabic honorific phrases never catch these. Matched ONLY when parenthesized
+# or bracketed, so a bare "as"/"ra"/"sa" substring INSIDE a real romanized name is
+# never touched (precision-first). Covers the dotted forms ("s.a.w.", "r.a.").
+_LATIN_BENEDICTION_RE = re.compile(
+    r"[(\[]\s*(?:s\.?a\.?w\.?w?|p\.?b\.?u\.?h|r\.?a\.?a?|r\.?a\.?h|a\.?s|s\.?w\.?t|r\.?t\.?a)\s*\.?\s*[)\]]",
+    re.IGNORECASE,
+)
+
+# Leading Latin honorific TITLE words (da#299) prefixed to a romanized name in the
+# same English-gloss sources — "Prophet Muhammad", "Hazrat Ali", "Sayyidina …".
+# Stripped only when they LEAD the span (a title, not a name component); a name
+# that merely CONTAINS one of these tokens mid-string is untouched. Closed set of
+# unambiguous honorific prefixes — precision-first.
+_LATIN_TITLE_RE = re.compile(
+    r"^\s*(?:prophet|hazrat|hadhrat|sayyidina|sayyiduna|sayyidna|imam)\s+",
+    re.IGNORECASE,
+)
+
 # Editorial connective ("that is / i.e.") — never part of a name.
 _CONNECTIVE_TOKENS = frozenset({"يعني"})
 
@@ -269,6 +290,19 @@ _HONORIFIC_PHRASES: tuple[str, ...] = (
     "رحمه الله",
     "عز وجل",
     "تبارك وتعالى",
+    # Urdu-folded taṣliya (da#299): normalize_arabic now folds the Urdu yeh ی
+    # (U+06CC) to the Arabic yeh ي, so a benediction typed in Urdu script —
+    # "صلی اللہ علیہ وسلم" — normalizes to "صلي الله عليه وسلم" (regular yeh),
+    # NOT the alif-maqsura "صلى …" spelling the Arabic-sourced forms above carry.
+    # Same asymmetry the da#308 رضى/رضي pair already handles: list the yeh spelling
+    # so an Urdu-script name folds to the SAME benediction-stripped canonical form
+    # as its Arabic twin. Longest-first (the strip loop) so the وسلم/واله forms win
+    # before the bare "صلي الله عليه".
+    "صلي الله عليه واله وسلم",
+    "صلي الله عليه وسلم",
+    "صلي الله عليه واله",
+    "صلي الله عليه و اله",
+    "صلي الله عليه",
     # taṣliya LIGATURE (da#311): the single-codepoint ﷺ (U+FDFA, "ARABIC LIGATURE
     # SALLALLAHOU ALAYHE WASALLAM") is the same benediction as the spelled-out
     # "صلى الله عليه وسلم" above but survives normalize_arabic untouched (it is
@@ -1548,6 +1582,17 @@ def _strip_markup_and_honorifics(name_normalized: str) -> str:
     for phrase in _HONORIFIC_TITLE_PHRASES:
         if phrase in text:
             text = text.replace(phrase, " ")
+
+    # 2c. Latin / English benediction + leading-title residue (da#299). A romanized
+    #     name from an English-gloss source carries a parenthesized benediction
+    #     ("Muhammad(saw)") and/or a leading honorific title ("Prophet Muhammad");
+    #     normalize_arabic leaves Latin untouched, so neither is caught by the Arabic
+    #     honorific phrases above. Strip the parenthesized benediction anywhere and
+    #     the honorific title only where it LEADS. (For the kaggle bio path the
+    #     Arabic-span extraction has already dropped all Latin, so this is a no-op
+    #     there; it recovers the name for the other English-gloss sources.)
+    text = _LATIN_BENEDICTION_RE.sub(" ", text)
+    text = _LATIN_TITLE_RE.sub("", text)
     return text
 
 

--- a/src/parse/sanadset.py
+++ b/src/parse/sanadset.py
@@ -84,6 +84,7 @@ from src.parse.schemas import (
 )
 from src.utils.arabic import (
     contains_transmission_marker,
+    extract_arabic_span,
     extract_transmission_phrases,
     is_arabic,
     normalize_arabic,
@@ -973,7 +974,15 @@ def _parse_narrators_bio(narrators_dir: Path) -> pa.Table | None:
                 col: table.column(col)[i].as_py() for col in table.column_names
             }
 
-            name_ar = safe_str(row_dict.get(field_map.get("name_ar", "")))
+            name_ar_raw = safe_str(row_dict.get(field_map.get("name_ar", "")))
+            # kaggle rijāl bios store the name as a mixed Latin + Urdu-script +
+            # Arabic blob ("Prophet Muhammad(saw) ( محمد … ( رضي الله عنه"). Pull
+            # the Arabic span out so the stored name_ar is the Arabic name rather
+            # than the Latin gloss + parenthesised benediction (da#299). A value
+            # with no Arabic at all is returned unchanged, so an English-only bio
+            # row is not blanked; the benediction tail is left for the name-quality
+            # cleaner (bio_promote / ner) to strip, exactly as for the other sources.
+            name_ar = extract_arabic_span(name_ar_raw) if name_ar_raw else name_ar_raw
             ext_id = safe_str(row_dict.get(field_map.get("external_id", "")))
             # The bio_id is a narrator-biography provenance key namespaced by the
             # *bio source* (``kaggle_narrators``), which is NOT a hadith

--- a/src/utils/arabic.py
+++ b/src/utils/arabic.py
@@ -14,10 +14,12 @@ __all__ = [
     "normalize_alif",
     "normalize_hamza",
     "normalize_taa_marbuta",
+    "normalize_urdu",
     "normalize_arabic",
     "clean_whitespace",
     "strip_to_letters",
     "is_arabic",
+    "extract_arabic_span",
     "extract_transmission_phrases",
     "contains_transmission_marker",
     "canonical_surface",
@@ -55,6 +57,45 @@ _FORMAT_MARKS_RE: re.Pattern[str] = re.compile(
 
 # Multiple whitespace
 _MULTI_WS_RE: re.Pattern[str] = re.compile(r"\s+")
+
+# Urdu / Persian letter variants -> their Arabic-script equivalents (da#299). The
+# kaggle rijal bios spell names (and their benediction tails, "salla llahu alayhi
+# wa-sallam") with Urdu keyboard letterforms -- the Urdu yeh U+06CC, keheh
+# U+06A9, heh-goal U+06C1, ... -- which are DISTINCT codepoints from the Arabic
+# letters they render (yeh U+064A, kaf U+0643, heh U+0647). Left un-folded, an
+# Urdu-script name never collapses onto the canonical form of its Arabic twin, so
+# the honorific-strip and canonical-id keying both miss it. This fold is
+# precision-safe by construction: every key is a Urdu/Persian-specific codepoint
+# that does not occur in real Arabic name text, so folding it can only touch
+# Urdu-script input -- an all-Arabic name passes through untouched. Only variants
+# with an unambiguous Arabic target are folded; Urdu/Persian consonants that have
+# NO Arabic counterpart (peh, cheh, jeh, gaf, retroflexes) are deliberately left
+# alone rather than invented a fold for (precision-first).
+_URDU_FOLD_MAP: dict[str, str] = {
+    "ک": "ك",  # KEHEH                 -> KAF
+    "ڪ": "ك",  # SWASH KAF             -> KAF
+    "ی": "ي",  # FARSI YEH             -> YEH
+    "ے": "ي",  # YEH BARREE            -> YEH
+    "ۓ": "ي",  # YEH BARREE WITH HAMZA -> YEH
+    "ہ": "ه",  # HEH GOAL              -> HEH
+    "ۂ": "ه",  # HEH GOAL WITH HAMZA   -> HEH
+    "ۀ": "ه",  # HEH WITH YEH ABOVE    -> HEH
+    "ھ": "ه",  # HEH DOACHASHMEE       -> HEH
+    "ں": "ن",  # NOON GHUNNA           -> NOON
+}
+_URDU_TRANSLATION: dict[int, str] = str.maketrans(_URDU_FOLD_MAP)
+
+# Arabic-script characters (base block U+0600-06FF, supplement U+0750-077F,
+# extended-A U+08A0-08FF, plus the presentation-forms ranges U+FB50-FDFF /
+# U+FE70-FEFF). Used to pull the Arabic name out of a mixed Latin+Arabic bio blob
+# (da#299). Including the presentation-forms ranges keeps a stray ligature (e.g.
+# the tasliya U+FDFA) riding with the span rather than torn out mid-name.
+_ARABIC_SPAN_CLASS: str = r"؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-﻿"
+# A maximal run of characters that are NEITHER Arabic-script NOR whitespace -- a
+# Latin word, an ASCII digit run, a parenthesis, punctuation. Replaced by a space
+# so the Arabic runs on either side of a dropped Latin chunk join into one span
+# rather than fusing across it.
+_NON_ARABIC_RUN_RE: re.Pattern[str] = re.compile(rf"[^{_ARABIC_SPAN_CLASS}\s]+")
 
 # Arabic script block: U+0600–U+06FF
 _ARABIC_CHAR_RE: re.Pattern[str] = re.compile(r"[\u0600-\u06FF]")
@@ -198,6 +239,19 @@ def normalize_taa_marbuta(text: str) -> str:
     return _TAA_MARBUTA_RE.sub("\u0647", text)
 
 
+def normalize_urdu(text: str) -> str:
+    """Fold Urdu/Persian letter variants to their Arabic equivalents (da#299).
+
+    Maps the Urdu-specific letterforms that render the SAME letter as an Arabic
+    codepoint (keheh->kaf, Farsi/barree yeh->yeh, heh-goal/doachashmee->heh,
+    noon-ghunna->noon) onto that Arabic letter (see :data:`_URDU_FOLD_MAP`). Every
+    mapped codepoint is Urdu/Persian-specific and never occurs in real Arabic name
+    text, so this is a no-op on all-Arabic input and only ever touches Urdu-script
+    names -- the property that makes it safe to run inside :func:`normalize_arabic`.
+    """
+    return text.translate(_URDU_TRANSLATION)
+
+
 def clean_whitespace(text: str) -> str:
     """Collapse multiple whitespace characters to a single space and strip edges."""
     return _MULTI_WS_RE.sub(" ", text).strip()
@@ -229,14 +283,22 @@ def normalize_arabic(text: str) -> str:
     Steps:
     1. Strip bidi / zero-width / format control marks
     2. Strip diacritics
-    3. Normalize alif variants
-    4. Normalize hamza variants
-    5. Normalize taa marbuta
-    6. Strip tatweel (kashida)
-    7. Collapse whitespace
+    3. Fold Urdu/Persian letter variants to Arabic (da#299)
+    4. Normalize alif variants
+    5. Normalize hamza variants
+    6. Normalize taa marbuta
+    7. Strip tatweel (kashida)
+    8. Collapse whitespace
+
+    The Urdu fold (step 3) runs BEFORE the alif/hamza/taa steps so a folded
+    letter is then carried through the rest of the pipeline identically to its
+    Arabic twin — e.g. Urdu ``ہ`` -> Arabic ``ه`` is indistinguishable from a
+    sourced ``ه`` downstream. It is a no-op on all-Arabic input (see
+    :func:`normalize_urdu`), so no existing normalization result changes.
     """
     text = strip_format_marks(text)
     text = strip_diacritics(text)
+    text = normalize_urdu(text)
     text = normalize_alif(text)
     text = normalize_hamza(text)
     text = normalize_taa_marbuta(text)
@@ -248,6 +310,29 @@ def normalize_arabic(text: str) -> str:
 def is_arabic(text: str) -> bool:
     """Return True if *text* contains at least one Arabic script character (U+0600–U+06FF)."""
     return bool(_ARABIC_CHAR_RE.search(text))
+
+
+def extract_arabic_span(text: str) -> str:
+    """Pull the Arabic-script name out of a mixed Latin+Arabic blob (da#299).
+
+    kaggle rijal bios store a name as a mixed blob — a Latin gloss, its
+    benediction abbreviation, then the Arabic name and an Arabic benediction tail
+    (``"Prophet Muhammad(saw) ( <arabic name> ( <arabic benediction>"``). Every
+    run of non-Arabic, non-space characters (Latin words, ASCII digits,
+    parentheses, punctuation) is replaced by a space and the whitespace collapsed,
+    so the surviving Arabic runs join into one span. The raw (voweled, still
+    Urdu-script) form is preserved — only :func:`normalize_arabic` folds it — so a
+    caller keeps the source's diacritics for display.
+
+    Returns the input (whitespace-collapsed) unchanged when it carries no Arabic
+    at all, so a pure-Latin name is never blanked. The benediction tail is NOT
+    stripped here (that is the name-quality cleaner's job); this only discards the
+    non-Arabic noise around the Arabic span.
+    """
+    if not text:
+        return text
+    span = clean_whitespace(_NON_ARABIC_RUN_RE.sub(" ", text))
+    return span if span else text.strip()
 
 
 def extract_transmission_phrases(text: str) -> list[tuple[int, int, str]]:

--- a/tests/test_parse/test_name_quality.py
+++ b/tests/test_parse/test_name_quality.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from src.parse.identity import make_canonical_id
 from src.parse.name_quality import (
     clean_narrator_name,
     clean_narrator_name_display,
@@ -11,7 +12,7 @@ from src.parse.name_quality import (
     split_compound_narrators,
     strip_markup,
 )
-from src.utils.arabic import normalize_arabic
+from src.utils.arabic import extract_arabic_span, normalize_arabic
 
 
 class TestIsMubhamRelational:
@@ -401,6 +402,66 @@ class TestBenedictionAndProphetReference:
         assert clean_narrator_name(normalize_arabic("انس بن مالك صلى الله عليه واله")) == (
             "انس بن مالك"
         )
+
+
+class TestUrduAndLatinResidue:
+    """da#299 — Urdu-script + Latin benediction/title residue in kaggle rijāl bios.
+
+    The kaggle bios store a mixed Latin + Urdu-script + Arabic blob. The Arabic
+    span is pulled out (:func:`extract_arabic_span`), Urdu letterforms fold to
+    Arabic (in :func:`normalize_arabic`), and the benediction — whether the Urdu
+    yeh-form or the Arabic maksura-form — is stripped, so an Urdu-script name
+    reaches the SAME benediction-free canonical form as its Arabic twin.
+    """
+
+    def _canonical(self, blob: str) -> str | None:
+        cleaned = clean_narrator_name(normalize_arabic(extract_arabic_span(blob)))
+        return make_canonical_id(cleaned) if cleaned else None
+
+    def test_urdu_blob_folds_to_arabic_twin_canonical(self) -> None:
+        urdu_blob = "Prophet Muhammad(saw) ( محمد صلی اللہ علیہ وسلم ( رضي الله عنه"
+        arabic_twin = "محمد صلى الله عليه وسلم رضي الله عنه"
+        assert self._canonical(urdu_blob) == self._canonical(arabic_twin)
+
+    def test_urdu_blob_reduces_to_the_bare_name(self) -> None:
+        urdu_blob = "Prophet Muhammad(saw) ( محمد صلی اللہ علیہ وسلم ( رضي الله عنه"
+        assert clean_narrator_name(normalize_arabic(extract_arabic_span(urdu_blob))) == "محمد"
+
+    def test_urdu_folded_tasliya_is_stripped(self) -> None:
+        # the Urdu benediction folds to the yeh-spelled "صلي …" form, which the
+        # da#299 honorific entries strip (mirrors the da#308 رضى/رضي pair).
+        name = "محمد بن یعقوب صلی اللہ علیہ وسلم"
+        assert clean_narrator_name(normalize_arabic(name)) == "محمد بن يعقوب"
+
+    # --- Latin / English benediction abbreviations stripped (parenthesized only) ---
+    @pytest.mark.parametrize(
+        ("polluted", "expected"),
+        [
+            ("Prophet Muhammad(saw)", "Muhammad"),
+            ("Abu Hurayra (r.a.)", "Abu Hurayra"),
+            ("Ali (as)", "Ali"),
+            ("Bilal (pbuh)", "Bilal"),
+            ("Hazrat Bilal", "Bilal"),
+            ("Sayyidina Umar", "Umar"),
+        ],
+    )
+    def test_latin_benediction_and_title_stripped(self, polluted: str, expected: str) -> None:
+        assert clean_narrator_name(normalize_arabic(polluted)) == expected
+
+    # --- PRECISION: a bare (non-parenthesized) benediction substring inside a real
+    #     romanized name is NOT stripped; real names pass through untouched ---
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Anas",
+            "Malik",
+            "Al-Zuhri",
+            "Asma",  # leading "as" substring, no parens → untouched
+            "Rabia",  # leading "ra" substring, no parens → untouched
+        ],
+    )
+    def test_precision_real_romanized_names_kept(self, name: str) -> None:
+        assert clean_narrator_name(normalize_arabic(name)) == name
 
 
 class TestMatnSentenceGate:

--- a/tests/test_parse/test_sanadset_parser.py
+++ b/tests/test_parse/test_sanadset_parser.py
@@ -279,6 +279,44 @@ class TestSanadsetParser:
         bio_ids = bio_table.column("bio_id").to_pylist()
         assert all(bid.startswith("kaggle_narrators:bios:") for bid in bio_ids)
 
+    def test_mixed_blob_bio_name_arabic_span_extracted(self, tmp_path: Path) -> None:
+        """da#299 — a mixed Latin+Urdu-script+Arabic bio name stores the Arabic span.
+
+        kaggle rijāl bios carry the name as a mixed blob
+        ("Prophet Muhammad(saw) ( محمد … ( رضي الله عنه"). The parser pulls the
+        Arabic span out for ``name_ar`` (dropping the Latin gloss + parenthesised
+        benediction), and ``name_ar_normalized`` folds the Urdu letterforms to
+        Arabic — so an Urdu-script bio and its Arabic twin share a normal form.
+        """
+        raw_dir = tmp_path / "raw" / "sanadset"
+        raw_dir.mkdir(parents=True)
+        narrators_dir = raw_dir / "narrators"
+        narrators_dir.mkdir()
+        staging_dir = tmp_path / "staging"
+
+        _make_sanadset_csv(raw_dir / "hadiths.csv")
+        (narrators_dir / "bios.csv").write_text(
+            "name,death_year\n"
+            "Prophet Muhammad(saw) ( محمد بن یعقوب صلی اللہ علیہ وسلم ( رضي الله عنه,329\n",
+            encoding="utf-8",
+        )
+
+        with patch("src.parse.sanadset.get_settings") as mock_settings:
+            mock_settings.return_value.data_raw_dir = tmp_path / "raw"
+            mock_settings.return_value.data_staging_dir = staging_dir
+            outputs = parse_sanadset(raw_dir=raw_dir, staging_dir=staging_dir)
+
+        row = pq.read_table(outputs["narrators_bio"]).to_pylist()[0]
+        # name_ar keeps ONLY the Arabic span — the Latin gloss + parens are gone.
+        assert "Prophet" not in row["name_ar"]
+        assert "(" not in row["name_ar"]
+        assert row["name_ar"].startswith("محمد بن")
+        # name_ar_normalized folds the Urdu Farsi-yeh (U+06CC) to the Arabic yeh,
+        # so the folded name substring is present and no Urdu yeh survives.
+        norm = row["name_ar_normalized"]
+        assert "ی" not in norm
+        assert "محمد بن يعقوب" in norm
+
 
 class TestSanadsetCollections:
     """Collection emission for APPEARS_IN linkage (da#219 / Path B-B1)."""

--- a/tests/test_utils/test_arabic.py
+++ b/tests/test_utils/test_arabic.py
@@ -7,12 +7,14 @@ import pytest
 from src.utils.arabic import (
     clean_whitespace,
     contains_transmission_marker,
+    extract_arabic_span,
     extract_transmission_phrases,
     is_arabic,
     normalize_alif,
     normalize_arabic,
     normalize_hamza,
     normalize_taa_marbuta,
+    normalize_urdu,
     strip_diacritics,
     strip_format_marks,
     transliterate,
@@ -128,6 +130,80 @@ class TestNormalizeTaaMarbuta:
 
 
 # ---------------------------------------------------------------------------
+# normalize_urdu (da#299)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeUrdu:
+    """da#299 — Urdu/Persian letterforms fold to their Arabic equivalents."""
+
+    @pytest.mark.parametrize(
+        ("urdu_char", "arabic_char"),
+        [
+            ("ک", "ك"),  # ک KEHEH               -> ك KAF
+            ("ڪ", "ك"),  # ڪ SWASH KAF           -> ك KAF
+            ("ی", "ي"),  # ی FARSI YEH           -> ي YEH
+            ("ے", "ي"),  # ے YEH BARREE          -> ي YEH
+            ("ۓ", "ي"),  # ۓ YEH BARREE W/ HAMZA -> ي YEH
+            ("ہ", "ه"),  # ہ HEH GOAL            -> ه HEH
+            ("ۂ", "ه"),  # ۂ HEH GOAL W/ HAMZA   -> ه HEH
+            ("ۀ", "ه"),  # ۀ HEH W/ YEH ABOVE    -> ه HEH
+            ("ھ", "ه"),  # ھ HEH DOACHASHMEE     -> ه HEH
+            ("ں", "ن"),  # ں NOON GHUNNA         -> ن NOON
+        ],
+    )
+    def test_each_variant_folds(self, urdu_char: str, arabic_char: str) -> None:
+        assert normalize_urdu(urdu_char) == arabic_char
+
+    def test_urdu_name_folds_to_arabic_form(self) -> None:
+        # علیہ (Urdu ی U+06CC + ہ U+06C1) folds to عليه (Arabic yeh + heh).
+        assert normalize_urdu("علیہ") == "عليه"
+
+    def test_all_arabic_is_noop(self) -> None:
+        """The fold only maps Urdu-specific codepoints — real Arabic passes through."""
+        for name in ("عبد الله بن عمر", "محمد", "ابو هريره", "علي"):
+            assert normalize_urdu(name) == name
+
+    def test_arabic_yeh_and_maksura_untouched(self) -> None:
+        # Regular yeh ي (U+064A) and alif-maqsura ى (U+0649) are Arabic, not folded.
+        assert normalize_urdu("علي") == "علي"
+        assert normalize_urdu("صلى") == "صلى"
+
+    def test_empty_string(self) -> None:
+        assert normalize_urdu("") == ""
+
+
+# ---------------------------------------------------------------------------
+# extract_arabic_span (da#299)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractArabicSpan:
+    """da#299 — pull the Arabic name out of a mixed Latin+Arabic bio blob."""
+
+    def test_mixed_blob_keeps_only_arabic_runs(self) -> None:
+        blob = "Prophet Muhammad(saw) ( محمد صلی اللہ علیہ وسلم ( رضي الله عنه"
+        # Latin, parens and ASCII dropped; the two Arabic runs join into one span
+        # (the raw voweled / Urdu-script form is preserved — normalization is
+        # a separate step).
+        assert extract_arabic_span(blob) == "محمد صلی اللہ علیہ وسلم رضي الله عنه"
+
+    def test_no_arabic_returns_input(self) -> None:
+        assert extract_arabic_span("John Smith") == "John Smith"
+
+    def test_pure_arabic_unchanged(self) -> None:
+        assert extract_arabic_span("عبد الله بن عمر") == "عبد الله بن عمر"
+
+    def test_latin_between_runs_does_not_fuse(self) -> None:
+        # A dropped Latin chunk becomes a space, so the Arabic tokens stay distinct
+        # rather than fusing into one word.
+        assert extract_arabic_span("علي X عمر") == "علي عمر"
+
+    def test_empty_string(self) -> None:
+        assert extract_arabic_span("") == ""
+
+
+# ---------------------------------------------------------------------------
 # clean_whitespace
 # ---------------------------------------------------------------------------
 
@@ -178,6 +254,25 @@ class TestNormalizeArabic:
         result = normalize_arabic("Hello أحمد World")
         assert "Hello" in result
         assert "World" in result
+
+    def test_urdu_name_normalizes_to_arabic_twin(self) -> None:
+        """da#299 — an Urdu-script name collapses onto its Arabic-twin normal form."""
+        # محمد بن یعقوب (Urdu ی) vs محمد بن يعقوب (Arabic yeh).
+        assert normalize_arabic("محمد بن یعقوب") == normalize_arabic("محمد بن يعقوب")
+
+    def test_urdu_benediction_folds_to_yeh_form(self) -> None:
+        """da#299 — the Urdu taṣliya folds to the regular-yeh spelling."""
+        assert normalize_arabic("صلی اللہ علیہ وسلم") == "صلي الله عليه وسلم"
+
+    def test_urdu_fold_is_idempotent(self) -> None:
+        text = "محمد بن یعقوب الکلینی"
+        assert normalize_arabic(normalize_arabic(text)) == normalize_arabic(text)
+
+    def test_all_arabic_normal_form_unchanged_by_urdu_step(self) -> None:
+        """da#299 must not perturb an existing all-Arabic normalization result."""
+        # Regression guard: the new fold step is a no-op on Arabic-only input.
+        for name in ("عبد الله بن عمر", "ابو هريره", "سفيان بن عيينه"):
+            assert normalize_arabic(name) == name
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #299.

## Problem
kaggle rijāl bios store the narrator name as a mixed **Latin + Urdu-script + Arabic** blob, e.g. `Prophet Muhammad(saw) ( محمد صلی اللہ … ( رضي الله عنه`. `clean_narrator_name` strips the *Arabic-script* benediction but the Latin residue and the **Urdu-script** letterforms survive, so an Urdu-script name never collapses onto the canonical form of its Arabic twin.

## Fix (three gaps, all closed)
1. **Urdu→Arabic folding** — new `normalize_urdu` (wired into `normalize_arabic` as step 3, before alif/hamza/taa). Folds the Urdu keheh `ک`→`ك`, Farsi/barree yeh `ی`/`ے`→`ي`, heh-goal/doachashmee `ہ`/`ھ`→`ه`, noon-ghunna `ں`→`ن`, etc. **Precision-safe by construction**: every mapped codepoint is Urdu/Persian-specific and never occurs in real Arabic name text, so the fold is a **no-op on all-Arabic input** (regression-guarded by a test). Urdu/Persian consonants with no Arabic counterpart (peh/cheh/jeh/gaf, retroflexes) are deliberately left alone.
2. **Arabic-span extraction** — new `extract_arabic_span`, used by the kaggle bio parser (`sanadset._parse_narrators_bio`): pulls the Arabic name out of the mixed blob for `name_ar`, dropping the Latin gloss + parenthesised benediction. A value with no Arabic is returned unchanged (English-only bios untouched).
3. **Latin/English benediction + title residue** in `clean_narrator_name`: strips parenthesised `(saw)`/`(pbuh)`/`(r.a.)`/`(as)` benedictions (**parens-anchored**, so a bare `as`/`ra` substring inside a real romanized name is never touched) and leading honorific titles (`Prophet`/`Hazrat`/`Sayyidina`/…). Adds the **yeh-spelled taṣliya** honorific entries so the Urdu-folded benediction `صلي الله عليه وسلم` is stripped — mirrors the existing da#308 `رضى`/`رضي` dual-spelling pattern.

## Verification
- Keystone test proves an Urdu-script blob folds to the **same `make_canonical_id`** as its Arabic twin.
- Latin `(saw)`/`(r.a.)`/`Hazrat` residue stripped; precision tests keep `Anas`/`Asma`/`Al-Zuhri` untouched.
- Kaggle-parser test asserts `name_ar` = the extracted Arabic span (no Latin/parens) and `name_ar_normalized` has the Urdu yeh folded.
- Every new test **mutation-checked** (each fails when its change is reverted).
- Full local⇄CI parity green: ruff-format, ruff-lint, mypy --strict, full pytest (2390 passed / 10 skipped), gitleaks. cspell/actionlint out of scope (docs/workflow only).

## Corpus/Docker note for reviewers
No Docker/Neo4j leg touched. The folding + extraction are pure-Python and unit-covered; the real-corpus effect (kaggle bio rows folding onto their Arabic twins) is exercised only at a full `make parse`+`make resolve` run, not in CI.