### PR TITLE
fix(#301): strip benediction from bio-only display name_ar

### DIFF
--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -270,6 +270,15 @@ _HONORIFIC_PHRASES: tuple[str, ...] = (
     "رضي الله عنه",
     "رضي الله عنها",
     "رضي الله عنهم",
+    # DUAL pronoun form (da#471): "رضي الله عنهما" ("… with both of them"), the
+    # standard benediction after a PAIR of Companions ("عبد الله بن عمر رضي الله
+    # عنهما"). It was absent, so the strip matched only the "رضي الله عنه" PREFIX
+    # and left a dangling "ما"/"ا" fragment — harmless while name_ar_normalized was
+    # the only cleaner output, but da#301 surfaces the cleaner on the DISPLAY name,
+    # where "عبد الله بن عمر ا" would become a Narrator label. Listed here (both ي
+    # and ى spellings); the LONGEST-FIRST strip loop removes it before the shorter
+    # عنه/عنها/عنهم forms, so the whole dual benediction goes cleanly.
+    "رضي الله عنهما",
     # alif-maqsura spelling (da#308): normalize_arabic does NOT fold ى→ي, so the
     # very common "رضى الله عنه" survives normalization distinct from the ي form
     # above and left an un-scrubbed benediction tail (e.g. "ابي هريره رضى الله عنه
@@ -278,6 +287,7 @@ _HONORIFIC_PHRASES: tuple[str, ...] = (
     "رضى الله عنه",
     "رضى الله عنها",
     "رضى الله عنهم",
+    "رضى الله عنهما",  # da#471 dual form, alif-maqsura spelling (see ي form above)
     # bare / truncated benediction fragments (da#311) — the source often stores a
     # benediction cut off before its pronoun tail ("… رضي الله", "… صلى الله عليه"
     # with no عنه/وسلم). Stripped LONGEST-FIRST (see the strip loop) so the full

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -360,10 +360,25 @@ def promote_bios_to_canonical(
                 # overwrites its name_ar), but a BIO-ONLY narrator surfaces the
                 # benediction in its label (the loader keys node.name on name_ar
                 # first). clean_narrator_name_display strips it while preserving the
-                # voweled surface; None (name_ar empty or all-eulogy) falls back to
-                # the cleaned normalized form via the loader's name_ar_normalized
-                # coalesce. Identity/matching are unchanged — cid + norm are as before.
+                # voweled surface. Identity/matching are unchanged — cid + norm are
+                # as before; only the display label changes.
+                #
+                # da#471 (review of da#301): the display MUST be consistent with the
+                # identity AND never empty/garbled. The graph loader stores name_ar
+                # VERBATIM (``SET n.name_ar = row.name_ar``; a None becomes ""), and
+                # does NOT coalesce the stored display to name_ar_normalized (that
+                # coalesce is only in the search-name derivation) — so a None display
+                # would surface as an EMPTY node label, worse than the raw eulogy.
+                # Two ways the display can go wrong here: (a) name_ar is honorific-only
+                # and cleans to None while name_ar_normalized is a real name (the
+                # fields diverged upstream); (b) clean_narrator_name_display's
+                # alignment fallback emits a denatured/garbled surface. Guard BOTH:
+                # keep the voweled display only when it normalizes back to the
+                # canonical `norm`; otherwise fall back to `norm` (clean, never empty
+                # when a real name exists, always consistent with the id).
                 display_name_ar = clean_narrator_name_display(name_ar) if name_ar else None
+                if not display_name_ar or normalize_arabic(display_name_ar) != norm:
+                    display_name_ar = norm
                 canonical_map[cid] = {
                     "canonical_id": cid,
                     "name_ar": display_name_ar,

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -30,6 +30,7 @@ from src.parse.base import safe_str
 from src.parse.identity import make_canonical_id
 from src.parse.name_quality import (
     clean_narrator_name,
+    clean_narrator_name_display,
     cleaner_removed_content,
     is_mubham_relational,
 )
@@ -351,9 +352,21 @@ def promote_bios_to_canonical(
                 # node after a truncation, not after an asserted name. Count it.
                 if truncated:
                     truncated_residue_minted += 1
+                # da#301: strip the benediction/eulogy from the DISPLAY name_ar on
+                # the new-node (bio-only) path. name_ar_normalized + make_canonical_id
+                # already use the cleaned form (`norm`), but the display `name_ar`
+                # kept the raw eulogy ("… رضي الله عنه"). That is harmless when the
+                # bio MERGES onto a clean mention-derived node (the else branch never
+                # overwrites its name_ar), but a BIO-ONLY narrator surfaces the
+                # benediction in its label (the loader keys node.name on name_ar
+                # first). clean_narrator_name_display strips it while preserving the
+                # voweled surface; None (name_ar empty or all-eulogy) falls back to
+                # the cleaned normalized form via the loader's name_ar_normalized
+                # coalesce. Identity/matching are unchanged — cid + norm are as before.
+                display_name_ar = clean_narrator_name_display(name_ar) if name_ar else None
                 canonical_map[cid] = {
                     "canonical_id": cid,
-                    "name_ar": name_ar,
+                    "name_ar": display_name_ar,
                     "name_en": safe_str(row.get("name_en")),
                     "name_ar_normalized": norm,
                     "aliases": [],

--- a/tests/test_parse/test_name_quality.py
+++ b/tests/test_parse/test_name_quality.py
@@ -940,6 +940,21 @@ class TestCleanNarratorNameDisplay:
         polluted = "الشيخ الجليل أبو جعفر محمد بن علي بن الحسين بن بابويه"
         assert clean_narrator_name_display(polluted) == ("أبو جعفر محمد بن علي بن الحسين بن بابويه")
 
+    def test_dual_benediction_leaves_no_dangling_token(self) -> None:
+        # da#471: the dual-pronoun benediction "رضي الله عنهما" (after a PAIR of
+        # Companions) was only prefix-matched by "رضي الله عنه", leaving a dangling
+        # "ا"/"ما" fragment ("عبد الله بن عمر ا"). Now stripped whole — the display
+        # is the clean voweled name, and the normalized cleaner drops it too.
+        display = clean_narrator_name_display("عَبْدُ اللَّهِ بْنُ عُمَر رضي الله عنهما")
+        assert display == "عَبْدُ اللَّهِ بْنُ عُمَر"
+        assert clean_narrator_name(normalize_arabic("عبد الله بن عمر رضي الله عنهما")) == (
+            "عبد الله بن عمر"
+        )
+        # alif-maqsura spelling of the dual form is stripped the same way.
+        assert clean_narrator_name(normalize_arabic("عبد الله بن عمر رضى الله عنهما")) == (
+            "عبد الله بن عمر"
+        )
+
     @pytest.mark.parametrize("empty", [None, "", "   ", "<NAR>"])
     def test_empty_display_returns_none(self, empty: str | None) -> None:
         assert clean_narrator_name_display(empty) is None

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -487,6 +487,84 @@ def test_bio_only_display_name_ar_strips_benediction(tmp_path: Path) -> None:
     assert rec["name_ar_normalized"] == normalize_arabic("ابو هريره")
 
 
+def test_bio_only_display_never_empty_when_name_ar_is_honorific_only(tmp_path: Path) -> None:
+    """da#471 gap 1: honorific-only name_ar + a distinct real name_ar_normalized.
+
+    clean_narrator_name_display(name_ar) is None (all-eulogy), and the graph loader
+    stores name_ar VERBATIM (None -> "") — it does NOT coalesce the stored display
+    to name_ar_normalized. Without the guard the bio-only node would get an EMPTY
+    label (worse than the pre-da#301 raw eulogy). The display must fall back to the
+    real (cleaned) name so the label is never empty when a real name exists.
+    """
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+
+    real_name = "انس بن مالك"
+    _write_bios(
+        staging,
+        "kaggle",
+        [
+            {
+                "bio_id": "kaggle:100",
+                "source": "kaggle_narrators",
+                # name_ar is PURE honorific (cleans to None), but the normalized
+                # field carries a real name — the divergence the guard must survive.
+                "name_ar": "رضي الله عنه",
+                "name_ar_normalized": normalize_arabic(real_name),
+            }
+        ],
+    )
+
+    rows = pq.read_table(promote_bios_to_canonical(staging, out_dir)).to_pylist()
+    rec = next(
+        r for r in rows if r["canonical_id"] == make_canonical_id(normalize_arabic(real_name))
+    )
+
+    # Never empty / None — falls back to the cleaned real name, consistent with id.
+    assert rec["name_ar"]
+    assert rec["name_ar"] == normalize_arabic(real_name)
+    assert rec["name_ar_normalized"] == normalize_arabic(real_name)
+
+
+def test_bio_only_display_dual_benediction_not_garbled(tmp_path: Path) -> None:
+    """da#471 gap 2: the dual-pronoun benediction "رضي الله عنهما" no longer leaves
+    a dangling fragment in the DISPLAY name (previously "عبد الله بن عمر ا").
+
+    Root-fixed by adding the dual form to the honorific set; the display stays
+    benediction-free and normalizes back to the canonical name (no stray token).
+    """
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+
+    raw = "عَبْدُ اللَّهِ بْنُ عُمَر رضي الله عنهما"
+    _write_bios(
+        staging,
+        "kaggle",
+        [
+            {
+                "bio_id": "kaggle:101",
+                "source": "kaggle_narrators",
+                "name_ar": raw,
+                "name_ar_normalized": normalize_arabic(raw),
+            }
+        ],
+    )
+
+    rows = pq.read_table(promote_bios_to_canonical(staging, out_dir)).to_pylist()
+    clean_norm = normalize_arabic("عبد الله بن عمر")
+    rec = next(r for r in rows if r["canonical_id"] == make_canonical_id(clean_norm))
+
+    # Benediction gone AND no dangling stray token — the display normalizes exactly
+    # to the canonical name (a "… ا" residue would fail this).
+    assert "رضي الله" not in rec["name_ar"]
+    assert normalize_arabic(rec["name_ar"]) == clean_norm
+    assert rec["name_ar_normalized"] == clean_norm
+
+
 # Verbatim `full_name` values from the acquired Itqan buckets — NOT synthetic. A
 # fabricated prose row would not exercise the truncation, and the guard could not go
 # red (feedback_fixture_makes_guard_assertion_inert). Provenance:

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -446,6 +446,47 @@ def test_bio_promote_applies_name_quality_filter(tmp_path: Path) -> None:
     assert clean_name in names
 
 
+def test_bio_only_display_name_ar_strips_benediction(tmp_path: Path) -> None:
+    """da#301: on the BIO-ONLY new-node path the DISPLAY name_ar is benediction-free.
+
+    name_ar_normalized + make_canonical_id already used the cleaned form, but the
+    display name_ar kept the raw eulogy — visible in the node label of a bio-only
+    narrator (the loader keys node.name on name_ar first). The voweled surface is
+    preserved; identity (canonical_id, name_ar_normalized) is unchanged.
+    """
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+
+    # A voweled bio name with a benediction suffix, minted BIO-ONLY (no attested
+    # mention node pre-exists this run, so it takes the new-node branch).
+    raw_display = "أَبُو هُرَيْرَة رضي الله عنه"
+    clean_display = "أَبُو هُرَيْرَة"
+    _write_bios(
+        staging,
+        "kaggle",
+        [
+            {
+                "bio_id": "kaggle:99",
+                "source": "kaggle_narrators",
+                "name_ar": raw_display,
+                "name_ar_normalized": normalize_arabic(raw_display),
+            }
+        ],
+    )
+
+    rows = pq.read_table(promote_bios_to_canonical(staging, out_dir)).to_pylist()
+    cid = make_canonical_id(normalize_arabic("ابو هريره"))
+    rec = next(r for r in rows if r["canonical_id"] == cid)
+
+    # DISPLAY name_ar: benediction stripped, vowels preserved (not the raw eulogy).
+    assert rec["name_ar"] == clean_display
+    assert "رضي الله عنه" not in rec["name_ar"]
+    # Identity/matching unchanged — normalized form is still the cleaned bare name.
+    assert rec["name_ar_normalized"] == normalize_arabic("ابو هريره")
+
+
 # Verbatim `full_name` values from the acquired Itqan buckets — NOT synthetic. A
 # fabricated prose row would not exercise the truncation, and the guard could not go
 # red (feedback_fixture_makes_guard_assertion_inert). Provenance:


### PR DESCRIPTION
Closes #301.

## Problem (observation 1 from PR #284)
In `bio_promote.promote_bios_to_canonical`, the cleaned form already feeds `name_ar_normalized` + `make_canonical_id`, but the **new-node path** stored the **raw** `name_ar` with the eulogy intact (`"… رضي الله عنه"`). Harmless when the bio **merges** onto a clean mention-derived node (the merge branch never overwrites its `name_ar`, and `name_ar` is not in `_BACKFILL_FIELDS`), but a **bio-only** narrator surfaces the benediction in its label — the graph loader keys `node.name` on `name_ar` first.

## Fix
On the new-node path, strip the benediction from the display `name_ar` via `clean_narrator_name_display`, which removes the eulogy while **preserving the voweled surface**. `None` (empty `name_ar`, or an all-eulogy value) falls back to the cleaned normalized form through the loader's existing `name_ar` → `name_ar_normalized` coalesce.

**Identity and matching are unchanged** — `canonical_id` + `name_ar_normalized` are exactly as before; only the display label changes. Scoped to the new-node branch only, per the issue.

Observation 2 (`_is_prophet_reference` being leader-anchored only) is the right precision-first call — the ask was observation 1 only; no change there.

## Verification
- Test: a bio-only benediction-suffixed name (`"أَبُو هُرَيْرَة رضي الله عنه"`) promotes with a benediction-free **voweled** display `name_ar` (`"أَبُو هُرَيْرَة"`) and an unchanged normalized form / canonical id. Mutation-checked (fails when the display reverts to the raw `name_ar`).
- Full local⇄CI parity green: ruff-format, ruff-lint, mypy --strict, full pytest (2400 passed / 10 skipped), gitleaks. cspell/actionlint out of scope.

## Corpus/Docker note
No Docker/Neo4j leg. The display-label improvement is visible at graph-load; the resolve-stage transform is unit-covered here.