### PR TITLE
name_quality: pin cleaner_removed_content's coarseness contract + cross-ref the gloss-tail split (da#398)

### DIFF
--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -1920,6 +1920,13 @@ def cleaner_removed_content(name_normalized: str | None, cleaned: str | None) ->
     is a homonymy question this function cannot answer — it needs biographical
     disambiguation, not a token diff.
 
+    The finer *gloss-tail vs name-cut* split this boolean deliberately withholds is
+    carried by :func:`is_recoverable_gloss_tail` (da#397): it recognises the
+    tail-after-a-complete-name class (a complete nasab that lost only a teacher-key
+    isnad tail) as the recoverable-pending-disambiguation subset. This predicate stays
+    the coarse affix/removal line; that one adds the sub-classification — and neither
+    decides identity, which still needs biographical disambiguation.
+
     Comparing against :func:`asserted_name_tokens` — rather than a re-tokenization of
     the raw input — is what draws the affix/removal line; a re-tokenization sees the
     entry number, the connective and the honorific as "content removed" and refuses a

--- a/tests/test_parse/test_name_quality.py
+++ b/tests/test_parse/test_name_quality.py
@@ -6,8 +6,10 @@ import pytest
 
 from src.parse.identity import make_canonical_id
 from src.parse.name_quality import (
+    asserted_name_tokens,
     clean_narrator_name,
     clean_narrator_name_display,
+    cleaner_removed_content,
     is_mubham_relational,
     split_compound_narrators,
     strip_markup,
@@ -1570,3 +1572,83 @@ class TestBioPromotedNarratorsSurvive:
     )
     def test_pure_provenance_fragment_still_drops(self, fragment: str) -> None:
         assert clean_narrator_name(normalize_arabic(fragment)) is None
+
+
+class TestCleanerRemovedContentContract:
+    """Pin `cleaner_removed_content`'s docstring CONTRACT (da#398).
+
+    da#398 corrected the docstring headline: a ``True`` means the cleaner "removed
+    more than an affix", NOT that it "cut into the name the source asserted." These
+    tests hold that contract against regression — the boolean is deliberately COARSE
+    and, in particular, returns ``True`` for BOTH a *cut-into-the-name* residue (a bare
+    ism) AND a *tail-after-a-complete-name* residue (a full nasab that lost only an
+    isnad tail). A caller keying identity on the cleaner's output must not read ``True``
+    as "the residue is not the asserted name" — for the tail class, it IS.
+
+    The finer split those two classes need is a SEPARATE predicate
+    (`is_recoverable_gloss_tail`, da#397); this boolean answers only the affix/removal
+    question, and this contract keeps `asserted_name_tokens` from quietly absorbing one
+    of the cleaner's cuts (which would evaporate the refusals it carries against a green
+    suite).
+    """
+
+    # Affix-only normalization → the asserted name is left WHOLE → False.
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "( 4875 ) عبد الله بن موسى",  # bracketed catalog entry number
+            "[ 969 ] احمد بن يوسف الثعلبي",  # square-bracket entry number
+            "مالك يعني بن انس",  # editorial connective يعني
+            "مالك بن انس رضي الله عنه",  # honorific suffix
+        ],
+    )
+    def test_affix_normalization_is_not_removed_content(self, raw: str) -> None:
+        normalized = normalize_arabic(raw)
+        cleaned = clean_narrator_name(normalized)
+        assert cleaned is not None, raw
+        assert not cleaner_removed_content(normalized, cleaned), (
+            f"normalization read as a cut: {raw}"
+        )
+        # The affix/removal line is drawn against the cleaner's OWN pre-truncation
+        # tokens, not a re-tokenization of the raw input.
+        assert tuple(cleaned.split()) == asserted_name_tokens(normalized)
+
+    def test_true_does_not_imply_cut_into_the_name(self) -> None:
+        """The load-bearing da#398 contract: ``True`` covers a cut-into-name AND a tail-cut.
+
+        Both a *cut-into-the-name* (bare-ism residue) and a *tail-after-a-complete-name*
+        (full-nasab residue that lost only a teacher-key isnad tail) return ``True`` — so
+        ``True`` alone cannot be read as "the residue is not the name the source
+        asserted." The tail-class residue below is a complete nasab.
+        """
+        # cut INTO the name: `عبيده` is a bare ism, a fragment of the asserted span.
+        cut_into = normalize_arabic("عبيدة مولى رسول الله ذكره بن شاهين واستدركه أبو موسى")
+        cut_into_cleaned = clean_narrator_name(cut_into)
+        assert cut_into_cleaned == "عبيده"
+        assert cleaner_removed_content(cut_into, cut_into_cleaned)
+
+        # tail AFTER a complete name: the full nasab is intact; only `عن انس` was cut.
+        tail_cut = normalize_arabic("اسحاق بن مره عن انس")
+        tail_cut_cleaned = clean_narrator_name(tail_cut)
+        assert tail_cut_cleaned == "اسحاق بن مره"
+        assert cleaner_removed_content(tail_cut, tail_cut_cleaned)
+
+        # The contract: same ``True``, categorically different residues. The tail-class
+        # residue is a COMPLETE nasab (>= 3 tokens carrying بن) — a real asserted name —
+        # while the cut-into-name residue is a bare ism. `True` does not distinguish them.
+        assert len(tail_cut_cleaned.split()) >= 3 and "بن" in tail_cut_cleaned.split()
+        assert len(cut_into_cleaned.split()) == 1
+
+    def test_removed_content_is_a_strict_shortening(self) -> None:
+        """Whenever the predicate is True, the residue is strictly shorter than asserted.
+
+        The dual framing of the contract: a cut removes tokens, so a ``True`` residue is
+        a proper prefix-length-reduction of what the source asserted — never equal, never
+        longer. This is what makes a truncation visible where a normalization is not.
+        """
+        for raw in ("اسحاق بن مره عن انس", "عبيدة مولى رسول الله ذكره بن شاهين واستدركه أبو موسى"):
+            normalized = normalize_arabic(raw)
+            cleaned = clean_narrator_name(normalized)
+            assert cleaned is not None, raw
+            assert cleaner_removed_content(normalized, cleaned), raw
+            assert len(cleaned.split()) < len(asserted_name_tokens(normalized)), raw


