### PR TITLE
docs(da#427): record the ى→ي fold full-corpus A/B artifact (da#477)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -166,3 +166,7 @@ tatweel
 gradings
 textless
 unsplit
+
+# --- da#427 alif-maqsura fold A/B report (docs/reports/alif-maqsura-fold-ab-da427.md) ---
+maqṣūra
+ʿAlī

--- a/docs/reports/alif-maqsura-fold-ab-da427.md
+++ b/docs/reports/alif-maqsura-fold-ab-da427.md
@@ -1,0 +1,84 @@
+# Alif-maqṣūra ى→ي fold: full-corpus A/B (da#427 AC#2 artifact)
+
+> Deferred follow-up from da#427 (PR #476), recorded here per da#477 so the AC#2
+> acceptance box has a durable artifact instead of living only in the #476 PR review.
+> Base-vs-head bidirectional A/B (`main` vs. the da#427 `normalize_arabic` +
+> `name_quality` change), on the `curated.pre-rerun-928` snapshot
+> (`data/curated.pre-rerun-928-20260711T203626Z`): 3,249,721 mentions / 129,234
+> canonical narrators. Per-row unweighted AND mention-weighted, mc=0 bio-promoted
+> rows included (the da#424 lesson — a corruption/deletion check that skips the
+> zero-mention-count tail misses the bio-only path, da#99/da#110).
+
+## TL;DR
+
+| Direction | Result |
+|---|---|
+| NEWLY-DELETED real narrators | **0** |
+| NEWLY-KEPT junk (the `على` carve-out question) | **0** |
+| Canonical-id re-key | 59 names / 60 mentions — all consistency-improving, **0** wrong merges |
+
+## 1. Deletion direction (kept→dropped)
+
+47 distinct `name_raw` / 81 mentions flip kept→dropped between base and head. Every
+one is a maqṣūra-spelled variant whose yeh-twin (the ي-spelled form of the same
+string) was **already** dropped on base — e.g. `ابى` → already-dropped `ابي`,
+`حدثنى شعبه` → already-dropped `حدثني شعبه`. The head is not deleting anything base
+kept; it is folding a maqṣūra spelling onto a drop decision base already made under
+the ي spelling, so the drop-gate becomes spelling-consistent rather than
+spelling-dependent.
+
+32 canonical nodes go clean→un-nameable. All 32 are junk residue on inspection: no
+death year, no `name_en`, no `external_id`. The largest (`mention_count` 43) is
+`أَبَى`, a bare relational fragment ("his father" — the da#247 relational-pronoun
+pollution class, `.claude/memory/project_relational_pollution_scrub_equiv.md`), not
+a narrator.
+
+## 2. Recall direction (dropped→kept) — the `على` carve-out question
+
+da#427 removed `على` from `_MATN_PARTICLES` because the fold makes the preposition
+`على` ("on") and the name `علي` (ʿAlī) homographic (both fold to `علي`); keeping
+`على` in the particle set would drop a bare `علي` narrator span via the all-particle
+rule (2c), deleting one of the most-attested transmitters. The tradeoff, per the
+da#427 PR, is a recall loss in the safe direction: `على`-preposition matn residue
+that base's particle-based drop-gate used to catch now survives.
+
+**On this snapshot, that feared recall loss did not materialize: newly-kept junk =
+0.** Removing `على` from `_MATN_PARTICLES` produced no new surviving matn fragment
+here — no row exists in this corpus where a bare `على` span, undetected as a
+particle, was the *only* thing keeping an otherwise-junk span alive.
+
+## 3. Canonical-id re-key (consistency direction)
+
+59 names / 60 mentions re-key to a different canonical id between base and head, all
+consistency-improving. The dominant shape is `يعنى`-gloss stripping re-attaching a
+mention to its clean real-narrator twin, e.g. `يحيى يعنى ابن سعيد` →
+`يحيي ابن سعيد`. **Zero** wrong cross-narrator merges were found in this set. The
+`يحيى`≡`يحيي` corpus-level merge itself is pre-existing (da#434
+`_fold_residual_noise`), already folded at the mint surface on base; this A/B only
+measures the *additional* re-keys the da#427 fold introduces on top of that.
+
+## Disposition
+
+- **AC#2 (da#427) is satisfied.** This is the bidirectional unweighted full-corpus
+  A/B (mc=0 rows visible) the acceptance criterion asked for; it lives here as the
+  durable artifact rather than only in the #476 review thread.
+- **The `على` bare-particle carve-out (da#477 task 2) is NOT built.** The measured
+  newly-kept junk is 0 on this snapshot, so the carve-out this task considered
+  (detect `على` as a matn preposition while exempting a bare `علي` narrator span)
+  would have no effect here — per da#477, it is not built speculatively. This
+  finding is **corpus-gated, not closed**: the next production re-run is a different,
+  unmeasured corpus, and if a future A/B on that corpus shows `على` matn residue
+  inflating the canonical node of ʿAlī (mention-count inflation via the `على`≡`علي`
+  id-level equivalence), re-open the carve-out question against that measurement.
+
+## Method notes
+
+- Snapshot is a point-in-time on-disk read (`data/curated.pre-rerun-928-*`); a live
+  resolve run owns `data/`, so this reflects that snapshot only, not necessarily the
+  current tree.
+- `normalize_arabic` / `name_quality` behaviour is taken from source
+  (`src/utils/arabic.py`, `src/parse/name_quality.py`), not inferred.
+- See `tests/test_parse/test_name_quality.py::TestAlifMaqsuraFold` and
+  `TestRecoveryIsNoWorseThanMain` for the fixture-level unit pins this full-corpus
+  measurement complements (unit fixtures are the accumulated regression shapes;
+  this report is the one-time full-corpus sweep).

--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -847,6 +847,13 @@ _MATN_OPENERS = frozenset(
 # SAFE direction (leaves residue in; never deletes a name), and the alternative
 # deletes ʿAlī. The set-level invariant test pins that no name (``علي`` included)
 # folds onto a member of this or any other droppable set.
+#
+# da#477 corpus A/B (curated.pre-rerun-928, see
+# docs/reports/alif-maqsura-fold-ab-da427.md): the feared recall loss did not
+# materialize on that snapshot — newly-kept junk = 0, so a carve-out that detects
+# ``على`` as a matn preposition while exempting a bare ``علي`` narrator span was
+# NOT built. This is corpus-gated, not closed: re-check against the next production
+# re-run before ruling the carve-out out permanently.
 _MATN_PARTICLES = frozenset(
     {
         # prepositions ("على" excluded — see header: folds onto the name علي)

--- a/tests/test_parse/test_name_quality.py
+++ b/tests/test_parse/test_name_quality.py
@@ -1804,9 +1804,11 @@ class TestRecoveryIsNoWorseThanMain:
     only ever turns a drop or a polluted whole span into a cleaner name.
 
     The full-corpus, bidirectional, unweighted A/B (row-level, mention_count=0 slice
-    visible) is DATA-GATED — no raw corpus ships in the repo (``data/raw`` is empty)
-    — and is deferred to a re-run, per the issue. These fixtures are the verbatim
-    corpus rows the series accumulated, standing in for the deletion-direction sweep.
+    visible) ran against the ``curated.pre-rerun-928`` snapshot (da#477): NEWLY-DELETED
+    real narrators = 0, matching the fixtures below. See
+    ``docs/reports/alif-maqsura-fold-ab-da427.md`` for the full measurement (deletion,
+    recall, and re-key directions). These fixtures remain the fast, no-data-required
+    unit pins for the deletion direction the #423/#314 series accumulated.
     """
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Closes #477.

da#427 (PR #476) shipped the alif-maqsura ى→ي fold in `normalize_arabic` with only a
fixture-level A/B (`data/raw` was empty at the time). AC#2 asked for the full-corpus
bidirectional A/B, which had been measured but only lived in the #476 review thread.

- Adds `docs/reports/alif-maqsura-fold-ab-da427.md`: the `curated.pre-rerun-928`
  snapshot A/B (3,249,721 mentions / 129,234 canonical narrators) — NEWLY-DELETED
  real narrators = 0, NEWLY-KEPT junk = 0, 59-name / 60-mention consistency-improving
  canonical-id re-key with 0 wrong merges.
- Updates the `TestRecoveryIsNoWorseThanMain` docstring in
  `tests/test_parse/test_name_quality.py` and the `_MATN_PARTICLES` `على` comment in
  `src/parse/name_quality.py` to point at the report instead of "deferred to a re-run".
- Adds `maqṣūra` / `ʿAlī` to the cspell project dictionary for the new report.

**Task 2 (`على` bare-particle carve-out) is explicitly NOT built.** Per the issue,
the measured newly-kept junk is 0 on this snapshot, so building the carve-out would
be speculative. Both the report and the code comment mark this as corpus-gated, not
closed — a future production re-run may still surface `على` residue worth revisiting.

## Test plan

- [x] `pre-commit run --all-files` (ruff-format, ruff-lint, gitleaks, actionlint,
      cspell, dockerfile-base-pin, fixture-realism) — all passed
- [x] `pre-commit run mypy --hook-stage pre-push --all-files` — passed
- [x] `ENVIRONMENT=test pre-commit run pytest --hook-stage pre-push --all-files` — passed
- [x] No production code behavior changed — docs + comments only

Reviewers: Alejandra Reyes-Fuentes (merge-gate) + Nikolaos Papadopoulos

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z