### PR TITLE
fix(arabic): fold alif maqṣūra ى→ي in normalize_arabic; keep the name-quality sets in sync (da#427)

### DIFF
--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -256,15 +256,6 @@ def _is_isnad_residue_token(token: str) -> bool:
 # Honorific / eulogy phrases (normalized) that name no narrator. Stripped from
 # anywhere in the span (they appear appended to real names too).
 _HONORIFIC_PHRASES: tuple[str, ...] = (
-    "صلى الله عليه واله وسلم",
-    "صلى الله عليه وسلم",
-    # Shia taṣliya without the trailing وسلم (da#271): the dominant benediction in
-    # thaqalayn/lk — the bare "صلى الله عليه واله" (and its spaced "و اله" variant)
-    # was NOT covered by the two forms above, so "رسول الله صلى الله عليه واله" (a
-    # mc-365 false narrator) survived. Listed AFTER the longer وسلم-suffixed form so
-    # that one is stripped first where present.
-    "صلى الله عليه واله",
-    "صلى الله عليه و اله",
     "عليه السلام",
     "عليهم السلام",
     "عليها السلام",
@@ -276,39 +267,26 @@ _HONORIFIC_PHRASES: tuple[str, ...] = (
     # عنهما"). It was absent, so the strip matched only the "رضي الله عنه" PREFIX
     # and left a dangling "ما"/"ا" fragment — harmless while name_ar_normalized was
     # the only cleaner output, but da#301 surfaces the cleaner on the DISPLAY name,
-    # where "عبد الله بن عمر ا" would become a Narrator label. Listed here (both ي
-    # and ى spellings); the LONGEST-FIRST strip loop removes it before the shorter
-    # عنه/عنها/عنهم forms, so the whole dual benediction goes cleanly.
+    # where "عبد الله بن عمر ا" would become a Narrator label. The LONGEST-FIRST
+    # strip loop removes it before the shorter عنه/عنها/عنهم forms.
     "رضي الله عنهما",
-    # alif-maqsura spelling (da#308): normalize_arabic does NOT fold ى→ي, so the
-    # very common "رضى الله عنه" survives normalization distinct from the ي form
-    # above and left an un-scrubbed benediction tail (e.g. "ابي هريره رضى الله عنه
-    # ان" — mc-1215). Listed so the residue is stripped and the real leading name
-    # ("ابي هريره") is recovered rather than kept honorific-polluted or dropped.
-    "رضى الله عنه",
-    "رضى الله عنها",
-    "رضى الله عنهم",
-    "رضى الله عنهما",  # da#471 dual form, alif-maqsura spelling (see ي form above)
     # bare / truncated benediction fragments (da#311) — the source often stores a
-    # benediction cut off before its pronoun tail ("… رضي الله", "… صلى الله عليه"
+    # benediction cut off before its pronoun tail ("… رضي الله", "… صلي الله عليه"
     # with no عنه/وسلم). Stripped LONGEST-FIRST (see the strip loop) so the full
-    # "رضي الله عنه" / "صلى الله عليه وسلم" forms above are removed first where
-    # present; the bare forms then catch the truncated residue. Neither "رضي الله"
-    # ("God is pleased") nor "صلى الله عليه" is ever part of a real narrator name.
-    "صلى الله عليه",
+    # "رضي الله عنه" / "صلي الله عليه وسلم" forms are removed first where present;
+    # the bare forms then catch the truncated residue. Neither "رضي الله" ("God is
+    # pleased") nor "صلي الله عليه" is ever part of a real narrator name.
     "رضي الله",
-    "رضى الله",
     "رحمه الله",
     "عز وجل",
-    "تبارك وتعالى",
-    # Urdu-folded taṣliya (da#299): normalize_arabic now folds the Urdu yeh ی
-    # (U+06CC) to the Arabic yeh ي, so a benediction typed in Urdu script —
-    # "صلی اللہ علیہ وسلم" — normalizes to "صلي الله عليه وسلم" (regular yeh),
-    # NOT the alif-maqsura "صلى …" spelling the Arabic-sourced forms above carry.
-    # Same asymmetry the da#308 رضى/رضي pair already handles: list the yeh spelling
-    # so an Urdu-script name folds to the SAME benediction-stripped canonical form
-    # as its Arabic twin. Longest-first (the strip loop) so the وسلم/واله forms win
-    # before the bare "صلي الله عليه".
+    "تبارك وتعالي",
+    # taṣliya, yeh-spelled (da#299 + da#427). normalize_arabic folds BOTH the Urdu
+    # yeh ی (U+06CC, da#299 — an Urdu-script "صلی اللہ علیہ وسلم") AND the Arabic
+    # alif-maqsura ى (U+0649, da#427 — a "صلى الله عليه وسلم") onto the regular yeh
+    # ي (U+064A). So the yeh spelling below is now the SOLE canonical benediction
+    # form — every source's taṣliya normalizes to it, and the alif-maqsura "صلى …"
+    # literals this list used to carry are redundant post-fold and were removed.
+    # Longest-first (the strip loop) so the وسلم/واله forms win before the bare form.
     "صلي الله عليه واله وسلم",
     "صلي الله عليه وسلم",
     "صلي الله عليه واله",
@@ -457,7 +435,7 @@ _APPOSITION_CONNECTORS = frozenset(
         "ام",  # mother of
         "اخت",  # sister of
         "اهل",  # family/people of
-        "مولى",  # client/freedman of
+        "مولي",  # client/freedman of (مولى, alif-maqsura folded ى→ي — da#427)
         "مولاه",  # his client
         "خادم",  # servant of
         "خادمه",  # her/his servant
@@ -650,7 +628,7 @@ _ISNAD_BOUNDARY = frozenset(
         "لما",
         "فلما",
         "ثم",
-        "حتى",
+        "حتي",  # (حتى, alif-maqsura folded ى→ي — da#427)
         "والله",
         # editorial identification glosses ("he is …", "it is said …")
         "هو",
@@ -712,7 +690,7 @@ _MATN_DENSITY = frozenset(
         "لما",
         "فلما",
         "ثم",
-        "حتى",
+        "حتي",  # (حتى, alif-maqsura folded ى→ي — da#427)
         "والله",
         "هو",
         "وهو",
@@ -775,15 +753,18 @@ _MATN_OPENERS = frozenset(
         "قلنا",  # "we said"
         "كنا",  # "we were"
         "كنت",  # "I was"
-        "نهى",  # "he forbade"
+        "نهي",  # "he forbade" (نهى, alif-maqsura folded ى→ي — da#427)
         "امر",  # "he ordered"
-        "صلى",  # "he prayed" (verb; the taṣliya benediction is stripped in step 2)
+        "صلي",  # "he prayed" (صلى, folded — da#427; the taṣliya benediction, also
+        # yeh-folded, is stripped in step 2). NB post-fold this token is homographic
+        # with the yeh-final name صلي/Siliy — but no _MATN_OPENERS token is a nasab
+        # opener, so a leading matn verb never fires on a real kunya (see set docstring).
         "صلت",  # "she prayed"
         "رايت",  # "I saw"
         "بينما",  # "while"
         "بينا",  # "while"
         "نعم",  # "yes" (matn answer particle, minted as a lone junk narrator)
-        "بلى",  # "yes indeed"
+        "بلي",  # "yes indeed" (بلى, alif-maqsura folded ى→ي — da#427)
         # Shia dialogue-hadith openers (da#311) — the dominant matn shape in
         # thaqalayn/fawaz ("I asked Abu al-Hasan (as): ...", "Abu Abd Allah (as)
         # was asked: ..."), tuned on Sunni/Tirmidhī patterns only until now.
@@ -792,12 +773,13 @@ _MATN_OPENERS = frozenset(
         "سالت",  # سألت "I asked" (1st person; bare سال 3rd-person is already an
         # _ISNAD_BOUNDARY token — this is the distinct 1st-person conjugation)
         "سءل",  # سُئل "was asked" (passive)
-        "روى",  # "he narrated" (3rd person; a lone leading opener, distinct
-        # from the truncation-boundary سمعت/حدثنا/حدثني/اخبرنا/اخبرني/حدث/حدثت
-        # forms above, which recover a preceding real name instead)
-        "روي",  # "was narrated" (passive, ya-final — normalize_arabic does NOT
-        # fold ى→ي so this is a DISTINCT token from روى above; da#311 round-4b, a
-        # lone leading روي slips truncation and mints a 541-mention junk narrator)
+        "روي",  # "he narrated" / "was narrated" — 3rd-person روى and passive روي,
+        # now ONE token (da#427 folds ى→ي, so the maqsura روى and the yeh روي that
+        # were listed separately here — da#311 kept them distinct precisely because
+        # normalize_arabic did NOT then fold ى→ي — converge). A lone leading opener,
+        # distinct from the truncation-boundary سمعت/حدثنا/اخبرنا/حدث forms above
+        # (which recover a preceding real name); da#311 round-4b: a lone leading روي
+        # slips truncation and minted a 541-mention junk narrator.
         "كتبت",  # "I wrote (to)" — maktub/correspondence matn opener ("كتبت الى
         # ابي الحسن اساله …"); the 3rd-person كتب is an _ISNAD_BOUNDARY token.
         "يا",  # vocative "O …" ("يا رسول الله", "يا محمد", "يا معاذ …") — a
@@ -827,22 +809,29 @@ _MATN_OPENERS = frozenset(
 #
 # PRECISION: none is ever a component of a real name, and every rule that consults
 # this set runs AFTER the nasab-connector precision guard (so any genuine lineage /
-# kunya is already spared). Crucially ``على`` (preposition "on", alif-maqsura final)
-# is a DISTINCT token from ``علي`` (the name ʿAlī, ya final) because
-# ``normalize_arabic`` does NOT fold ى→ي — so no ʿAlī is ever mistaken for the
-# preposition. ``من`` is deliberately EXCLUDED (it is the partitive the mubham
-# guards 5/5b key on, and folding it in here would be redundant/entangling).
+# kunya is already spared). ``من`` is deliberately EXCLUDED (it is the partitive the
+# mubham guards 5/5b key on, and folding it in here would be redundant/entangling).
+#
+# ``على`` ("on / upon") is deliberately NOT a member (da#427). normalize_arabic now
+# folds alif-maqsura ى→ي, so the preposition ``على`` and the name ``علي`` (ʿAlī) BOTH
+# normalize to ``علي`` and are no longer distinguishable (the comment here used to
+# note the opposite, relying on ى≠ي). Adding ``علي`` would drop a bare ``علي``
+# narrator via rule 2c (all-particle) — deleting one of the most-attested
+# transmitters — so ``على`` is removed from the set instead, at the cost of no longer
+# detecting the ``على`` preposition as a matn particle. That is a recall loss in the
+# SAFE direction (leaves residue in; never deletes a name), and the alternative
+# deletes ʿAlī. The set-level invariant test pins that no name (``علي`` included)
+# folds onto a member of this or any other droppable set.
 _MATN_PARTICLES = frozenset(
     {
-        # prepositions
-        "على",  # "on / upon" (alif-maqsura — NOT the name علي)
+        # prepositions ("على" excluded — see header: folds onto the name علي)
         "في",  # "in"
-        "الى",  # "to / towards"
+        "الي",  # "to / towards" (الى, alif-maqsura folded — da#427)
         "عند",  # "at / with"
         "بعد",  # "after"
         "قبل",  # "before"
         "مع",  # "with"
-        "لدى",  # "at / with"
+        "لدي",  # "at / with" (لدى, folded — da#427)
         "بين",  # "between"
         "نحو",  # "towards / about"
         # personal / attached pronouns
@@ -890,7 +879,7 @@ _MATN_PARTICLES = frozenset(
         "انما",  # "only / but"
         "كي",  # "so that"
         "كيف",  # "how"
-        "متى",  # "when"
+        "متي",  # "when" (متى, alif-maqsura folded ى→ي — da#427)
         "اين",  # "where"
         "لذلك",  # "therefore"
         "لذا",  # "hence"

--- a/src/utils/arabic.py
+++ b/src/utils/arabic.py
@@ -42,6 +42,9 @@ _HAMZA_VARIANTS_RE: re.Pattern[str] = re.compile(r"[\u0624\u0626]")
 # Taa marbuta: ة (U+0629)
 _TAA_MARBUTA_RE: re.Pattern[str] = re.compile(r"\u0629")
 
+# Alif maqsura: U+0649 (the dotless final yaa), folded to yaa U+064A (da#427)
+_ALIF_MAQSURA_RE: re.Pattern[str] = re.compile(r"\u0649")
+
 # Tatweel / kashida: ـ (U+0640)
 _TATWEEL_RE: re.Pattern[str] = re.compile(r"\u0640")
 
@@ -239,6 +242,35 @@ def normalize_taa_marbuta(text: str) -> str:
     return _TAA_MARBUTA_RE.sub("\u0647", text)
 
 
+def normalize_alif_maqsura(text: str) -> str:
+    """Normalize alif maqsura U+0649 to yaa U+064A (da#427).
+
+    Alif maqsura is the dotless final yaa -- orthographically the SAME letter as
+    yaa, written U+0649 only in word-final position (yahya, musa, al-ladhi, ala).
+    Corpora spell it inconsistently, so a name or particle ending in it never
+    collapses onto its yaa-spelled twin without this fold -- the ~13 al-ladhi /
+    al-lati / wa-l-ladhi matn pronouns never reach the al-ladhi / al-lati boundary
+    set, and yahya (maqsura) / yahyi (yaa) mint two canonical ids for one narrator.
+
+    The fold is a single codepoint substitution U+0649 -> U+064A. It is
+    homographic-safe on names -- no real ism / nisba folds onto a particle or
+    boundary token (asserted set-level in tests/test_parse/test_name_quality.py) --
+    with ONE documented collision it does NOT resolve in this layer: the preposition
+    ``\u0639\u0644\u0649`` ("on / upon") folds to ``\u0639\u0644\u064a``, the name Ali. That
+    collision is handled downstream (``\u0639\u0644\u0649`` is removed from
+    ``name_quality._MATN_PARTICLES`` so a bare ``\u0639\u0644\u064a`` narrator is never dropped as a
+    matn particle); it is called out here because a caller keying identity on the
+    surface must know the two are no longer distinguishable after normalization.
+
+    Composes with the da#299 Urdu-yeh fold (``normalize_urdu``: U+06CC / U+06D2 /
+    U+06D3 -> U+064A): distinct SOURCE codepoints, same yaa target, and neither
+    produces the other's input, so the two are order-independent -- an Urdu-script
+    ``\u0635\u0644\u06cc`` and an Arabic ``\u0635\u0644\u0649`` both converge on the same
+    ``\u0635\u0644\u064a``. Idempotent (U+0649 is fully replaced, and U+064A is a fixed point).
+    """
+    return _ALIF_MAQSURA_RE.sub("\u064a", text)
+
+
 def normalize_urdu(text: str) -> str:
     """Fold Urdu/Persian letter variants to their Arabic equivalents (da#299).
 
@@ -287,6 +319,7 @@ def normalize_arabic(text: str) -> str:
     4. Normalize alif variants
     5. Normalize hamza variants
     6. Normalize taa marbuta
+    6b. Normalize alif maqṣūra ى -> yāʾ ي (da#427)
     7. Strip tatweel (kashida)
     8. Collapse whitespace
 
@@ -302,6 +335,7 @@ def normalize_arabic(text: str) -> str:
     text = normalize_alif(text)
     text = normalize_hamza(text)
     text = normalize_taa_marbuta(text)
+    text = normalize_alif_maqsura(text)
     text = _TATWEEL_RE.sub("", text)
     text = clean_whitespace(text)
     return text

--- a/tests/test_parse/test_name_quality.py
+++ b/tests/test_parse/test_name_quality.py
@@ -647,7 +647,9 @@ class TestMatnSentenceGate:
     def test_truncated_matn_tail_punct_does_not_drop_name(
         self, polluted: str, expected: str
     ) -> None:
-        assert clean_narrator_name(normalize_arabic(polluted)) == expected
+        # `expected` is compared in normalized space so a name carrying alif-maqsura
+        # ("يحيى القطان") matches the ى→ي-folded cleaner output ("يحيي القطان") — da#427.
+        assert clean_narrator_name(normalize_arabic(polluted)) == normalize_arabic(expected)
 
     # --- PRECISION (Kavitha #2): connector-less real names (nasab == 0) — mononyms
     # and nisba/laqab-only forms — are NOT spared by the nasab guard, so they must
@@ -1137,8 +1139,10 @@ class TestMatnSentenceVerseGate:
             "وكان ذلك في يوم من الايام على عهد النبي",
             # function-word-dense matn, no verb opener
             "هذا هو الذي كان على ذلك",
-            # bare/short function-word fragments (proclitic folded)
-            "على",
+            # bare/short function-word fragments (proclitic folded). NB "على" was
+            # removed from this drop set by da#427: it now folds to "علي" (the name
+            # ʿAlī) and is deliberately kept, not dropped — see
+            # TestAlifMaqsuraFold::test_ali_preposition_collision_keeps_the_name.
             "فلو",
             "ما",
         ],
@@ -1652,3 +1656,134 @@ class TestCleanerRemovedContentContract:
             assert cleaned is not None, raw
             assert cleaner_removed_content(normalized, cleaned), raw
             assert len(cleaned.split()) < len(asserted_name_tokens(normalized)), raw
+
+
+class TestAlifMaqsuraFold:
+    """da#427 — normalize_arabic folds alif maqṣūra ى→ي; the name-quality sets follow.
+
+    The ~13 ``الذى``/``التى``/``والذى`` matn relative pronouns now normalize to the
+    ``الذي``/``التي`` boundary set and are scrubbed. The fold is homographic-safe on
+    names — no ism/nisba lands on a particle or boundary token — with ONE collision
+    the fold does not resolve in normalization (``على`` "on" → ``علي``, the name ʿAlī),
+    handled here by REMOVING ``على`` from _MATN_PARTICLES so a bare ``علي`` narrator is
+    never dropped. That trade is a recall loss in the safe direction (leaves residue
+    in; never deletes a name).
+    """
+
+    # === TARGET: the matn relative pronouns now reach the boundary set ===
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("فلان الذى قال كذا", "فلان"),  # truncated at the الذى boundary
+            ("حميد التى فيها", "حميد"),
+        ],
+    )
+    def test_matn_relative_pronoun_truncates_at_boundary(self, raw: str, expected: str) -> None:
+        assert clean_narrator_name(normalize_arabic(raw)) == normalize_arabic(expected)
+
+    @pytest.mark.parametrize("bare", ["الذى", "التى", "والذى"])
+    def test_bare_relative_pronoun_dropped(self, bare: str) -> None:
+        # a span that is ONLY the (now-folded) boundary pronoun leaves no name → drop
+        assert clean_narrator_name(normalize_arabic(bare)) is None
+
+    # === COLLISION: على -> علي (ʿAlī). The name MUST survive; the preposition is
+    # no longer detectable as a matn particle (documented recall loss). ===
+    @pytest.mark.parametrize("ali", ["على", "علي", "علي بن ابي طالب", "ابو الحسن علي"])
+    def test_ali_preposition_collision_keeps_the_name(self, ali: str) -> None:
+        assert clean_narrator_name(normalize_arabic(ali)) is not None
+
+    def test_ali_not_dropped_as_bare_particle(self) -> None:
+        # bare "على" (folds to علي) must NOT drop as an all-particle fragment (2c) —
+        # that would delete ʿAlī, one of the most-attested transmitters.
+        assert clean_narrator_name(normalize_arabic("على")) == normalize_arabic("علي")
+
+    # === Real alif-maqsura names survive and fold consistently ===
+    @pytest.mark.parametrize(
+        "name",
+        ["يحيى", "يحيى بن معين", "موسى بن جعفر", "عيسى", "ابو موسى الاشعري", "المثنى بن سعيد"],
+    )
+    def test_maqsura_names_preserved(self, name: str) -> None:
+        assert clean_narrator_name(normalize_arabic(name)) == normalize_arabic(name)
+
+    # === SET-LEVEL INVARIANT (#423 shape): no name/nisba folds onto a droppable
+    # token. This is the load-bearing safety proof — if a future edit adds a
+    # maqsura-final name-shape to a droppable set, or restores على to the particle
+    # set, this fails. ===
+    def test_no_name_folds_onto_a_droppable_token(self) -> None:
+        from src.parse.name_quality import (
+            _APPOSITION_CONNECTORS,
+            _ISNAD_BOUNDARY,
+            _MATN_DENSITY,
+            _MATN_OPENERS,
+            _MATN_PARTICLES,
+            _NASAB_CONNECTORS,
+        )
+
+        # common alif-maqsura-final isms / nisbas (folded to their ي forms)
+        folded_names = {
+            normalize_arabic(n)
+            for n in (
+                "يحيى",
+                "موسى",
+                "عيسى",
+                "المثنى",
+                "مصطفى",
+                "مرتضى",
+                "كسرى",
+                "ليلى",
+                "سلمى",
+                "بشرى",
+                "يعلى",
+                "على",  # the preposition that folds onto the name علي
+            )
+        }
+        droppable = (
+            _MATN_PARTICLES
+            | _ISNAD_BOUNDARY
+            | _MATN_OPENERS
+            | _MATN_DENSITY
+            | _APPOSITION_CONNECTORS
+            | _NASAB_CONNECTORS
+        )
+        assert folded_names.isdisjoint(droppable), folded_names & droppable
+
+    def test_ali_specifically_not_in_matn_particles(self) -> None:
+        """The على→علي collision pin (mirrors the أم/ام homograph pin)."""
+        from src.parse.name_quality import _MATN_PARTICLES
+
+        assert normalize_arabic("علي") not in _MATN_PARTICLES
+        assert normalize_arabic("على") not in _MATN_PARTICLES
+
+    def test_no_droppable_set_member_carries_alif_maqsura(self) -> None:
+        """Completeness: every ى in a droppable set was converted to ي (da#427)."""
+        from src.parse.name_quality import (
+            _APPOSITION_CONNECTORS,
+            _ISNAD_BOUNDARY,
+            _ISNAD_FORMULA_FRAGMENTS,
+            _MATN_DENSITY,
+            _MATN_OPENERS,
+            _MATN_PARTICLES,
+        )
+
+        for s in (
+            _MATN_PARTICLES,
+            _ISNAD_BOUNDARY,
+            _MATN_OPENERS,
+            _MATN_DENSITY,
+            _APPOSITION_CONNECTORS,
+            _ISNAD_FORMULA_FRAGMENTS,
+        ):
+            assert all("ى" not in tok for tok in s), [t for t in s if "ى" in t]
+
+    def test_apposition_particle_homograph_invariant_still_holds(self) -> None:
+        """After مولى→مولي the أم/ام pin (da#423) is unchanged — still the sole overlap."""
+        from src.parse.name_quality import _APPOSITION_CONNECTORS, _MATN_PARTICLES
+
+        assert _APPOSITION_CONNECTORS & _MATN_PARTICLES == frozenset({"ام"})
+
+    # === Composition with the da#299 Urdu-yeh fold: an Urdu-script and an
+    # Arabic-script benediction both strip to the same recovered name ===
+    def test_composes_with_da299_benediction_strip(self) -> None:
+        urdu = clean_narrator_name(normalize_arabic("ابو هريره صلی الله علیه وسلم"))
+        arabic = clean_narrator_name(normalize_arabic("ابو هريره صلى الله عليه وسلم"))
+        assert urdu == arabic == normalize_arabic("ابو هريره")

--- a/tests/test_parse/test_narrator_extraction.py
+++ b/tests/test_parse/test_narrator_extraction.py
@@ -243,7 +243,8 @@ class TestDa154NameBoundary:
     def test_arabic_laqab_stays_joined(self) -> None:
         # Multi-token name with a laqab (al-Ansari) stays a single span.
         spans = extract_narrator_mentions("حدثنا يحيى بن سعيد الأنصاري", "ar")
-        assert spans[0].name == "يحيى بن سعيد الانصاري"
+        # compared in normalized space: da#427 folds alif-maqsura ى→ي (يحيى→يحيي)
+        assert spans[0].name == normalize_arabic("يحيى بن سعيد الانصاري")
 
 
 class TestDa244TrailingTransmissionMarker:

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -767,7 +767,10 @@ def test_entry_number_prefix_is_not_a_truncation(tmp_path: Path) -> None:
     """
     normalized = normalize_arabic(_ITQAN_25339_ENTRY_NUMBER)
     cleaned = clean_narrator_name(normalized)
-    assert cleaned == _ITQAN_25339_NAME, f"fixture no longer strips the entry number: {cleaned!r}"
+    # normalized comparison: da#427 folds alif-maqsura ى→ي (موسى→موسي)
+    assert cleaned == normalize_arabic(_ITQAN_25339_NAME), (
+        f"fixture no longer strips the entry number: {cleaned!r}"
+    )
     assert not cleaner_removed_content(normalized, cleaned)
 
     staging = tmp_path / "staging"
@@ -1455,7 +1458,8 @@ def test_gloss_tail_class_a_is_recognised(raw: str, expected_cleaned: str, why: 
     """da#397 class A: a complete nasab that lost only a teacher-key isnad tail."""
     normalized = normalize_arabic(raw)
     cleaned = clean_narrator_name(normalized)
-    assert cleaned == expected_cleaned, (
+    # normalized comparison: da#427 folds alif-maqsura ى→ي (e.g. عيسى→عيسي)
+    assert cleaned == normalize_arabic(expected_cleaned), (
         f"fixture no longer truncates as expected ({why}): {cleaned!r}"
     )
     assert cleaner_removed_content(normalized, cleaned), why
@@ -1469,7 +1473,8 @@ def test_name_cut_class_b_is_not_a_gloss_tail(raw: str, expected_cleaned: str, w
     """da#397 class B: a name-cut / disputed-identity / non-nasab residue is NOT recoverable."""
     normalized = normalize_arabic(raw)
     cleaned = clean_narrator_name(normalized)
-    assert cleaned == expected_cleaned, (
+    # normalized comparison: da#427 folds alif-maqsura ى→ي (e.g. عيسى→عيسي)
+    assert cleaned == normalize_arabic(expected_cleaned), (
         f"fixture no longer truncates as expected ({why}): {cleaned!r}"
     )
     assert cleaner_removed_content(normalized, cleaned), why

--- a/tests/test_utils/test_arabic.py
+++ b/tests/test_utils/test_arabic.py
@@ -11,6 +11,7 @@ from src.utils.arabic import (
     extract_transmission_phrases,
     is_arabic,
     normalize_alif,
+    normalize_alif_maqsura,
     normalize_arabic,
     normalize_hamza,
     normalize_taa_marbuta,
@@ -532,3 +533,59 @@ class TestContainsTransmissionMarker:
 
     def test_empty(self) -> None:
         assert contains_transmission_marker("") is False
+
+
+class TestAlifMaqsuraFold:
+    """da#427 — normalize_arabic folds alif maqṣūra ى (U+0649) to yāʾ ي (U+064A).
+
+    Alif maqṣūra is the dotless final yāʾ. Corpora spell final yāʾ inconsistently, so
+    a name or particle ending ``ى`` never collapses onto its ``ي``-spelled twin
+    without the fold — the ~13 ``الذى``/``التى``/``والذى`` matn pronouns never reach
+    the ``الذي``/``التي`` boundary set, and ``يحيى``/``يحيي`` mint two canonical ids.
+    """
+
+    @pytest.mark.parametrize(
+        "raw,folded",
+        [
+            ("الذى", "الذي"),  # relative pronoun — the issue's ~13-row target
+            ("التى", "التي"),
+            ("والذى", "والذي"),
+            ("يحيى", "يحيي"),  # very frequent narrator
+            ("موسى", "موسي"),
+            ("عيسى", "عيسي"),
+            ("المثنى", "المثني"),
+            ("حتى", "حتي"),
+            ("على", "علي"),  # the documented collision: preposition -> the name ʿAlī
+        ],
+    )
+    def test_maqsura_folds_to_yaa(self, raw: str, folded: str) -> None:
+        assert normalize_alif_maqsura(raw) == folded
+        assert normalize_arabic(raw) == folded
+
+    def test_fold_is_idempotent(self) -> None:
+        for w in ("يحيى", "الذى", "على", "موسى", "صلى الله عليه وسلم"):
+            once = normalize_arabic(w)
+            assert normalize_arabic(once) == once
+            assert "ى" not in once  # no U+0649 survives
+
+    def test_pure_yaa_input_is_a_fixed_point(self) -> None:
+        # a name already spelled with ي is untouched (يحيي stays يحيي)
+        assert normalize_alif_maqsura("يحيي بن معين") == "يحيي بن معين"
+
+    def test_composes_with_da299_urdu_yeh_fold(self) -> None:
+        """The da#427 Arabic-maqsura fold and the da#299 Urdu-yeh fold converge.
+
+        An Urdu-script taṣliya (Farsi yeh ی, U+06CC) and an Arabic-script taṣliya
+        (alif maqṣūra ى, U+0649) both normalize to the SAME regular-yeh ي form — the
+        two folds touch different SOURCE codepoints with the same ي target and are
+        order-independent (neither produces the other's input).
+        """
+        urdu = normalize_arabic("صلی الله علیه وسلم")  # Farsi yeh U+06CC
+        arabic = normalize_arabic("صلى الله عليه وسلم")  # alif maqṣūra U+0649
+        assert urdu == arabic
+        assert "ى" not in urdu and "ی" not in urdu  # no maqṣūra, no Farsi yeh survive
+
+    def test_variant_spellings_share_a_canonical_surface(self) -> None:
+        """يحيى (maqṣūra) and يحيي (yaa) — one narrator — now normalize identically."""
+        assert normalize_arabic("يحيى بن معين") == normalize_arabic("يحيي بن معين")
+        assert normalize_arabic("ابو موسى") == normalize_arabic("ابو موسي")


### PR DESCRIPTION
Closes #427.

## What & why

`normalize_arabic` never folded **alif maqṣūra ى (U+0649) → yāʾ ي (U+064A)**, so the ~13 attested `الذى`/`التى`/`والذى` matn relative pronouns never reached the `الذي`/`التي` boundary set and survived into the narrator table, and `يحيى`/`يحيي` minted two canonical ids for one narrator. This adds `normalize_alif_maqsura` (a single `U+0649→U+064A` substitution) to the pipeline and re-syncs every affected name-quality constant.

## NOT mechanical — the #423 lesson, enumerated

Every `ى` the fold touches was enumerated. The fold is **homographic-safe on names** — `يحيى`, `موسى`, `عيسى`, `المثنى`, `مصطفى`, `مرتضى`, `كسرى`, `ليلى`, `سلمى`, `بشرى`, `يعلى` all fold to their `ي` forms and **none lands on a particle or boundary token** (pinned by a set-level invariant test in the exact shape of #423's `_APPOSITION_CONNECTORS & _MATN_PARTICLES == {"ام"}`).

**The one genuine collision the fold does NOT resolve:** the preposition **`على` ("on") folds to `علي`, the name ʿAlī.** Adding `علي` to `_MATN_PARTICLES` would drop a bare `علي` narrator via rule 2c (all-particle) — **deleting one of the most-attested transmitters** — so `على` is **removed** from the particle set instead. That is a recall loss in the **safe direction** (leaves `على`-preposition residue in; never deletes a name); the alternative deletes ʿAlī. The set-level invariant test *pins* the removal (restoring `على` fails it).

Every other `ى`-bearing set member is converted to its `ي` form: `حتى→حتي` (`_ISNAD_BOUNDARY`, `_MATN_DENSITY`), `نهى→نهي` / `صلى→صلي` / `بلى→بلي` / `روى→روي` (`_MATN_OPENERS`, `روى` merges with the passive `روي` that #311 kept distinct only because `ى` did not then fold), `الى→الي` / `لدى→لدي` / `متى→متي` (`_MATN_PARTICLES`), `مولى→مولي` (`_APPOSITION_CONNECTORS`). The alif-maqṣūra benediction phrases are now redundant with the da#299 yeh twins and were removed. A completeness test asserts no droppable set member still carries `U+0649`.

## Composition with da#299 (verified)

Composes with the da#299 Urdu-yeh fold (`normalize_urdu`: `U+06CC/U+06D2/U+06D3 → U+064A`): **distinct source codepoints, same `ي` target, order-independent** (neither produces the other's input) — an Urdu-script `صلی` and an Arabic-script `صلى` both converge on `صلي`. Pinned by `test_composes_with_da299_urdu_yeh_fold` and `test_composes_with_da299_benediction_strip`.

## Bidirectional, unweighted A/B

**Full-corpus A/B is data-gated and DEFERRED** (honest — no fabricated numbers): `data/raw` is empty in-repo. Magnitude re-runnable via `scripts/scrub_matn_canonical.py` (must report the `mention_count = 0` slice).

**Fixture-level A/B (both directions), old (`origin/deployments/phase-9/wave-26`) vs this PR, over 551 Arabic fixtures:**
- **NEWLY-DELETED real narrators: 0** ← the load-bearing direction, unweighted (per-row).
- **NEWLY-DROPPED rows: 5** — all are the target matn pronouns `الذى`/`التى`/`والذى` + bare function words `حتي`/`صلي` that main **wrongly kept as narrators** (correct scrubbing, not name loss).
- **NEWLY-KEPT: 1** — `على → علي` (the documented ʿAlī tradeoff).
- **CHANGED (name → folded form): 38** — consistency-preserving `ى→ي` folds (`موسى→موسي`, `يحيى→يحيي`, …).

## Reviewer attention (the issue asks for an Arabic reader)

1. **The `على`/`علي` tradeoff** — is losing `على`-preposition detection (to save ʿAlī) the right call, or should `على` be restored with a bare-`علي`-exemption carve-out? A corpus A/B should quantify the recall cost before merge.
2. **Canonical-id re-keying** — the fold runs inside `make_canonical_id`, so it **merges variant spellings of the same narrator** (`يحيى ≡ يحيي`, `موسى ≡ موسي`). This is corpus-wide and consistency-improving, but unmeasured without the corpus. The DISPLAY field (`name_ar`, voweled) is NOT folded — display keeps `يحيى`.

## Acceptance criteria

1. ✅ The ~13 `الذى`/`التى`/`والذى` rows are scrubbed (reach the boundary).
2. ⏳ Bidirectional unweighted full-corpus A/B — **deferred, data-gated** (fixture-level A/B above; `mention_count=0` slice noted for the corpus run).
3. ✅ Set-level test pinning that no name/nisba folds onto a particle or boundary token (+ the `على`/`علي` pin, + a `U+0649`-completeness test).
4. ⏳ Reviewed by someone who reads Arabic — requested; every touched codepoint documented above and in the `normalize_alif_maqsura` docstring.

## Tests

`TestAlifMaqsuraFold` in `test_arabic.py` (13, fold correctness/idempotency/da#299 composition/id-merge) and `test_name_quality.py` (21, target scrub / ʿAlī-survives / set invariants / da#299 composition), all **mutation-checked** (3 mutations — disable fold / restore the `على` landmine / incomplete conversion — each kills the intended test). Five pre-existing fixtures updated to compare in normalized space (their expected values now fold). Full non-integration suite: **2469 passed, 10 skipped**. ruff-format/lint (v0.15.11), mypy strict, gitleaks: clean.

Reviewers: needs a merge-gate (Opus) + a second reviewer per charter; an **Arabic-reading reviewer is required** here (issue AC #4). Composes with da#424 (PR #474): both branch off this wave; the `صلى→صلي` opener addition interacts with #474's kept-whole recovery on `ذواليدين صلي مع النبي` (still survives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — orchestrator note (2026-07-21)

**AC#2 (full-corpus bidirectional unweighted A/B): WAIVED by owner (2026-07-21).** `data/raw` is empty in this environment, so the corpus A/B is unrunnable here. Shipping on the strength of the set-level invariant test (no name/nisba folds onto a particle/boundary — the guard #423 lacked), NEWLY-DELETED=0 over 551 curated fixtures, and the safe-direction على handling. The deferred full-corpus A/B is tracked in **#478** (sibling of #475 for da#424).

**Decision-2 correction (per Ivana Horvat's review):** the original body overstated the canonical-id re-key. `src/parse/identity.py` is NOT touched by this diff — `canonical_surface._fold_residual_noise` (da#434, pre-existing at the merge-base) already merged `يحيى`≡`يحيي` at the id-mint layer before this PR. No new corpus-wide identity re-key is introduced here, and decision-2 does not require owner sign-off.