### PR DESCRIPTION
## da#398 — recall-cost quantification + docstring-contract precision

Sequenced **after #472 (da#397, now MERGED into the wave branch at `940864b`)**. This branch is rebased on the post-#472 wave HEAD, so the docstring's `is_recoverable_gloss_tail` cross-ref resolves in-tree. Closes the implementable half of da#398; the full-corpus recall quantification stays honestly deferred.

### Premise verification at wave-26 HEAD
- da#398 scope-2 (docstring contract fix) **already landed** in PR #441 (`1c74083`) — the headline no longer reads "cut into the name the source asserted"; it distinguishes *cut-into-name* from *tail-after-a-complete-name*. Verified in-tree.
- What was **missing**: a contract TEST pinning that promise, and the tie-in to the finer predicate. This PR adds both.
- The raw parquets are **not present** in this environment, so scope-1's same-person-vs-homonym rate is deferred, not fabricated.

### What this PR does
- **Docstring cross-reference** (`cleaner_removed_content`): names where the finer *gloss-tail vs name-cut* split lives — `is_recoverable_gloss_tail` (da#397) — so a caller knows the boolean's coarseness is deliberate and where to get the sub-classification. Neither predicate decides identity.
- **Contract test** (`TestCleanerRemovedContentContract`): pins that a `True` covers BOTH a *cut-into-the-name* residue (bare ism `عبيده`) AND a *tail-after-a-complete-name* residue (full nasab `اسحاق بن مره`, only `عن انس` cut) — so `True` alone cannot be read as "the residue is not the asserted name"; that affix-only normalization is `False`; and that a `True` residue is a strict shortening of the asserted tokens. This stops `asserted_name_tokens` from quietly absorbing one of the cleaner's cuts (which would evaporate the refusals it carries against a green suite).

### da#398 scope-1 (quantify recall cost)
The per-run **mechanism** landed in da#397 (#472): the `skipped_truncated_merge_gloss_tail` counter + `bio_promote_gloss_tail_refusals_deferred` log line make the recall cost a live metric. The **full-corpus same-person-vs-homonym rate** stays deferred behind biographical disambiguation + a corpus run — an unmeasured remainder, labelled unmeasured.

### Deferral disposition (owner-confirmed)
The behavioral class-A recovery (da#397) and the full-corpus recall quantification are **deferred to a future corpus-gated follow-up, per owner decision (2026-07-21)**. The flip is contra-indicated by #441's committed adjudication (~18.75% provable homonyms via conflicting jarḥ grades, keyword-independent) and would violate the canonical-identity invariant. The eventual follow-up, if pursued, requires a clean pre-backfill corpus run + a biographical-disambiguation signal + explicit owner sign-off on the invariant tradeoff.

### Interaction with da#397 (#472)
da#397 did **not** change which rows the guard refuses (both truncation classes still refused), so this contract on `cleaner_removed_content` is behavior-stable. Self-contained — touches only `name_quality.py` + `test_name_quality.py`.

### Tests
6 new tests (all green; full name_quality + bio_promote suites 468 passed post-rebase). Each mutation-checked: `asserted_name_tokens` absorbing the isnad cut → tail-class contract RED; re-tokenization-of-raw comparison → affix contract RED; both restored.

Full local⇄CI parity: ruff-format, ruff-lint, mypy --strict, pytest — commit + push hooks all green.

Re #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z
