### PR TITLE
fix(da#454): bound attested death_year_ah to the isnad-plausibility envelope at stamp time

### DIFF
--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -44,6 +44,7 @@ from src.resolve.sect_affiliation import (
     normalize_corpus,
     primary_corpus,
 )
+from src.resolve.tabaqa_dates import plausible_attested_death_year
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
 
@@ -52,10 +53,11 @@ logger = get_logger(__name__)
 __all__ = ["promote_bios_to_canonical"]
 
 # Scalar bio fields back-filled onto an existing canonical record when missing.
+# ``death_year_ah`` is handled separately (da#454, plausibility-bound at stamp
+# time) rather than through this generic pass-through.
 _BACKFILL_FIELDS = (
     "name_en",
     "birth_year_ah",
-    "death_year_ah",
     "generation",
     "gender",
     "trustworthiness",
@@ -308,6 +310,14 @@ def promote_bios_to_canonical(
 
             bio_id = safe_str(row.get("bio_id"))
             cid = make_canonical_id(norm)
+            # da#454: bound the bio's attested death year against the isnad-narrator
+            # plausibility envelope *before* it can be written anywhere — a raw
+            # death_year_ah outside the envelope (the d. ~700-780 AH late-collector
+            # pollution) becomes None rather than landing on a fresh node or
+            # back-filling an existing one.
+            death_year = plausible_attested_death_year(
+                row.get("death_year_ah"), row.get("generation")
+            )
 
             # When `cleaner_removed_content` is True the cleaner removed name-span
             # material beyond its affix normalizations. That covers TWO classes the
@@ -409,7 +419,7 @@ def promote_bios_to_canonical(
                     "name_ar_normalized": norm,
                     "aliases": [],
                     "birth_year_ah": row.get("birth_year_ah"),
-                    "death_year_ah": row.get("death_year_ah"),
+                    "death_year_ah": death_year,
                     "generation": safe_str(row.get("generation")),
                     "gender": safe_str(row.get("gender")),
                     "trustworthiness": safe_str(row.get("trustworthiness")),
@@ -441,6 +451,11 @@ def promote_bios_to_canonical(
                 for field_name in _BACKFILL_FIELDS:
                     if rec.get(field_name) in (None, "") and row.get(field_name) not in (None, ""):
                         rec[field_name] = row.get(field_name)
+                # death_year_ah backfills from the plausibility-bound value (da#454),
+                # never the raw row — an implausible attested year must not sneak
+                # onto an existing (even zero-mention) record either.
+                if rec.get("death_year_ah") in (None, "") and death_year is not None:
+                    rec["death_year_ah"] = death_year
             promoted += 1
             promoted_cids.add(cid)
 

--- a/src/resolve/date_reconcile.py
+++ b/src/resolve/date_reconcile.py
@@ -86,6 +86,7 @@ from src.parse.narrator_dates import (
 )
 from src.resolve._run_record import write_canonical
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.resolve.tabaqa_dates import generation_from_value, is_plausible_narrator_death_ah
 from src.utils.arabic import normalize_arabic
 from src.utils.hijri import ah_year_to_ce_range
 from src.utils.logging import get_logger
@@ -510,6 +511,25 @@ def reconcile_canonical_dates(
         obs_slot = obs_by_cid.get(cid) if cid else None
         if obs_slot is not None:
             merged = reconcile_narrator(obs_slot["birth"], obs_slot["death"])
+            # da#454: a reconciled DEATH point outside the isnad-narrator plausibility
+            # envelope (the d. ~700-780 AH late-collector/commentator pollution welded
+            # onto an early node — see tabaqa_dates.is_plausible_narrator_death_ah) must
+            # never be written onto the canonical record. Reconciliation folds per-
+            # source OBSERVATIONS (agreement/conflict/noise-gap) but has no concept of
+            # "impossible for THIS narrator's generation" — a single uncontested corrupt
+            # source sails straight through as a "conflict-free" EXACT point. Scrub the
+            # WHOLE death dating (point + both bounds + precision), not just the point:
+            # leaving corrupt bounds/EXACT precision behind a null point would read as
+            # "dated" to tabaqa_dates' undated-check and skip the ṭabaqa fallback that
+            # runs next, stranding the narrator on a half-scrubbed, still-wrong dating.
+            death_point = merged.get("death_year_ah")
+            if death_point is not None and not is_plausible_narrator_death_ah(
+                death_point, generation_from_value(rec.get("generation"))
+            ):
+                merged["death_year_ah"] = None
+                merged["death_year_ah_earliest"] = None
+                merged["death_year_ah_latest"] = None
+                merged["death_date_precision"] = DatePrecision.UNKNOWN.value
             for key, value in merged.items():
                 # Never null out a point a prior producer back-filled (defensive —
                 # a contributing bio would itself have surfaced that point here).

--- a/src/resolve/date_reconcile.py
+++ b/src/resolve/date_reconcile.py
@@ -523,6 +523,10 @@ def reconcile_canonical_dates(
             # "dated" to tabaqa_dates' undated-check and skip the ṭabaqa fallback that
             # runs next, stranding the narrator on a half-scrubbed, still-wrong dating.
             death_point = merged.get("death_year_ah")
+            # Death columns the da#454 scrub cleared with EXPLICIT intent, so the
+            # back-fill-protection loop below honours the clear instead of swallowing
+            # it (empty on the normal path — populated only when the scrub fires).
+            scrub_cleared: set[str] = set()
             if death_point is not None and not is_plausible_narrator_death_ah(
                 death_point, generation_from_value(rec.get("generation"))
             ):
@@ -530,10 +534,29 @@ def reconcile_canonical_dates(
                 merged["death_year_ah_earliest"] = None
                 merged["death_year_ah_latest"] = None
                 merged["death_date_precision"] = DatePrecision.UNKNOWN.value
+                scrub_cleared = {
+                    "death_year_ah",
+                    "death_year_ah_earliest",
+                    "death_year_ah_latest",
+                }
             for key, value in merged.items():
                 # Never null out a point a prior producer back-filled (defensive —
-                # a contributing bio would itself have surfaced that point here).
-                if key.endswith("_year_ah") and value is None and rec.get(key) is not None:
+                # a contributing bio would itself have surfaced that point here) —
+                # UNLESS the da#454 scrub above cleared it with explicit intent. When
+                # the canonical record ALREADY holds a death point (a persisted
+                # pre-fix corrupt point on an idempotent `resolve --from-step
+                # reconcile` re-run, or a bio_promote-stamped point reconciliation
+                # recomputes as implausible from the fuller unscrubbed bio set), the
+                # guard would otherwise keep that point while its bounds + precision
+                # are nulled — the self-inconsistent half-scrub this scrub exists to
+                # prevent, which then reads as "dated" to tabaqa_dates' undated-check
+                # and skips the ṭabaqa fallback (da#454).
+                if (
+                    key.endswith("_year_ah")
+                    and value is None
+                    and rec.get(key) is not None
+                    and key not in scrub_cleared
+                ):
                     continue
                 rec[key] = value
             reconciled += 1

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -51,6 +51,7 @@ from src.resolve.sect_affiliation import (
     normalize_corpus,
     primary_corpus,
 )
+from src.resolve.tabaqa_dates import plausible_attested_death_year
 from src.utils.arabic import canonical_surface
 from src.utils.logging import get_logger
 
@@ -473,6 +474,7 @@ def _load_candidates(staging_dir: Path) -> list[Candidate]:
             # key does, or Stage 1 can never exact-match across an inflection (and the
             # da#371 provenance drift leaves un-normalized bio keys nothing can match).
             name_ar_norm = canonical_surface(name_ar_norm) if name_ar_norm else None
+            generation = safe_str(table.column("generation")[i].as_py())
 
             candidates.append(
                 Candidate(
@@ -483,10 +485,16 @@ def _load_candidates(staging_dir: Path) -> list[Candidate]:
                     kunya=safe_str(table.column("kunya")[i].as_py()),
                     nisba=safe_str(table.column("nisba")[i].as_py()),
                     birth_year_ah=table.column("birth_year_ah")[i].as_py(),
-                    death_year_ah=table.column("death_year_ah")[i].as_py(),
+                    # da#454: an implausible attested death (the d. ~700-780 AH
+                    # late-collector pollution) must not enter the candidate pool —
+                    # it feeds _temporal_filter/_bio_corroborated below and, via
+                    # death_year_index, narrator_split's neighbour-death evidence.
+                    death_year_ah=plausible_attested_death_year(
+                        table.column("death_year_ah")[i].as_py(), generation
+                    ),
                     birth_location=safe_str(table.column("birth_location")[i].as_py()),
                     death_location=safe_str(table.column("death_location")[i].as_py()),
-                    generation=safe_str(table.column("generation")[i].as_py()),
+                    generation=generation,
                     gender=safe_str(table.column("gender")[i].as_py()),
                     trustworthiness=safe_str(table.column("trustworthiness")[i].as_py()),
                     external_id=safe_str(table.column("external_id")[i].as_py()),

--- a/src/resolve/tabaqa_dates.py
+++ b/src/resolve/tabaqa_dates.py
@@ -74,6 +74,7 @@ __all__ = [
     "estimate_death_window",
     "generation_from_value",
     "is_plausible_narrator_death_ah",
+    "plausible_attested_death_year",
 ]
 
 # Generation (ṭabaqa) → approximate Hijri (AH) death-year window.
@@ -159,6 +160,39 @@ def is_plausible_narrator_death_ah(
         if not (lo - DEATH_PLAUSIBILITY_MARGIN_AH <= year <= hi + DEATH_PLAUSIBILITY_MARGIN_AH):
             return False
     return True
+
+
+def plausible_attested_death_year(year: int | None, generation: object = None) -> int | None:
+    """Bound-check a source-attested death year at STAMP time (da#454).
+
+    ``year`` is a raw bio/candidate ``death_year_ah`` — not yet written onto a
+    canonical record or carried into the disambiguator's candidate pool.
+    ``generation`` is the accompanying raw ``generation`` value (a Parquet
+    string, possibly missing/out-of-domain), passed through
+    :func:`generation_from_value`.
+
+    Returns ``year`` unchanged when :func:`is_plausible_narrator_death_ah`
+    accepts it (or when ``year`` is ``None`` — a bio with no attested death);
+    otherwise ``None``.
+
+    da#446 added the *output*-side scrub — ``narrator_split._attested_death``
+    drops an implausible attested death from the neighbour-death evidence pool
+    right before it would poison a mention's ``neighbour_death ± MID_GAP``
+    estimate. da#454 is the *input*/source companion: the same late-collector
+    pollution (a d. ~700-780 AH commentator's death mislabelled onto an early
+    isnad node) should never be written onto ``narrators_canonical`` or a
+    disambiguation ``Candidate`` in the first place — every stamp site
+    (:mod:`~src.resolve.bio_promote`, :mod:`~src.resolve.disambiguate`) calls
+    this so a corrupt year cannot enter the pipeline upstream of the da#446
+    gate. Keeping ``narrator_split``'s own scrub in place is deliberate
+    defense-in-depth, not redundancy: a curated corpus produced before this fix
+    shipped can still carry pre-existing corrupt values.
+    """
+    if year is None:
+        return None
+    if not is_plausible_narrator_death_ah(year, generation_from_value(generation)):
+        return None
+    return year
 
 
 def clamp_death_ah(year: int) -> int:

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -1615,3 +1615,104 @@ def test_name_cut_row_is_refused_and_counted_class_b(
     assert not any(event == "bio_promote_gloss_tail_refusals_deferred" for event, kw in events), (
         "deferred-recall line fired with no gloss-tail refusals"
     )
+
+
+# --------------------------------------------------------------------------- #
+# Implausible attested death scrub at stamp time (da#454)
+# --------------------------------------------------------------------------- #
+def test_new_node_never_stamps_implausible_death_year(tmp_path: Path) -> None:
+    """da#454: a fresh bio-only node never gets an out-of-horizon death_year_ah.
+
+    A Companion (sahabi) whose bio attests d. 720 AH — the late-collector
+    pollution class (d. ~700-780 AH) welded onto an early node — must not be
+    written onto the freshly-minted canonical record at all.
+    """
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    name = "صحابي ملوث"
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:454a",
+                "source": "itqan",
+                "name_ar": name,
+                "name_ar_normalized": normalize_arabic(name),
+                "death_year_ah": 720,
+                "generation": "sahabi",
+            }
+        ],
+    )
+
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    rec = pq.read_table(path).to_pylist()[0]
+    assert rec["death_year_ah"] is None
+    # The rest of the bio still promotes normally — only the implausible date is scrubbed.
+    assert rec["generation"] == "sahabi"
+
+
+def test_backfill_never_stamps_implausible_death_year(tmp_path: Path) -> None:
+    """da#454: the backfill path is bound-checked too, not just node creation."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    name = "صحابي معروف"
+    norm = normalize_arabic(name)
+    attested_id = _write_attested_narrator(out_dir, norm, mentions=5)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:454b",
+                "source": "itqan",
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                "death_year_ah": 780,
+                "generation": "sahabi",
+                "trustworthiness": "thiqa",
+            }
+        ],
+    )
+
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    rec = next(r for r in pq.read_table(path).to_pylist() if r["canonical_id"] == attested_id)
+    assert rec["death_year_ah"] is None
+    # Unrelated backfilled fields are unaffected — only the implausible date is refused.
+    assert rec["trustworthiness"] == "thiqa"
+
+
+def test_plausible_death_year_still_backfills(tmp_path: Path) -> None:
+    """Regression: a generation-consistent attested death still back-fills as before."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    name = "تابعي معروف"
+    norm = normalize_arabic(name)
+    attested_id = _write_attested_narrator(out_dir, norm, mentions=5)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:454c",
+                "source": "itqan",
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                "death_year_ah": 160,
+                "generation": "tabii",
+            }
+        ],
+    )
+
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    rec = next(r for r in pq.read_table(path).to_pylist() if r["canonical_id"] == attested_id)
+    assert rec["death_year_ah"] == 160

--- a/tests/test_resolve/test_date_reconcile.py
+++ b/tests/test_resolve/test_date_reconcile.py
@@ -517,6 +517,77 @@ def test_stage_scrubs_implausible_attested_death_for_generation(tmp_path: Path) 
     assert rec["death_date_precision"] == "unknown"
 
 
+def test_stage_scrubs_implausible_death_over_preexisting_canonical_point(tmp_path: Path) -> None:
+    """The scrub must pierce the back-fill-protection guard (da#454, Jean-Claude must-fix).
+
+    Reproduces the idempotent-re-run / already-dated-canonical hole: the canonical
+    record ALREADY carries a legacy pre-fix corrupt death point (d. 720 AH welded
+    onto a Companion), exactly the state a persisted pre-fix
+    ``narrators_canonical.parquet`` carries into a ``resolve --from-step reconcile``
+    re-run. The scrub nulls the reconciled death dating, but the back-fill guard
+    (``value is None and rec.get(key) is not None -> continue``) would otherwise
+    keep the surviving 720 point while its bounds + precision are nulled — a
+    self-inconsistent half-scrub that ``_death_is_undated`` then reads as "dated",
+    skipping the ṭabaqa fallback. Assert the WHOLE death dating is cleared: point
+    AND both bounds AND precision, with no surviving point behind a nulled envelope.
+    """
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    curated = tmp_path / "curated"
+    curated.mkdir()
+
+    name = "صحابي ملوث"
+    norm = normalize_arabic(name)
+    cid = make_canonical_id(norm)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            _bio_date_row(
+                bio_id="itqan:454d",
+                source="itqan",
+                name_ar=name,
+                name_ar_normalized=norm,
+                death_year_ah=720,
+                death_year_ah_earliest=720,
+                death_year_ah_latest=720,
+                death_date_precision="exact",
+            )
+        ],
+    )
+    # Canonical record already dated with the pre-fix corrupt point — the guard
+    # branch (rec.get("death_year_ah") is not None) MUST fire for this to exercise
+    # the hole rather than the clean from-scratch path.
+    _write_canonical(
+        curated,
+        [
+            {
+                "canonical_id": cid,
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                "generation": "sahabi",
+                "death_year_ah": 720,
+                "death_year_ah_earliest": 720,
+                "death_year_ah_latest": 720,
+                "death_date_precision": "exact",
+                "source_corpus": "itqan",
+                "source_corpora": ["itqan"],
+                "mention_count": 0,
+            }
+        ],
+    )
+
+    out = reconcile_canonical_dates(staging, curated)
+    assert out is not None
+    rec = next(r for r in pq.read_table(out).to_pylist() if r["canonical_id"] == cid)
+
+    # No half-scrubbed survivor: point, both bounds, and precision all cleared.
+    assert rec["death_year_ah"] is None
+    assert rec["death_year_ah_earliest"] is None
+    assert rec["death_year_ah_latest"] is None
+    assert rec["death_date_precision"] == "unknown"
+
+
 def test_stage_scrubs_implausible_attested_death_absolute_envelope(tmp_path: Path) -> None:
     """No/unknown generation still bounds against the absolute plausibility envelope."""
     staging = tmp_path / "staging"

--- a/tests/test_resolve/test_date_reconcile.py
+++ b/tests/test_resolve/test_date_reconcile.py
@@ -453,3 +453,161 @@ def test_stage_no_canonical_is_noop(tmp_path: Path) -> None:
     curated = tmp_path / "curated"
     curated.mkdir()
     assert reconcile_canonical_dates(staging, curated) is None
+
+
+# --------------------------------------------------------------------------- #
+# Implausible attested death scrub (da#454) — the input-side companion to
+# narrator_split's da#446 output-side gate: a single UNCONTESTED late-collector
+# attested death (no competing source, so reconciliation sees no "conflict") must
+# still not survive reconciliation when it is impossible for the narrator's own
+# generation.
+# --------------------------------------------------------------------------- #
+def test_stage_scrubs_implausible_attested_death_for_generation(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    curated = tmp_path / "curated"
+    curated.mkdir()
+
+    # A Companion (sahabi, plausible window ~[11, 110] AH) whose single bio source
+    # attests a d. 720 AH death — the late-collector pollution class da#446/#454
+    # documents: a commentator's death mislabelled onto an early isnad node.
+    name = "صحابي وهمي"
+    norm = normalize_arabic(name)
+    cid = make_canonical_id(norm)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            _bio_date_row(
+                bio_id="itqan:454a",
+                source="itqan",
+                name_ar=name,
+                name_ar_normalized=norm,
+                death_year_ah=720,
+                death_year_ah_earliest=720,
+                death_year_ah_latest=720,
+                death_date_precision="exact",
+            )
+        ],
+    )
+    _write_canonical(
+        curated,
+        [
+            {
+                "canonical_id": cid,
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                "generation": "sahabi",
+                "source_corpus": "itqan",
+                "source_corpora": ["itqan"],
+                "mention_count": 0,
+            }
+        ],
+    )
+
+    out = reconcile_canonical_dates(staging, curated)
+    assert out is not None
+    rec = next(r for r in pq.read_table(out).to_pylist() if r["canonical_id"] == cid)
+
+    # The whole death dating is scrubbed back to undated — not just the point —
+    # so the ṭabaqa fallback (da#166) sees a genuinely undated narrator next.
+    assert rec["death_year_ah"] is None
+    assert rec["death_year_ah_earliest"] is None
+    assert rec["death_year_ah_latest"] is None
+    assert rec["death_date_precision"] == "unknown"
+
+
+def test_stage_scrubs_implausible_attested_death_absolute_envelope(tmp_path: Path) -> None:
+    """No/unknown generation still bounds against the absolute plausibility envelope."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    curated = tmp_path / "curated"
+    curated.mkdir()
+
+    name = "مجهول الطبقة"
+    norm = normalize_arabic(name)
+    cid = make_canonical_id(norm)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            _bio_date_row(
+                bio_id="itqan:454b",
+                source="itqan",
+                name_ar=name,
+                name_ar_normalized=norm,
+                death_year_ah=805,
+                death_year_ah_earliest=805,
+                death_year_ah_latest=805,
+                death_date_precision="exact",
+            )
+        ],
+    )
+    _write_canonical(
+        curated,
+        [
+            {
+                "canonical_id": cid,
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                # generation left unset — the absolute envelope still applies.
+                "source_corpus": "itqan",
+                "source_corpora": ["itqan"],
+                "mention_count": 0,
+            }
+        ],
+    )
+
+    out = reconcile_canonical_dates(staging, curated)
+    assert out is not None
+    rec = next(r for r in pq.read_table(out).to_pylist() if r["canonical_id"] == cid)
+    assert rec["death_year_ah"] is None
+    assert rec["death_date_precision"] == "unknown"
+
+
+def test_stage_keeps_plausible_attested_death_for_generation(tmp_path: Path) -> None:
+    """Regression: a plausible generation-consistent death is reconciled as before."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    curated = tmp_path / "curated"
+    curated.mkdir()
+
+    name = "تابعي حقيقي"
+    norm = normalize_arabic(name)
+    cid = make_canonical_id(norm)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            _bio_date_row(
+                bio_id="itqan:454c",
+                source="itqan",
+                name_ar=name,
+                name_ar_normalized=norm,
+                death_year_ah=110,
+                death_year_ah_earliest=110,
+                death_year_ah_latest=110,
+                death_date_precision="exact",
+            )
+        ],
+    )
+    _write_canonical(
+        curated,
+        [
+            {
+                "canonical_id": cid,
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                "generation": "tabii",
+                "source_corpus": "itqan",
+                "source_corpora": ["itqan"],
+                "mention_count": 0,
+            }
+        ],
+    )
+
+    out = reconcile_canonical_dates(staging, curated)
+    assert out is not None
+    rec = next(r for r in pq.read_table(out).to_pylist() if r["canonical_id"] == cid)
+    assert rec["death_year_ah"] == 110
+    assert rec["death_date_precision"] == "exact"

--- a/tests/test_resolve/test_disambiguate.py
+++ b/tests/test_resolve/test_disambiguate.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from src.parse.identity import CANONICAL_NAMESPACE
+from src.parse.schemas import NARRATOR_BIO_SCHEMA
 from src.resolve.disambiguate import (
     Candidate,
     ChainContext,
@@ -19,6 +23,7 @@ from src.resolve.disambiguate import (
     _fuzzy_match,
     _fuzzy_match_blocked,
     _geographic_filter,
+    _load_candidates,
     _make_canonical_id,
     _temporal_filter,
     _upsert_canonical,
@@ -451,3 +456,49 @@ class TestUpsertAliasDeixisScrub:
         aliases = canonical_map[cid]["aliases"]
         assert aliases == ["عاءشه ابنه ابي بكر"]
         assert "خالته" not in aliases  # deixis dropped
+
+
+def _write_bio_row(staging: Path, **row: object) -> None:
+    """Write a single-row narrators_bio_*.parquet, schema defaults filled in."""
+    base = {f.name: None for f in NARRATOR_BIO_SCHEMA}
+    base.update(row)
+    arrays = {f.name: [base[f.name]] for f in NARRATOR_BIO_SCHEMA}
+    table = pa.table(arrays, schema=NARRATOR_BIO_SCHEMA)
+    pq.write_table(table, staging / "narrators_bio_itqan.parquet")
+
+
+class TestLoadCandidatesDeathYearScrub:
+    """da#454: an implausible attested death year must never enter the candidate
+    pool ``_load_candidates`` builds — it feeds ``_temporal_filter`` and
+    ``_bio_corroborated`` (and, via ``death_year_index``, narrator_split's
+    neighbour-death evidence), so a corrupt year here propagates into identity
+    decisions, not just display."""
+
+    def test_implausible_death_year_is_scrubbed(self, tmp_path: Path) -> None:
+        _write_bio_row(
+            tmp_path,
+            bio_id="itqan:454",
+            source="itqan",
+            name_ar="صحابي ملوث",
+            name_ar_normalized="صحابي ملوث",
+            death_year_ah=720,  # impossible for a Companion (sahabi)
+            generation="sahabi",
+        )
+        candidates = _load_candidates(tmp_path)
+        assert len(candidates) == 1
+        assert candidates[0].death_year_ah is None
+        assert candidates[0].generation == "sahabi"
+
+    def test_plausible_death_year_is_kept(self, tmp_path: Path) -> None:
+        _write_bio_row(
+            tmp_path,
+            bio_id="itqan:455",
+            source="itqan",
+            name_ar="تابعي حقيقي",
+            name_ar_normalized="تابعي حقيقي",
+            death_year_ah=150,
+            generation="tabii",
+        )
+        candidates = _load_candidates(tmp_path)
+        assert len(candidates) == 1
+        assert candidates[0].death_year_ah == 150

--- a/tests/test_resolve/test_tabaqa_dates.py
+++ b/tests/test_resolve/test_tabaqa_dates.py
@@ -29,6 +29,7 @@ from src.resolve.tabaqa_dates import (
     estimate_death_window,
     generation_from_value,
     is_plausible_narrator_death_ah,
+    plausible_attested_death_year,
 )
 from src.utils.hijri import ah_year_to_ce_range
 
@@ -151,6 +152,34 @@ def test_clamp_death_ah_bounds_axis_estimates() -> None:
     assert clamp_death_ah(805) == NARRATOR_DEATH_MAX_AH == 450
     assert clamp_death_ah(497) == 450  # student-of-latest-plausible boundary overflow
     assert clamp_death_ah(256) == 256
+
+
+# --------------------------------------------------------------------------- #
+# da#454 — plausible_attested_death_year, the stamp-time companion to the
+# da#446 output-side scrub: bio_promote/disambiguate call this so an implausible
+# attested year never enters narrators_canonical or the candidate pool.
+# --------------------------------------------------------------------------- #
+def test_plausible_attested_death_year_passes_through_valid_year() -> None:
+    assert plausible_attested_death_year(256) == 256
+    assert plausible_attested_death_year(160, "sahabi") == 160
+
+
+def test_plausible_attested_death_year_none_is_none() -> None:
+    # A bio with no attested death stays None — never fabricated.
+    assert plausible_attested_death_year(None) is None
+    assert plausible_attested_death_year(None, "sahabi") is None
+
+
+def test_plausible_attested_death_year_scrubs_absolute_envelope_violation() -> None:
+    assert plausible_attested_death_year(805) is None
+    assert plausible_attested_death_year(754, "unknown") is None
+
+
+def test_plausible_attested_death_year_scrubs_generation_mismatch() -> None:
+    # 300 AH sits inside the loose absolute envelope but is impossible for a
+    # Companion (sahabi) — matches is_plausible_narrator_death_ah's own gate.
+    assert plausible_attested_death_year(300, "sahabi") is None
+    assert plausible_attested_death_year(300, "later") == 300
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Closes #454.

Narrator nodes were carrying impossibly-late attested `death_year_ah`
(~500-740 AH) — companion/successor-era narrators stamped with a late-
collector/commentator's death year. da#452 (Wave 25) added the **output**-side
gate (`narrator_split._attested_death`) that keeps the split's neighbour-death
evidence clean regardless, but the corrupt values were still landing on
`narrators_canonical.parquet` in the first place, from three independent
producers that each wrote a bio's raw `death_year_ah` with no plausibility
check:

- `disambiguate._load_candidates` — feeds `_temporal_filter` /
  `_bio_corroborated`, so a bad year could sway a match/corroboration decision
  and (via `death_year_index`) narrator_split's own neighbour-death evidence.
- `bio_promote`'s new-node and backfill paths.
- `date_reconcile.reconcile_canonical_dates` — the actual authoritative
  producer of the final canonical `death_year_ah`/bounds/precision; it
  re-derives these straight from the raw per-source bio rows independent of
  what `bio_promote`/`disambiguate` wrote, and would silently re-introduce a
  value the earlier stages had scrubbed.

Also: `fuzzy_cluster`'s ±2-year death-year merge guard runs *before*
`date_reconcile` in the pipeline (`RESOLVE_STEP_ORDER`) and has no plausibility
gate of its own, so an unscrubbed value from `bio_promote`/`disambiguate` could
wrongly block or allow a merge there too.

## Fix

Added `tabaqa_dates.plausible_attested_death_year` — a thin, reused wrapper
around the existing `is_plausible_narrator_death_ah` + `generation_from_value`
(the da#446 envelope) — and call it at every stamp site above:

- `disambiguate._load_candidates`: the `Candidate.death_year_ah` loaded from a
  bio row is bound-checked against the row's own `generation`.
- `bio_promote`: both the new-canonical-node path and the existing-record
  backfill path use the bound-checked value.
- `date_reconcile.reconcile_canonical_dates`: after per-source reconciliation,
  the reconciled death *point* is bound-checked against the record's
  `generation`; when implausible, the **whole** death dating (point + both
  bounds + precision) is scrubbed back to undated — not just the point — so
  the narrator reads as genuinely undated for the ṭabaqa fallback stage that
  runs immediately after, instead of carrying a null point next to stale
  corrupt bounds/precision.

`narrator_split._attested_death` (da#446) is left unchanged — it stays as
deliberate defense-in-depth for a pre-existing curated corpus that predates
this fix, per the issue's own framing (this closes the *input*-side gap; the
magnitude is a re-run measurement, not a live-corpus hotfix).

## Test plan

- [x] New unit tests for `plausible_attested_death_year` (valid year, `None`
      passthrough, absolute-envelope violation, generation-mismatch scrub) in
      `tests/test_resolve/test_tabaqa_dates.py`.
- [x] New tests for `bio_promote`'s new-node and backfill scrub paths (plus a
      plausible-year regression) in `tests/test_resolve/test_bio_promote.py`.
- [x] New tests for `disambiguate._load_candidates`' scrub in
      `tests/test_resolve/test_disambiguate.py`.
- [x] New end-to-end tests for `date_reconcile.reconcile_canonical_dates`'s
      scrub — generation-aware, absolute-envelope, and a plausible-year
      regression — in `tests/test_resolve/test_date_reconcile.py`.
- [x] Full existing suite green: `uv run pytest tests/ -m "not integration"`
      (2527 passed, 10 skipped, 58 deselected — integration tests need Docker).
- [x] `pre-commit run --all-files` and `--hook-stage push` (ruff-format,
      ruff-lint, gitleaks, actionlint, cspell, mypy-strict, pytest) all green.

Reviewers: Jean-Claude Habimana (merge-gate) + Ivana Horvat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z