### PR TITLE
tech-debt: share the resolve-stage gross death-year spread band

### DIFF
--- a/src/resolve/_death_year_bands.py
+++ b/src/resolve/_death_year_bands.py
@@ -1,0 +1,33 @@
+"""Shared resolve-stage death-year sanity bands (da#464).
+
+``fuzzy_cluster`` (da#380) and ``narrator_unify`` (da#431) each veto a
+merge/unify decision on a death-year conflict, weighed at two bands:
+
+* :data:`DEATH_YEAR_TOLERANCE` — the tight band. Two *trusted* years
+  (corroborated, or an untagged/legacy record) disagreeing by more than this
+  many AH years block the merge outright; one source rounding a year by a
+  year or two is fine, a whole generation apart is not.
+* :data:`GROSS_DEATH_SPREAD` — the loose band. A much wider sanity check that
+  still catches a distinct namesake even when neither year carries full
+  trust — an ``uncorroborated`` fuzzy-bio year in ``fuzzy_cluster``, or a
+  curated unify-group member in ``narrator_unify``.
+
+Both stages must weigh an uncorroborated/noisy year the same way — that
+cross-stage invariant used to be two independent literals a code comment
+merely *promised* stayed equal (one retune away from silent drift). Hoisting
+both constants here makes the invariant structural: there is only one place
+to change either band, and both stages import it.
+"""
+
+from __future__ import annotations
+
+# Two *trusted* death years (corroborated, or untagged/legacy) disagreeing by
+# more than this many AH years block a merge/unify outright.
+DEATH_YEAR_TOLERANCE = 2
+
+# Loose sanity band (in AH years) applied when at least one death year is not
+# fully trusted (fuzzy_cluster's `uncorroborated` tag; narrator_unify's
+# curated-but-noisy group members). Wide enough to pass a genuine
+# generation-default noise gap, tight enough to still refuse a
+# cross-generation namesake.
+GROSS_DEATH_SPREAD = 50

--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -92,6 +92,7 @@ from src.resolve._checkpoint import (
     resolve_cadence,
     save_checkpoint,
 )
+from src.resolve._death_year_bands import DEATH_YEAR_TOLERANCE, GROSS_DEATH_SPREAD
 from src.resolve._run_record import write_canonical
 from src.resolve.attestation import derive_attestation
 from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
@@ -114,7 +115,8 @@ _CLUSTER_RATIO_THRESHOLD = 90.0
 # When both records carry a death year, a disagreement beyond this many AH years
 # blocks the merge regardless of name score (two narrators a generation+ apart
 # are not the same person). One source rounding a death year by a year is fine.
-_DEATH_YEAR_TOLERANCE = 2
+# Shared with ``narrator_unify`` (da#464) — see ``_death_year_bands`` for why.
+_DEATH_YEAR_TOLERANCE = DEATH_YEAR_TOLERANCE
 
 # Discounted band for a death year tagged ``uncorroborated`` (da#380). A weak
 # Stage-2 fuzzy bio match persists its year on the record but marks it
@@ -122,9 +124,11 @@ _DEATH_YEAR_TOLERANCE = 2
 # narrators (disambiguate.py, da#356). An OCR-corrupt uncorroborated year off by
 # a handful of AH years must therefore NOT veto a merge at the tight
 # ``_DEATH_YEAR_TOLERANCE``; only a gross, generations-apart spread still blocks.
-# Mirrors ``narrator_unify._gross_death_spread``'s da#431 sanity band (=50) so the
-# resolve stage weighs an uncorroborated year the same way everywhere.
-_UNCORROBORATED_DEATH_SPREAD = 50
+# Imported from ``_death_year_bands`` (da#464) — the same value
+# ``narrator_unify._gross_death_spread``'s da#431 sanity band imports, so the
+# resolve stage weighs an uncorroborated year the same way everywhere by
+# construction, not by a comment promising two literals stay equal.
+_UNCORROBORATED_DEATH_SPREAD = GROSS_DEATH_SPREAD
 
 # Minimum number of *shared* significant (non-connector) name tokens required to
 # merge. token_set_ratio scores a bare given name as a perfect (100) subset of

--- a/src/resolve/narrator_unify.py
+++ b/src/resolve/narrator_unify.py
@@ -65,9 +65,10 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import yaml
 
+from src.resolve._death_year_bands import DEATH_YEAR_TOLERANCE as _DEATH_YEAR_TOLERANCE
+from src.resolve._death_year_bands import GROSS_DEATH_SPREAD
 from src.resolve._run_record import write_canonical
 from src.resolve.fuzzy_cluster import (
-    _DEATH_YEAR_TOLERANCE,
     _genders_conflict,
     _merge_cluster,
     _remap_mention_canonical_ids,
@@ -90,7 +91,10 @@ _SEED_PATH = Path(__file__).with_name("narrator_unify.yaml")
 # but wide gaps (> this) mark a distinct namesake, not one person. Chosen so a genuine
 # generation-default noise gap (Anas: bare d.60 vs qualified d.91 = 31) passes while a
 # cross-generation namesake (bare Shaqīq d.200 vs Abū Wāʾil d.82 = 118) is refused.
-_UNIFY_MAX_DEATH_SPREAD = 50
+# Imported from ``_death_year_bands`` (da#464) — the same value
+# ``fuzzy_cluster._UNCORROBORATED_DEATH_SPREAD`` imports, so a retune of either
+# stage's band can no longer drift from the other.
+_UNIFY_MAX_DEATH_SPREAD = GROSS_DEATH_SPREAD
 
 __all__ = [
     "UnifyGroup",


### PR DESCRIPTION
## Summary

`fuzzy_cluster._UNCORROBORATED_DEATH_SPREAD` (da#380 / PR #463) and `narrator_unify._UNIFY_MAX_DEATH_SPREAD` (da#431) were two independent `= 50` literals. A code comment on each asserted they must stay equal ("mirrors ... so the resolve stage weighs an uncorroborated year the same way everywhere"), but nothing enforced it — retuning one silently breaks the cross-stage invariant.

This hoists both the tight tolerance (`_DEATH_YEAR_TOLERANCE`) and the gross-spread band (`= 50`) into a new shared module, `src/resolve/_death_year_bands.py` (`DEATH_YEAR_TOLERANCE`, `GROSS_DEATH_SPREAD`), and points both `fuzzy_cluster` and `narrator_unify` at it directly (rather than one importing transitively through the other).

- `narrator_unify` already imported `_DEATH_YEAR_TOLERANCE` from `fuzzy_cluster` (that half couldn't drift); it now imports it from the shared module instead.
- The gross-spread band, previously duplicated as two `= 50` literals, is now a single value both stages alias locally (`_UNCORROBORATED_DEATH_SPREAD` / `_UNIFY_MAX_DEATH_SPREAD` keep their existing local names — and their existing worked-example doc comments — but both now read from the one shared constant).

Non-behavioral refactor: no logic, thresholds, or public names changed. da#380 and da#431 guard tests are unmodified and stay green.

Closes #464

## Test plan
- [x] `ENVIRONMENT=test uv run pytest tests/test_resolve/test_fuzzy_cluster.py tests/test_resolve/test_narrator_unify.py -q` — 45 passed
- [x] `pre-commit run --all-files` (commit-stage) — all green
- [x] `pre-commit run --all-files --hook-stage pre-push` (mypy-strict + full pytest suite) — all green

## Reviewers
- Jean-Claude Habimana (merge-gate)
- Oyunbileg Batbayar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z