### PR TITLE
bio_promote: discriminate gloss-tail vs name-cut refusals + quantify recall (da#397)

### DIFF
--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -156,6 +156,7 @@ __all__ = [
     "clean_narrator_name_display",
     "asserted_name_tokens",
     "cleaner_removed_content",
+    "is_recoverable_gloss_tail",
     "is_mubham_relational",
     "split_compound_narrators",
     "strip_markup",
@@ -1927,6 +1928,105 @@ def cleaner_removed_content(name_normalized: str | None, cleaned: str | None) ->
     if not name_normalized or not cleaned:
         return False
     return tuple(cleaned.split()) != asserted_name_tokens(name_normalized)
+
+
+# --- Gloss-tail vs name-cut discrimination (da#397) -----------------------------
+# Isnad TRANSMISSION connectors that open a "teacher key" — a rijāl compiler's
+# "<narrator> عن <teacher>" / "<narrator> حدثنا <student>" chain fragment appended
+# AFTER a complete name to disambiguate a narrator known through one chain. A removed
+# tail opening on one of these is a GLOSS about how the narrator transmitted, not
+# alternative name material. Deliberately a SUBSET of _ISNAD_BOUNDARY: it holds the
+# transmission verbs + عن and EXCLUDES the dispute/speech openers (قيل / قال / يقال /
+# وقيل — "it is said" / "he said"), which introduce a DISPUTED or alternative identity
+# and must not read as a mere gloss, and the relative-pronoun / temporal boundaries.
+_TEACHER_KEY_OPENERS = frozenset(
+    {
+        "عن",  # "from" — the canonical teacher key
+        "عنه",  # "from him"
+        "حدثنا",
+        "حدثني",
+        "حدث",
+        "حدثت",
+        "حدثاه",
+        "اخبرنا",
+        "اخبرني",
+        "انبانا",
+        "سمعت",
+        "سمع",
+        "روت",  # "she narrated" (روى sibling)
+    }
+)
+
+# Explicit disputed-identity markers (da#397). Even when a removed tail opens on a
+# teacher key AND the residue is a complete nasab, a tail carrying one of these grades
+# the SUBJECT unidentified/disputed — the ``محمد بن شرحبيل … وقيل اسمه عمرو مجهول`` case
+# — so the residue is NOT a safely-discriminating name. Checked against the removed
+# tail only, keeping the graded-مجهول / ``وقيل اسمه`` case conservative (class B /
+# refused). ``يعرف`` catches the ``لا يعرف`` ("not known") tail; the residue itself is
+# never inspected for these (a real name never carries them).
+_DISPUTED_IDENTITY_MARKERS = frozenset({"مجهول", "يعرف", "وقيل", "قيل", "يقال"})
+
+# Patronymic nasab connectors (da#397). A "complete nasab" residue must carry an
+# ``ibn`` link — narrower than :data:`_NASAB_CONNECTORS` (which also spares kunya
+# ``ابو``/``ابي`` and tribal ``بنو``): da#397's discriminating-name test is a
+# lineage ``<ism> بن <father> …``, not a bare kunya.
+_PATRONYMIC_CONNECTORS = frozenset({"بن", "ابن"})
+
+
+def is_recoverable_gloss_tail(name_normalized: str | None, cleaned: str | None) -> bool:
+    """True when a truncation is a class-A *gloss-tail* cut (da#397).
+
+    Discriminates da#397's two categorically different truncations, which
+    :func:`cleaner_removed_content` alone conflates:
+
+    * **Class A — gloss-tail (this returns True):** the removed tail opens on an isnad
+      TRANSMISSION connector (``عن`` / ``حدثنا`` / … — a teacher key, not name
+      material) AND the residue is a *complete nasab* (``>= 3`` tokens carrying a
+      patronymic ``بن``/``ابن``) AND the removed tail carries no disputed-identity
+      marker. The residue IS the discriminating name the source asserted
+      (``اسحاق بن مره عن انس`` → ``اسحاق بن مره``), so it is the
+      RECOVERABLE-pending-disambiguation subset.
+    * **Class B — name-cut (this returns False):** a bare ism/kunya residue
+      (``عبيده``, ``ابو نهشل``), a non-teacher-key cut (``… يقال`` / ``… الذي``), or a
+      tail/span carrying a disputed-identity marker (``مجهول`` / ``وقيل`` — the
+      ``محمد بن شرحبيل … مجهول`` homonym). Refusing these stays correct.
+
+    IMPORTANT — this does NOT decide the merge. Recovering class A onto an attested
+    narrator is NOT provably safe: :func:`~src.parse.identity.make_canonical_id` folds
+    Arabic inflection but NOT homonymy, and a complete nasab can still collide with a
+    homonym — measured, 45 of 240 class-A accept-target name-keys carry conflicting
+    jarḥ grades (one key graded both *thiqa* and *kadhdhab* = provably >1 person; da#397
+    PR#441 / da#423). So :func:`~src.resolve.bio_promote.promote_bios_to_canonical`
+    still REFUSES class A; this predicate only *quantifies* the recoverable subset
+    (splitting the refusal counter, da#398 scope-1) and is the precondition for a
+    future disambiguation-gated recovery. Same coarseness caveat as
+    :func:`cleaner_removed_content`: a token diff cannot answer the homonymy question.
+
+    Returns ``False`` for a non-truncation (nothing was cut) and for class B.
+    """
+    if not cleaned or not cleaner_removed_content(name_normalized, cleaned):
+        return False
+    asserted = asserted_name_tokens(name_normalized)
+    residue = tuple(cleaned.split())
+    # The removed material must be a TRAILING cut — residue is a strict prefix of the
+    # asserted tokens. When it is not (a colon-prose cut, or any unexpected shape) the
+    # removed-tail opener cannot be identified, so classify conservatively as name-cut.
+    if len(residue) >= len(asserted) or asserted[: len(residue)] != residue:
+        return False
+    removed_tail = asserted[len(residue) :]
+    # (a) tail opens on a teacher-key / transmission connector (not a dispute/speech
+    #     opener, not a relative pronoun / temporal boundary).
+    if removed_tail[0] not in _TEACHER_KEY_OPENERS:
+        return False
+    # (b) no disputed-identity marker anywhere in the removed tail — the graded-مجهول /
+    #     ``وقيل اسمه`` case stays conservative (class B).
+    if any(t in _DISPUTED_IDENTITY_MARKERS for t in removed_tail):
+        return False
+    # (c) residue is a COMPLETE nasab: >= 3 tokens carrying a patronymic connector. A
+    #     bare ism/kunya residue may not merge regardless of tail (da#397).
+    if len(residue) < 3:
+        return False
+    return any(t in _PATRONYMIC_CONNECTORS for t in residue)
 
 
 def clean_narrator_name_display(name_ar: str | None) -> str | None:

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -33,6 +33,7 @@ from src.parse.name_quality import (
     clean_narrator_name_display,
     cleaner_removed_content,
     is_mubham_relational,
+    is_recoverable_gloss_tail,
 )
 from src.resolve._inputs import require_input
 from src.resolve._run_record import write_canonical
@@ -244,6 +245,15 @@ def promote_bios_to_canonical(
     skipped_source = 0
     skipped_pollution = 0
     skipped_truncated_merge = 0
+    # da#397/da#398: split the refusal by WHAT the truncation removed. Class A
+    # (gloss-tail) is a complete nasab that lost only a teacher-key isnad tail — the
+    # RECOVERABLE-pending-disambiguation subset; class B (name-cut) is a bare ism/kunya
+    # residue, a dispute/speech cut, or a disputed-identity marker, and refusing it
+    # stays correct. Both are still refused below; the split only QUANTIFIES the
+    # recoverable subset (da#398 scope-1) and is the precondition for a future
+    # disambiguation-gated recovery. See is_recoverable_gloss_tail + da#397 PR#441.
+    skipped_truncated_merge_gloss_tail = 0
+    skipped_truncated_merge_name_cut = 0
     # The ACCEPTED truncated-residue residual (da#385). The guard only refuses a
     # truncated residue that would claim an *attested* node (mention_count > 0);
     # every other truncated residue is accepted — it either lands on a zero-mention
@@ -288,6 +298,12 @@ def promote_bios_to_canonical(
                 skipped_pollution += 1
                 continue
             truncated = cleaner_removed_content(norm, cleaned)
+            # da#397/da#398: classify the truncation as gloss-tail (class A, recoverable
+            # pending biographical homonym disambiguation) vs name-cut (class B, correctly
+            # refused) for the refusal-counter split. Computed on the PRE-clean `norm`
+            # (before it is reassigned to `cleaned` just below). This does NOT change the
+            # merge decision — both classes are still refused at the guard.
+            truncation_is_gloss_tail = truncated and is_recoverable_gloss_tail(norm, cleaned)
             norm = cleaned
 
             bio_id = safe_str(row.get("bio_id"))
@@ -345,6 +361,13 @@ def promote_bios_to_canonical(
             existing = canonical_map.get(cid)
             if truncated and existing is not None and (existing.get("mention_count") or 0) > 0:
                 skipped_truncated_merge += 1
+                # da#397/da#398: split the refusal — the gloss-tail (class A) count is
+                # the recall cost of the deliberate class-2 over-refusal, made a live
+                # per-run metric rather than a one-off script measurement (da#398 scope-1).
+                if truncation_is_gloss_tail:
+                    skipped_truncated_merge_gloss_tail += 1
+                else:
+                    skipped_truncated_merge_name_cut += 1
                 continue
 
             if cid not in canonical_map:
@@ -486,6 +509,26 @@ def promote_bios_to_canonical(
             ),
         )
 
+    # da#397/da#398: surface the gloss-tail refusals — the RECOVERABLE-pending-
+    # disambiguation subset. These are complete nasabs that lost only a teacher-key
+    # isnad tail, refused solely because make_canonical_id cannot rule out a homonym
+    # (45/240 class-A accept-target name-keys carry conflicting jarḥ grades, da#423).
+    # Emitting the count turns da#398's recall cost into a live metric, not a one-off
+    # script. Owner of the eventual recovery = biographical homonym disambiguation
+    # (jarḥ-grade / death-year separation), same bar as da#347b/da#431. The name-cut
+    # count is carried alongside so the split is legible from the log line alone.
+    if skipped_truncated_merge_gloss_tail:
+        logger.info(
+            "bio_promote_gloss_tail_refusals_deferred",
+            gloss_tail=skipped_truncated_merge_gloss_tail,
+            name_cut=skipped_truncated_merge_name_cut,
+            note=(
+                "class-A gloss-tail refusals (complete nasab, teacher-key عن/isnad tail "
+                "removed) — recall cost of the deliberate class-2 over-refusal; recovery "
+                "deferred behind biographical homonym disambiguation (da#397/da#398/da#423)"
+            ),
+        )
+
     logger.info(
         "bio_promote_complete",
         bio_files=len(bio_files),
@@ -496,6 +539,8 @@ def promote_bios_to_canonical(
         skipped_source=skipped_source,
         skipped_pollution=skipped_pollution,
         skipped_truncated_merge=skipped_truncated_merge,
+        skipped_truncated_merge_gloss_tail=skipped_truncated_merge_gloss_tail,
+        skipped_truncated_merge_name_cut=skipped_truncated_merge_name_cut,
         truncated_residue_onto_unattested=truncated_residue_onto_unattested,
         truncated_residue_minted=truncated_residue_minted,
         aliases_added=alias_stats.added,

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -15,6 +15,7 @@ from src.parse.name_quality import (
     asserted_name_tokens,
     clean_narrator_name,
     cleaner_removed_content,
+    is_recoverable_gloss_tail,
 )
 from src.parse.schemas import NARRATOR_ALIAS_SCHEMA, NARRATOR_BIO_SCHEMA
 from src.resolve import MissingInputError
@@ -1415,3 +1416,197 @@ def test_truncated_residue_onto_zero_mention_node_is_counted(
     complete = next(kw for event, kw in events if event == "bio_promote_complete")
     assert complete["truncated_residue_onto_unattested"] == 1
     assert complete["truncated_residue_minted"] == 0
+
+
+# da#397 — the gloss-tail (class A) vs name-cut (class B) discrimination. Class A is a
+# COMPLETE nasab (>= 3 tokens, carries بن/ابن) that lost only a teacher-key isnad tail
+# (the removed suffix opens on عن / حدثنا / …); class B is a bare ism/kunya residue, a
+# non-teacher-key cut (يقال / الذي), or a tail carrying a disputed-identity marker
+# (مجهول / وقيل — the homonym case). The predicate quantifies the recoverable subset;
+# it does NOT flip the guard, which still refuses BOTH classes (see the integration
+# tests below). Fixtures are the issue's own verbatim rows where cited.
+_GLOSS_TAIL_CLASS_A = [
+    # da#397's headline example: residue is the full nasab, only `عن انس` cut.
+    ("اسحاق بن مره عن انس", "اسحاق بن مره", "da#397 headline — teacher-key عن tail"),
+    # A longer nasab that lost a `عن <teacher>` tail.
+    ("عبد الله بن يوسف بن عيسى عن مالك", "عبد الله بن يوسف بن عيسى", "5-token nasab + عن tail"),
+]
+_GLOSS_TAIL_CLASS_B = [
+    # da#397's homonym example: teacher-key عن tail AND full nasab residue, but the tail
+    # grades the subject مجهول / وقيل اسمه — a disputed identity, so still class B.
+    (
+        "محمد بن شرحبيل عن قيس بن سعد وقيل اسمه عمرو مجهول من الثالثه ق",
+        "محمد بن شرحبيل",
+        "da#397 homonym — dispute marker مجهول/وقيل in the tail",
+    ),
+    # Bare kunya residue (2 tokens, no بن): may not merge regardless of the عن tail.
+    ("أبو نهشل ، عن أبي وائل", "ابو نهشل", "bare kunya residue (2 tokens)"),
+    # Bare ism residue (the da#379 عبيده class): a name-cut, not a gloss-tail.
+    (_ITQAN_60592_PROSE, "عبيده", "bare ism residue (da#379 عبيده)"),
+    # Non-teacher-key cut: the tail opens on يقال ("it is said"), a dispute/speech opener.
+    ("عبد الله بن محمد العدوي يقال", "عبد الله بن محمد العدوي", "non-teacher-key cut (يقال)"),
+    # A عن tail but the residue is a kunya+nisba with NO patronymic بن — not a nasab.
+    ("ابو محمد بصري عن محمد بن علي", "ابو محمد بصري", "عن tail but residue carries no بن"),
+]
+
+
+@pytest.mark.parametrize(("raw", "expected_cleaned", "why"), _GLOSS_TAIL_CLASS_A)
+def test_gloss_tail_class_a_is_recognised(raw: str, expected_cleaned: str, why: str) -> None:
+    """da#397 class A: a complete nasab that lost only a teacher-key isnad tail."""
+    normalized = normalize_arabic(raw)
+    cleaned = clean_narrator_name(normalized)
+    assert cleaned == expected_cleaned, (
+        f"fixture no longer truncates as expected ({why}): {cleaned!r}"
+    )
+    assert cleaner_removed_content(normalized, cleaned), why
+    assert is_recoverable_gloss_tail(normalized, cleaned), (
+        f"class-A gloss-tail not recognised ({why})"
+    )
+
+
+@pytest.mark.parametrize(("raw", "expected_cleaned", "why"), _GLOSS_TAIL_CLASS_B)
+def test_name_cut_class_b_is_not_a_gloss_tail(raw: str, expected_cleaned: str, why: str) -> None:
+    """da#397 class B: a name-cut / disputed-identity / non-nasab residue is NOT recoverable."""
+    normalized = normalize_arabic(raw)
+    cleaned = clean_narrator_name(normalized)
+    assert cleaned == expected_cleaned, (
+        f"fixture no longer truncates as expected ({why}): {cleaned!r}"
+    )
+    assert cleaner_removed_content(normalized, cleaned), why
+    assert not is_recoverable_gloss_tail(normalized, cleaned), (
+        f"class-B row read as gloss-tail ({why})"
+    )
+
+
+def test_non_truncation_is_never_a_gloss_tail() -> None:
+    """A span the cleaner only NORMALIZED (no cut) is not a gloss-tail — nothing was removed.
+
+    The dual of the class-A/B split: `is_recoverable_gloss_tail` must return False whenever
+    `cleaner_removed_content` is False, so an affix-only unwrap (a bracketed entry number, a
+    trailing honorific) can never be miscounted as a recoverable refusal.
+    """
+    for raw in ("( 4875 ) عبد الله بن موسى", "مالك بن انس رضي الله عنه", "سعيد بن سماك"):
+        normalized = normalize_arabic(raw)
+        cleaned = clean_narrator_name(normalized)
+        assert cleaned is not None, raw
+        assert not cleaner_removed_content(normalized, cleaned), raw
+        assert not is_recoverable_gloss_tail(normalized, cleaned), raw
+
+
+# Verbatim from da#397 (residue `اسحاق بن مره`, attested target mention_count = 18).
+_ITQAN_GLOSS_TAIL = "اسحاق بن مره عن انس"
+
+
+def test_gloss_tail_row_is_still_refused_and_counted_class_a(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """da#397: a class-A gloss-tail row targeting an attested narrator is STILL REFUSED.
+
+    This is the invariant-preservation assertion — the discrimination QUANTIFIES the
+    recoverable subset, it does NOT flip the guard. Recovering class A is not provably
+    safe (make_canonical_id folds inflection but not homonymy; 45/240 class-A accept-
+    targets carry conflicting jarḥ grades, da#423), so the merge stays refused and the
+    backfill never fires. The refusal is attributed to `skipped_truncated_merge_gloss_tail`
+    and surfaced by the deferred-recall info line (da#398 scope-1).
+    """
+    from src.resolve import bio_promote as bp
+
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+
+    normalized = normalize_arabic(_ITQAN_GLOSS_TAIL)
+    assert clean_narrator_name(normalized) == "اسحاق بن مره"
+    assert is_recoverable_gloss_tail(normalized, clean_narrator_name(normalized))
+
+    attested_id = _write_attested_narrator(out_dir, "اسحاق بن مره", mentions=18)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:397a",
+                "source": "itqan",
+                "name_ar": _ITQAN_GLOSS_TAIL,
+                "name_ar_normalized": normalized,
+                "trustworthiness": "daif",
+                "death_year_ah": 150,
+                "generation": "tabi_tabiin",
+            }
+        ],
+    )
+
+    events: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(bp.logger, "info", lambda event, **kw: events.append((event, kw)))
+    monkeypatch.setattr(bp.logger, "warning", lambda event, **kw: events.append((event, kw)))
+
+    rows = pq.read_table(bp.promote_bios_to_canonical(staging, out_dir)).to_pylist()  # type: ignore[arg-type]
+
+    # The merge is STILL refused — no behavioral flip.
+    attested = next(r for r in rows if r["canonical_id"] == attested_id)
+    assert attested["source_ids"] == ["sanadset:1"], "gloss-tail row was merged — guard flipped!"
+    assert attested["trustworthiness"] is None, "backfill fired — guard flipped!"
+    assert attested["death_year_ah"] is None
+    assert attested["generation"] is None
+    assert len(rows) == 1
+    assert attested["mention_count"] == 18
+
+    # And the refusal is attributed to the gloss-tail (class A) bucket + surfaced.
+    complete = next(kw for event, kw in events if event == "bio_promote_complete")
+    assert complete["skipped_truncated_merge"] == 1
+    assert complete["skipped_truncated_merge_gloss_tail"] == 1
+    assert complete["skipped_truncated_merge_name_cut"] == 0
+    assert any(
+        event == "bio_promote_gloss_tail_refusals_deferred" and kw.get("gloss_tail") == 1
+        for event, kw in events
+    ), events
+
+
+def test_name_cut_row_is_refused_and_counted_class_b(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """da#397: a class-B name-cut row (bare ism) targeting an attested narrator is counted name_cut.
+
+    The dual of the gloss-tail integration test: the same refusal, but attributed to the
+    `_name_cut` bucket (NOT `_gloss_tail`), and the deferred-recall info line does NOT fire
+    when there is no recoverable subset.
+    """
+    from src.resolve import bio_promote as bp
+
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+
+    assert not is_recoverable_gloss_tail(
+        normalize_arabic(_ITQAN_60592_PROSE),
+        clean_narrator_name(normalize_arabic(_ITQAN_60592_PROSE)),
+    )
+    _write_attested_narrator(out_dir, "عبيده", mentions=1695)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:60592",
+                "source": "itqan",
+                "name_ar": _ITQAN_60592_PROSE,
+                "name_ar_normalized": normalize_arabic(_ITQAN_60592_PROSE),
+                "trustworthiness": "thiqa",
+            }
+        ],
+    )
+
+    events: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(bp.logger, "info", lambda event, **kw: events.append((event, kw)))
+    monkeypatch.setattr(bp.logger, "warning", lambda event, **kw: events.append((event, kw)))
+
+    assert bp.promote_bios_to_canonical(staging, out_dir) is not None
+    complete = next(kw for event, kw in events if event == "bio_promote_complete")
+    assert complete["skipped_truncated_merge"] == 1
+    assert complete["skipped_truncated_merge_name_cut"] == 1
+    assert complete["skipped_truncated_merge_gloss_tail"] == 0
+    assert not any(event == "bio_promote_gloss_tail_refusals_deferred" for event, kw in events), (
+        "deferred-recall line fired with no gloss-tail refusals"
+    )


### PR DESCRIPTION
## da#397 — recover-class-A framing, adapted to the wave-HEAD premise

Closes the **implementable, invariant-safe** half of da#397. The behavioral class-A recovery the issue originally proposed is **not landed** here — see "Why no behavioral flip" — but the discrimination rule it asked for is encoded, tested, and made a live metric.

### Premise verification at wave-26 HEAD (`dc39e12`)
- da#397's documentation defect (the misleading inline guard comment) **already landed** in PR #441 (`1c74083`, merged 2026-07-12) — verified in-tree.
- PR #441 also **deferred** the behavioral recovery behind biographical homonym disambiguation, with a committed + issue-posted measurement (45/240 class-A accept-target name-keys carry conflicting jarḥ grades → provable homonyms; da#423 direction). da#397's own "needs domain adjudication on the homonym rate before it lands" gate therefore came back **unfavorable** — so, per the issue's own gate, the recovery does not land.
- The raw parquets are **not present** in this environment (`data/staging`, `data/curated` empty), so the full-corpus recall numbers are honestly **deferred**, not reproduced.

### What this PR does
- Adds `is_recoverable_gloss_tail(name_normalized, cleaned)` in `name_quality.py`, encoding da#397's discrimination:
  - **Class A (gloss-tail):** removed tail opens on a teacher-key/transmission connector (`عن` / `حدثنا` / …), residue is a complete nasab (`>= 3` tokens carrying `بن`/`ابن`), and the tail carries **no** disputed-identity marker (`مجهول` / `وقيل` / …).
  - **Class B (name-cut):** bare ism/kunya residue, non-teacher-key cut, or a disputed-identity marker present. The `محمد بن شرحبيل … مجهول` homonym from the issue lands in class B, as required.
- Splits `bio_promote`'s `skipped_truncated_merge` counter into `_gloss_tail` / `_name_cut` and emits a `bio_promote_gloss_tail_refusals_deferred` info line — turning da#398's recall cost into a per-run metric (da#398 scope-1).

### Why no behavioral flip (the guard still refuses BOTH classes)
Recovering class A on the name alone is **not** provably safe: `make_canonical_id` folds Arabic inflection but not homonymy, and a complete nasab can still collide with a homonym (45/240 accept-targets graded both *thiqa* and *kadhdhab*; ~18.75% provable homonyms, keyword-independent; da#441/da#423). Flipping the guard would back-fill `death_year_ah` / `generation` / `external_id` + a homonym's mention graph onto ~18% distinct persons — a **canonical-identity-invariant** violation. So the class-2 over-refusal stays the deliberate DEFAULT; this PR only **quantifies** the recoverable subset and is the precondition for a future disambiguation-gated recovery.

### Deferral disposition (owner-confirmed)
The behavioral class-A recovery is **deferred to a future corpus-gated follow-up, per owner decision (2026-07-21)** — not "pending sign-off." The flip is contra-indicated by #441's committed adjudication (~18.75% provable homonyms via conflicting jarḥ grades) and would violate the canonical-identity invariant. If the recovery is ever pursued, it needs **all** of: a clean pre-backfill corpus run + a biographical-disambiguation signal (jarḥ-grade / death-year separation) + explicit owner sign-off on the invariant tradeoff (same bar as da#347b/da#431). No corpus is present here to validate even a narrower "`عن`-only is safe" hypothesis.

### Tests
10 new tests: class-A recognised (issue's `اسحاق بن مره عن انس`), class-B not (homonym `مجهول`, bare kunya, bare ism, `يقال` cut, `عن`-tail-without-`بن`), non-truncation never gloss-tail, and two integration tests proving the guard **still refuses** a class-A row (no flip) while attributing the refusal to the right counter. Each mutation-checked (dispute-marker drop / patronymic drop / always-False classifier / counter-branch swap → RED → restore).

Full local⇄CI parity: ruff-format, ruff-lint, mypy --strict, pytest (462 passed) all green.

Re #397 — the behavioral recovery + full-corpus recall stay tracked on the issue, deferred to a corpus-gated follow-up per owner decision (2026-07-21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z
