### PR TITLE
Phase 9 Wave 27 → main (data-acquisition)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -166,3 +166,7 @@ tatweel
 gradings
 textless
 unsplit
+
+# --- da#427 alif-maqsura fold A/B report (docs/reports/alif-maqsura-fold-ab-da427.md) ---
+maqṣūra
+ʿAlī

--- a/docs/reports/alif-maqsura-fold-ab-da427.md
+++ b/docs/reports/alif-maqsura-fold-ab-da427.md
@@ -1,0 +1,84 @@
+# Alif-maqṣūra ى→ي fold: full-corpus A/B (da#427 AC#2 artifact)
+
+> Deferred follow-up from da#427 (PR #476), recorded here per da#477 so the AC#2
+> acceptance box has a durable artifact instead of living only in the #476 PR review.
+> Base-vs-head bidirectional A/B (`main` vs. the da#427 `normalize_arabic` +
+> `name_quality` change), on the `curated.pre-rerun-928` snapshot
+> (`data/curated.pre-rerun-928-20260711T203626Z`): 3,249,721 mentions / 129,234
+> canonical narrators. Per-row unweighted AND mention-weighted, mc=0 bio-promoted
+> rows included (the da#424 lesson — a corruption/deletion check that skips the
+> zero-mention-count tail misses the bio-only path, da#99/da#110).
+
+## TL;DR
+
+| Direction | Result |
+|---|---|
+| NEWLY-DELETED real narrators | **0** |
+| NEWLY-KEPT junk (the `على` carve-out question) | **0** |
+| Canonical-id re-key | 59 names / 60 mentions — all consistency-improving, **0** wrong merges |
+
+## 1. Deletion direction (kept→dropped)
+
+47 distinct `name_raw` / 81 mentions flip kept→dropped between base and head. Every
+one is a maqṣūra-spelled variant whose yeh-twin (the ي-spelled form of the same
+string) was **already** dropped on base — e.g. `ابى` → already-dropped `ابي`,
+`حدثنى شعبه` → already-dropped `حدثني شعبه`. The head is not deleting anything base
+kept; it is folding a maqṣūra spelling onto a drop decision base already made under
+the ي spelling, so the drop-gate becomes spelling-consistent rather than
+spelling-dependent.
+
+32 canonical nodes go clean→un-nameable. All 32 are junk residue on inspection: no
+death year, no `name_en`, no `external_id`. The largest (`mention_count` 43) is
+`أَبَى`, a bare relational fragment ("his father" — the da#247 relational-pronoun
+pollution class, `.claude/memory/project_relational_pollution_scrub_equiv.md`), not
+a narrator.
+
+## 2. Recall direction (dropped→kept) — the `على` carve-out question
+
+da#427 removed `على` from `_MATN_PARTICLES` because the fold makes the preposition
+`على` ("on") and the name `علي` (ʿAlī) homographic (both fold to `علي`); keeping
+`على` in the particle set would drop a bare `علي` narrator span via the all-particle
+rule (2c), deleting one of the most-attested transmitters. The tradeoff, per the
+da#427 PR, is a recall loss in the safe direction: `على`-preposition matn residue
+that base's particle-based drop-gate used to catch now survives.
+
+**On this snapshot, that feared recall loss did not materialize: newly-kept junk =
+0.** Removing `على` from `_MATN_PARTICLES` produced no new surviving matn fragment
+here — no row exists in this corpus where a bare `على` span, undetected as a
+particle, was the *only* thing keeping an otherwise-junk span alive.
+
+## 3. Canonical-id re-key (consistency direction)
+
+59 names / 60 mentions re-key to a different canonical id between base and head, all
+consistency-improving. The dominant shape is `يعنى`-gloss stripping re-attaching a
+mention to its clean real-narrator twin, e.g. `يحيى يعنى ابن سعيد` →
+`يحيي ابن سعيد`. **Zero** wrong cross-narrator merges were found in this set. The
+`يحيى`≡`يحيي` corpus-level merge itself is pre-existing (da#434
+`_fold_residual_noise`), already folded at the mint surface on base; this A/B only
+measures the *additional* re-keys the da#427 fold introduces on top of that.
+
+## Disposition
+
+- **AC#2 (da#427) is satisfied.** This is the bidirectional unweighted full-corpus
+  A/B (mc=0 rows visible) the acceptance criterion asked for; it lives here as the
+  durable artifact rather than only in the #476 review thread.
+- **The `على` bare-particle carve-out (da#477 task 2) is NOT built.** The measured
+  newly-kept junk is 0 on this snapshot, so the carve-out this task considered
+  (detect `على` as a matn preposition while exempting a bare `علي` narrator span)
+  would have no effect here — per da#477, it is not built speculatively. This
+  finding is **corpus-gated, not closed**: the next production re-run is a different,
+  unmeasured corpus, and if a future A/B on that corpus shows `على` matn residue
+  inflating the canonical node of ʿAlī (mention-count inflation via the `على`≡`علي`
+  id-level equivalence), re-open the carve-out question against that measurement.
+
+## Method notes
+
+- Snapshot is a point-in-time on-disk read (`data/curated.pre-rerun-928-*`); a live
+  resolve run owns `data/`, so this reflects that snapshot only, not necessarily the
+  current tree.
+- `normalize_arabic` / `name_quality` behaviour is taken from source
+  (`src/utils/arabic.py`, `src/parse/name_quality.py`), not inferred.
+- See `tests/test_parse/test_name_quality.py::TestAlifMaqsuraFold` and
+  `TestRecoveryIsNoWorseThanMain` for the fixture-level unit pins this full-corpus
+  measurement complements (unit fixtures are the accumulated regression shapes;
+  this report is the one-time full-corpus sweep).

--- a/src/parse/name_quality.py
+++ b/src/parse/name_quality.py
@@ -847,6 +847,13 @@ _MATN_OPENERS = frozenset(
 # SAFE direction (leaves residue in; never deletes a name), and the alternative
 # deletes ʿAlī. The set-level invariant test pins that no name (``علي`` included)
 # folds onto a member of this or any other droppable set.
+#
+# da#477 corpus A/B (curated.pre-rerun-928, see
+# docs/reports/alif-maqsura-fold-ab-da427.md): the feared recall loss did not
+# materialize on that snapshot — newly-kept junk = 0, so a carve-out that detects
+# ``على`` as a matn preposition while exempting a bare ``علي`` narrator span was
+# NOT built. This is corpus-gated, not closed: re-check against the next production
+# re-run before ruling the carve-out out permanently.
 _MATN_PARTICLES = frozenset(
     {
         # prepositions ("على" excluded — see header: folds onto the name علي)

--- a/src/resolve/_death_year_bands.py
+++ b/src/resolve/_death_year_bands.py
@@ -1,0 +1,33 @@
+"""Shared resolve-stage death-year sanity bands (da#464).
+
+``fuzzy_cluster`` (da#380) and ``narrator_unify`` (da#431) each veto a
+merge/unify decision on a death-year conflict, weighed at two bands:
+
+* :data:`DEATH_YEAR_TOLERANCE` — the tight band. Two *trusted* years
+  (corroborated, or an untagged/legacy record) disagreeing by more than this
+  many AH years block the merge outright; one source rounding a year by a
+  year or two is fine, a whole generation apart is not.
+* :data:`GROSS_DEATH_SPREAD` — the loose band. A much wider sanity check that
+  still catches a distinct namesake even when neither year carries full
+  trust — an ``uncorroborated`` fuzzy-bio year in ``fuzzy_cluster``, or a
+  curated unify-group member in ``narrator_unify``.
+
+Both stages must weigh an uncorroborated/noisy year the same way — that
+cross-stage invariant used to be two independent literals a code comment
+merely *promised* stayed equal (one retune away from silent drift). Hoisting
+both constants here makes the invariant structural: there is only one place
+to change either band, and both stages import it.
+"""
+
+from __future__ import annotations
+
+# Two *trusted* death years (corroborated, or untagged/legacy) disagreeing by
+# more than this many AH years block a merge/unify outright.
+DEATH_YEAR_TOLERANCE = 2
+
+# Loose sanity band (in AH years) applied when at least one death year is not
+# fully trusted (fuzzy_cluster's `uncorroborated` tag; narrator_unify's
+# curated-but-noisy group members). Wide enough to pass a genuine
+# generation-default noise gap, tight enough to still refuse a
+# cross-generation namesake.
+GROSS_DEATH_SPREAD = 50

--- a/src/resolve/bio_promote.py
+++ b/src/resolve/bio_promote.py
@@ -44,6 +44,7 @@ from src.resolve.sect_affiliation import (
     normalize_corpus,
     primary_corpus,
 )
+from src.resolve.tabaqa_dates import plausible_attested_death_year
 from src.utils.arabic import normalize_arabic
 from src.utils.logging import get_logger
 
@@ -52,10 +53,11 @@ logger = get_logger(__name__)
 __all__ = ["promote_bios_to_canonical"]
 
 # Scalar bio fields back-filled onto an existing canonical record when missing.
+# ``death_year_ah`` is handled separately (da#454, plausibility-bound at stamp
+# time) rather than through this generic pass-through.
 _BACKFILL_FIELDS = (
     "name_en",
     "birth_year_ah",
-    "death_year_ah",
     "generation",
     "gender",
     "trustworthiness",
@@ -308,6 +310,14 @@ def promote_bios_to_canonical(
 
             bio_id = safe_str(row.get("bio_id"))
             cid = make_canonical_id(norm)
+            # da#454: bound the bio's attested death year against the isnad-narrator
+            # plausibility envelope *before* it can be written anywhere — a raw
+            # death_year_ah outside the envelope (the d. ~700-780 AH late-collector
+            # pollution) becomes None rather than landing on a fresh node or
+            # back-filling an existing one.
+            death_year = plausible_attested_death_year(
+                row.get("death_year_ah"), row.get("generation")
+            )
 
             # When `cleaner_removed_content` is True the cleaner removed name-span
             # material beyond its affix normalizations. That covers TWO classes the
@@ -409,7 +419,7 @@ def promote_bios_to_canonical(
                     "name_ar_normalized": norm,
                     "aliases": [],
                     "birth_year_ah": row.get("birth_year_ah"),
-                    "death_year_ah": row.get("death_year_ah"),
+                    "death_year_ah": death_year,
                     "generation": safe_str(row.get("generation")),
                     "gender": safe_str(row.get("gender")),
                     "trustworthiness": safe_str(row.get("trustworthiness")),
@@ -441,6 +451,11 @@ def promote_bios_to_canonical(
                 for field_name in _BACKFILL_FIELDS:
                     if rec.get(field_name) in (None, "") and row.get(field_name) not in (None, ""):
                         rec[field_name] = row.get(field_name)
+                # death_year_ah backfills from the plausibility-bound value (da#454),
+                # never the raw row — an implausible attested year must not sneak
+                # onto an existing (even zero-mention) record either.
+                if rec.get("death_year_ah") in (None, "") and death_year is not None:
+                    rec["death_year_ah"] = death_year
             promoted += 1
             promoted_cids.add(cid)
 

--- a/src/resolve/date_reconcile.py
+++ b/src/resolve/date_reconcile.py
@@ -86,6 +86,7 @@ from src.parse.narrator_dates import (
 )
 from src.resolve._run_record import write_canonical
 from src.resolve.schemas import NARRATORS_CANONICAL_SCHEMA
+from src.resolve.tabaqa_dates import generation_from_value, is_plausible_narrator_death_ah
 from src.utils.arabic import normalize_arabic
 from src.utils.hijri import ah_year_to_ce_range
 from src.utils.logging import get_logger
@@ -510,6 +511,25 @@ def reconcile_canonical_dates(
         obs_slot = obs_by_cid.get(cid) if cid else None
         if obs_slot is not None:
             merged = reconcile_narrator(obs_slot["birth"], obs_slot["death"])
+            # da#454: a reconciled DEATH point outside the isnad-narrator plausibility
+            # envelope (the d. ~700-780 AH late-collector/commentator pollution welded
+            # onto an early node — see tabaqa_dates.is_plausible_narrator_death_ah) must
+            # never be written onto the canonical record. Reconciliation folds per-
+            # source OBSERVATIONS (agreement/conflict/noise-gap) but has no concept of
+            # "impossible for THIS narrator's generation" — a single uncontested corrupt
+            # source sails straight through as a "conflict-free" EXACT point. Scrub the
+            # WHOLE death dating (point + both bounds + precision), not just the point:
+            # leaving corrupt bounds/EXACT precision behind a null point would read as
+            # "dated" to tabaqa_dates' undated-check and skip the ṭabaqa fallback that
+            # runs next, stranding the narrator on a half-scrubbed, still-wrong dating.
+            death_point = merged.get("death_year_ah")
+            if death_point is not None and not is_plausible_narrator_death_ah(
+                death_point, generation_from_value(rec.get("generation"))
+            ):
+                merged["death_year_ah"] = None
+                merged["death_year_ah_earliest"] = None
+                merged["death_year_ah_latest"] = None
+                merged["death_date_precision"] = DatePrecision.UNKNOWN.value
             for key, value in merged.items():
                 # Never null out a point a prior producer back-filled (defensive —
                 # a contributing bio would itself have surfaced that point here).

--- a/src/resolve/date_reconcile.py
+++ b/src/resolve/date_reconcile.py
@@ -523,6 +523,10 @@ def reconcile_canonical_dates(
             # "dated" to tabaqa_dates' undated-check and skip the ṭabaqa fallback that
             # runs next, stranding the narrator on a half-scrubbed, still-wrong dating.
             death_point = merged.get("death_year_ah")
+            # Death columns the da#454 scrub cleared with EXPLICIT intent, so the
+            # back-fill-protection loop below honours the clear instead of swallowing
+            # it (empty on the normal path — populated only when the scrub fires).
+            scrub_cleared: set[str] = set()
             if death_point is not None and not is_plausible_narrator_death_ah(
                 death_point, generation_from_value(rec.get("generation"))
             ):
@@ -530,10 +534,29 @@ def reconcile_canonical_dates(
                 merged["death_year_ah_earliest"] = None
                 merged["death_year_ah_latest"] = None
                 merged["death_date_precision"] = DatePrecision.UNKNOWN.value
+                scrub_cleared = {
+                    "death_year_ah",
+                    "death_year_ah_earliest",
+                    "death_year_ah_latest",
+                }
             for key, value in merged.items():
                 # Never null out a point a prior producer back-filled (defensive —
-                # a contributing bio would itself have surfaced that point here).
-                if key.endswith("_year_ah") and value is None and rec.get(key) is not None:
+                # a contributing bio would itself have surfaced that point here) —
+                # UNLESS the da#454 scrub above cleared it with explicit intent. When
+                # the canonical record ALREADY holds a death point (a persisted
+                # pre-fix corrupt point on an idempotent `resolve --from-step
+                # reconcile` re-run, or a bio_promote-stamped point reconciliation
+                # recomputes as implausible from the fuller unscrubbed bio set), the
+                # guard would otherwise keep that point while its bounds + precision
+                # are nulled — the self-inconsistent half-scrub this scrub exists to
+                # prevent, which then reads as "dated" to tabaqa_dates' undated-check
+                # and skips the ṭabaqa fallback (da#454).
+                if (
+                    key.endswith("_year_ah")
+                    and value is None
+                    and rec.get(key) is not None
+                    and key not in scrub_cleared
+                ):
                     continue
                 rec[key] = value
             reconciled += 1

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -51,6 +51,7 @@ from src.resolve.sect_affiliation import (
     normalize_corpus,
     primary_corpus,
 )
+from src.resolve.tabaqa_dates import plausible_attested_death_year
 from src.utils.arabic import canonical_surface
 from src.utils.logging import get_logger
 
@@ -473,6 +474,7 @@ def _load_candidates(staging_dir: Path) -> list[Candidate]:
             # key does, or Stage 1 can never exact-match across an inflection (and the
             # da#371 provenance drift leaves un-normalized bio keys nothing can match).
             name_ar_norm = canonical_surface(name_ar_norm) if name_ar_norm else None
+            generation = safe_str(table.column("generation")[i].as_py())
 
             candidates.append(
                 Candidate(
@@ -483,10 +485,16 @@ def _load_candidates(staging_dir: Path) -> list[Candidate]:
                     kunya=safe_str(table.column("kunya")[i].as_py()),
                     nisba=safe_str(table.column("nisba")[i].as_py()),
                     birth_year_ah=table.column("birth_year_ah")[i].as_py(),
-                    death_year_ah=table.column("death_year_ah")[i].as_py(),
+                    # da#454: an implausible attested death (the d. ~700-780 AH
+                    # late-collector pollution) must not enter the candidate pool —
+                    # it feeds _temporal_filter/_bio_corroborated below and, via
+                    # death_year_index, narrator_split's neighbour-death evidence.
+                    death_year_ah=plausible_attested_death_year(
+                        table.column("death_year_ah")[i].as_py(), generation
+                    ),
                     birth_location=safe_str(table.column("birth_location")[i].as_py()),
                     death_location=safe_str(table.column("death_location")[i].as_py()),
-                    generation=safe_str(table.column("generation")[i].as_py()),
+                    generation=generation,
                     gender=safe_str(table.column("gender")[i].as_py()),
                     trustworthiness=safe_str(table.column("trustworthiness")[i].as_py()),
                     external_id=safe_str(table.column("external_id")[i].as_py()),

--- a/src/resolve/fuzzy_cluster.py
+++ b/src/resolve/fuzzy_cluster.py
@@ -92,6 +92,7 @@ from src.resolve._checkpoint import (
     resolve_cadence,
     save_checkpoint,
 )
+from src.resolve._death_year_bands import DEATH_YEAR_TOLERANCE, GROSS_DEATH_SPREAD
 from src.resolve._run_record import write_canonical
 from src.resolve.attestation import derive_attestation
 from src.resolve.schemas import NARRATOR_MENTIONS_RESOLVED_SCHEMA, NARRATORS_CANONICAL_SCHEMA
@@ -114,7 +115,8 @@ _CLUSTER_RATIO_THRESHOLD = 90.0
 # When both records carry a death year, a disagreement beyond this many AH years
 # blocks the merge regardless of name score (two narrators a generation+ apart
 # are not the same person). One source rounding a death year by a year is fine.
-_DEATH_YEAR_TOLERANCE = 2
+# Shared with ``narrator_unify`` (da#464) — see ``_death_year_bands`` for why.
+_DEATH_YEAR_TOLERANCE = DEATH_YEAR_TOLERANCE
 
 # Discounted band for a death year tagged ``uncorroborated`` (da#380). A weak
 # Stage-2 fuzzy bio match persists its year on the record but marks it
@@ -122,9 +124,11 @@ _DEATH_YEAR_TOLERANCE = 2
 # narrators (disambiguate.py, da#356). An OCR-corrupt uncorroborated year off by
 # a handful of AH years must therefore NOT veto a merge at the tight
 # ``_DEATH_YEAR_TOLERANCE``; only a gross, generations-apart spread still blocks.
-# Mirrors ``narrator_unify._gross_death_spread``'s da#431 sanity band (=50) so the
-# resolve stage weighs an uncorroborated year the same way everywhere.
-_UNCORROBORATED_DEATH_SPREAD = 50
+# Imported from ``_death_year_bands`` (da#464) — the same value
+# ``narrator_unify._gross_death_spread``'s da#431 sanity band imports, so the
+# resolve stage weighs an uncorroborated year the same way everywhere by
+# construction, not by a comment promising two literals stay equal.
+_UNCORROBORATED_DEATH_SPREAD = GROSS_DEATH_SPREAD
 
 # Minimum number of *shared* significant (non-connector) name tokens required to
 # merge. token_set_ratio scores a bare given name as a perfect (100) subset of

--- a/src/resolve/narrator_unify.py
+++ b/src/resolve/narrator_unify.py
@@ -65,9 +65,10 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import yaml
 
+from src.resolve._death_year_bands import DEATH_YEAR_TOLERANCE as _DEATH_YEAR_TOLERANCE
+from src.resolve._death_year_bands import GROSS_DEATH_SPREAD
 from src.resolve._run_record import write_canonical
 from src.resolve.fuzzy_cluster import (
-    _DEATH_YEAR_TOLERANCE,
     _genders_conflict,
     _merge_cluster,
     _remap_mention_canonical_ids,
@@ -90,7 +91,10 @@ _SEED_PATH = Path(__file__).with_name("narrator_unify.yaml")
 # but wide gaps (> this) mark a distinct namesake, not one person. Chosen so a genuine
 # generation-default noise gap (Anas: bare d.60 vs qualified d.91 = 31) passes while a
 # cross-generation namesake (bare Shaqīq d.200 vs Abū Wāʾil d.82 = 118) is refused.
-_UNIFY_MAX_DEATH_SPREAD = 50
+# Imported from ``_death_year_bands`` (da#464) — the same value
+# ``fuzzy_cluster._UNCORROBORATED_DEATH_SPREAD`` imports, so a retune of either
+# stage's band can no longer drift from the other.
+_UNIFY_MAX_DEATH_SPREAD = GROSS_DEATH_SPREAD
 
 __all__ = [
     "UnifyGroup",

--- a/src/resolve/tabaqa_dates.py
+++ b/src/resolve/tabaqa_dates.py
@@ -74,6 +74,7 @@ __all__ = [
     "estimate_death_window",
     "generation_from_value",
     "is_plausible_narrator_death_ah",
+    "plausible_attested_death_year",
 ]
 
 # Generation (ṭabaqa) → approximate Hijri (AH) death-year window.
@@ -159,6 +160,39 @@ def is_plausible_narrator_death_ah(
         if not (lo - DEATH_PLAUSIBILITY_MARGIN_AH <= year <= hi + DEATH_PLAUSIBILITY_MARGIN_AH):
             return False
     return True
+
+
+def plausible_attested_death_year(year: int | None, generation: object = None) -> int | None:
+    """Bound-check a source-attested death year at STAMP time (da#454).
+
+    ``year`` is a raw bio/candidate ``death_year_ah`` — not yet written onto a
+    canonical record or carried into the disambiguator's candidate pool.
+    ``generation`` is the accompanying raw ``generation`` value (a Parquet
+    string, possibly missing/out-of-domain), passed through
+    :func:`generation_from_value`.
+
+    Returns ``year`` unchanged when :func:`is_plausible_narrator_death_ah`
+    accepts it (or when ``year`` is ``None`` — a bio with no attested death);
+    otherwise ``None``.
+
+    da#446 added the *output*-side scrub — ``narrator_split._attested_death``
+    drops an implausible attested death from the neighbour-death evidence pool
+    right before it would poison a mention's ``neighbour_death ± MID_GAP``
+    estimate. da#454 is the *input*/source companion: the same late-collector
+    pollution (a d. ~700-780 AH commentator's death mislabelled onto an early
+    isnad node) should never be written onto ``narrators_canonical`` or a
+    disambiguation ``Candidate`` in the first place — every stamp site
+    (:mod:`~src.resolve.bio_promote`, :mod:`~src.resolve.disambiguate`) calls
+    this so a corrupt year cannot enter the pipeline upstream of the da#446
+    gate. Keeping ``narrator_split``'s own scrub in place is deliberate
+    defense-in-depth, not redundancy: a curated corpus produced before this fix
+    shipped can still carry pre-existing corrupt values.
+    """
+    if year is None:
+        return None
+    if not is_plausible_narrator_death_ah(year, generation_from_value(generation)):
+        return None
+    return year
 
 
 def clamp_death_ah(year: int) -> int:

--- a/tests/test_parse/test_name_quality.py
+++ b/tests/test_parse/test_name_quality.py
@@ -1804,9 +1804,11 @@ class TestRecoveryIsNoWorseThanMain:
     only ever turns a drop or a polluted whole span into a cleaner name.
 
     The full-corpus, bidirectional, unweighted A/B (row-level, mention_count=0 slice
-    visible) is DATA-GATED — no raw corpus ships in the repo (``data/raw`` is empty)
-    — and is deferred to a re-run, per the issue. These fixtures are the verbatim
-    corpus rows the series accumulated, standing in for the deletion-direction sweep.
+    visible) ran against the ``curated.pre-rerun-928`` snapshot (da#477): NEWLY-DELETED
+    real narrators = 0, matching the fixtures below. See
+    ``docs/reports/alif-maqsura-fold-ab-da427.md`` for the full measurement (deletion,
+    recall, and re-key directions). These fixtures remain the fast, no-data-required
+    unit pins for the deletion direction the #423/#314 series accumulated.
     """
 
     @pytest.mark.parametrize(

--- a/tests/test_resolve/test_bio_promote.py
+++ b/tests/test_resolve/test_bio_promote.py
@@ -1615,3 +1615,104 @@ def test_name_cut_row_is_refused_and_counted_class_b(
     assert not any(event == "bio_promote_gloss_tail_refusals_deferred" for event, kw in events), (
         "deferred-recall line fired with no gloss-tail refusals"
     )
+
+
+# --------------------------------------------------------------------------- #
+# Implausible attested death scrub at stamp time (da#454)
+# --------------------------------------------------------------------------- #
+def test_new_node_never_stamps_implausible_death_year(tmp_path: Path) -> None:
+    """da#454: a fresh bio-only node never gets an out-of-horizon death_year_ah.
+
+    A Companion (sahabi) whose bio attests d. 720 AH — the late-collector
+    pollution class (d. ~700-780 AH) welded onto an early node — must not be
+    written onto the freshly-minted canonical record at all.
+    """
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    name = "صحابي ملوث"
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:454a",
+                "source": "itqan",
+                "name_ar": name,
+                "name_ar_normalized": normalize_arabic(name),
+                "death_year_ah": 720,
+                "generation": "sahabi",
+            }
+        ],
+    )
+
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    rec = pq.read_table(path).to_pylist()[0]
+    assert rec["death_year_ah"] is None
+    # The rest of the bio still promotes normally — only the implausible date is scrubbed.
+    assert rec["generation"] == "sahabi"
+
+
+def test_backfill_never_stamps_implausible_death_year(tmp_path: Path) -> None:
+    """da#454: the backfill path is bound-checked too, not just node creation."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    name = "صحابي معروف"
+    norm = normalize_arabic(name)
+    attested_id = _write_attested_narrator(out_dir, norm, mentions=5)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:454b",
+                "source": "itqan",
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                "death_year_ah": 780,
+                "generation": "sahabi",
+                "trustworthiness": "thiqa",
+            }
+        ],
+    )
+
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    rec = next(r for r in pq.read_table(path).to_pylist() if r["canonical_id"] == attested_id)
+    assert rec["death_year_ah"] is None
+    # Unrelated backfilled fields are unaffected — only the implausible date is refused.
+    assert rec["trustworthiness"] == "thiqa"
+
+
+def test_plausible_death_year_still_backfills(tmp_path: Path) -> None:
+    """Regression: a generation-consistent attested death still back-fills as before."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    out_dir = tmp_path / "curated"
+    out_dir.mkdir()
+    name = "تابعي معروف"
+    norm = normalize_arabic(name)
+    attested_id = _write_attested_narrator(out_dir, norm, mentions=5)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            {
+                "bio_id": "itqan:454c",
+                "source": "itqan",
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                "death_year_ah": 160,
+                "generation": "tabii",
+            }
+        ],
+    )
+
+    path = promote_bios_to_canonical(staging, out_dir)
+    assert path is not None
+    rec = next(r for r in pq.read_table(path).to_pylist() if r["canonical_id"] == attested_id)
+    assert rec["death_year_ah"] == 160

--- a/tests/test_resolve/test_date_reconcile.py
+++ b/tests/test_resolve/test_date_reconcile.py
@@ -517,6 +517,77 @@ def test_stage_scrubs_implausible_attested_death_for_generation(tmp_path: Path) 
     assert rec["death_date_precision"] == "unknown"
 
 
+def test_stage_scrubs_implausible_death_over_preexisting_canonical_point(tmp_path: Path) -> None:
+    """The scrub must pierce the back-fill-protection guard (da#454, Jean-Claude must-fix).
+
+    Reproduces the idempotent-re-run / already-dated-canonical hole: the canonical
+    record ALREADY carries a legacy pre-fix corrupt death point (d. 720 AH welded
+    onto a Companion), exactly the state a persisted pre-fix
+    ``narrators_canonical.parquet`` carries into a ``resolve --from-step reconcile``
+    re-run. The scrub nulls the reconciled death dating, but the back-fill guard
+    (``value is None and rec.get(key) is not None -> continue``) would otherwise
+    keep the surviving 720 point while its bounds + precision are nulled — a
+    self-inconsistent half-scrub that ``_death_is_undated`` then reads as "dated",
+    skipping the ṭabaqa fallback. Assert the WHOLE death dating is cleared: point
+    AND both bounds AND precision, with no surviving point behind a nulled envelope.
+    """
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    curated = tmp_path / "curated"
+    curated.mkdir()
+
+    name = "صحابي ملوث"
+    norm = normalize_arabic(name)
+    cid = make_canonical_id(norm)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            _bio_date_row(
+                bio_id="itqan:454d",
+                source="itqan",
+                name_ar=name,
+                name_ar_normalized=norm,
+                death_year_ah=720,
+                death_year_ah_earliest=720,
+                death_year_ah_latest=720,
+                death_date_precision="exact",
+            )
+        ],
+    )
+    # Canonical record already dated with the pre-fix corrupt point — the guard
+    # branch (rec.get("death_year_ah") is not None) MUST fire for this to exercise
+    # the hole rather than the clean from-scratch path.
+    _write_canonical(
+        curated,
+        [
+            {
+                "canonical_id": cid,
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                "generation": "sahabi",
+                "death_year_ah": 720,
+                "death_year_ah_earliest": 720,
+                "death_year_ah_latest": 720,
+                "death_date_precision": "exact",
+                "source_corpus": "itqan",
+                "source_corpora": ["itqan"],
+                "mention_count": 0,
+            }
+        ],
+    )
+
+    out = reconcile_canonical_dates(staging, curated)
+    assert out is not None
+    rec = next(r for r in pq.read_table(out).to_pylist() if r["canonical_id"] == cid)
+
+    # No half-scrubbed survivor: point, both bounds, and precision all cleared.
+    assert rec["death_year_ah"] is None
+    assert rec["death_year_ah_earliest"] is None
+    assert rec["death_year_ah_latest"] is None
+    assert rec["death_date_precision"] == "unknown"
+
+
 def test_stage_scrubs_implausible_attested_death_absolute_envelope(tmp_path: Path) -> None:
     """No/unknown generation still bounds against the absolute plausibility envelope."""
     staging = tmp_path / "staging"

--- a/tests/test_resolve/test_date_reconcile.py
+++ b/tests/test_resolve/test_date_reconcile.py
@@ -453,3 +453,161 @@ def test_stage_no_canonical_is_noop(tmp_path: Path) -> None:
     curated = tmp_path / "curated"
     curated.mkdir()
     assert reconcile_canonical_dates(staging, curated) is None
+
+
+# --------------------------------------------------------------------------- #
+# Implausible attested death scrub (da#454) — the input-side companion to
+# narrator_split's da#446 output-side gate: a single UNCONTESTED late-collector
+# attested death (no competing source, so reconciliation sees no "conflict") must
+# still not survive reconciliation when it is impossible for the narrator's own
+# generation.
+# --------------------------------------------------------------------------- #
+def test_stage_scrubs_implausible_attested_death_for_generation(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    curated = tmp_path / "curated"
+    curated.mkdir()
+
+    # A Companion (sahabi, plausible window ~[11, 110] AH) whose single bio source
+    # attests a d. 720 AH death — the late-collector pollution class da#446/#454
+    # documents: a commentator's death mislabelled onto an early isnad node.
+    name = "صحابي وهمي"
+    norm = normalize_arabic(name)
+    cid = make_canonical_id(norm)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            _bio_date_row(
+                bio_id="itqan:454a",
+                source="itqan",
+                name_ar=name,
+                name_ar_normalized=norm,
+                death_year_ah=720,
+                death_year_ah_earliest=720,
+                death_year_ah_latest=720,
+                death_date_precision="exact",
+            )
+        ],
+    )
+    _write_canonical(
+        curated,
+        [
+            {
+                "canonical_id": cid,
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                "generation": "sahabi",
+                "source_corpus": "itqan",
+                "source_corpora": ["itqan"],
+                "mention_count": 0,
+            }
+        ],
+    )
+
+    out = reconcile_canonical_dates(staging, curated)
+    assert out is not None
+    rec = next(r for r in pq.read_table(out).to_pylist() if r["canonical_id"] == cid)
+
+    # The whole death dating is scrubbed back to undated — not just the point —
+    # so the ṭabaqa fallback (da#166) sees a genuinely undated narrator next.
+    assert rec["death_year_ah"] is None
+    assert rec["death_year_ah_earliest"] is None
+    assert rec["death_year_ah_latest"] is None
+    assert rec["death_date_precision"] == "unknown"
+
+
+def test_stage_scrubs_implausible_attested_death_absolute_envelope(tmp_path: Path) -> None:
+    """No/unknown generation still bounds against the absolute plausibility envelope."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    curated = tmp_path / "curated"
+    curated.mkdir()
+
+    name = "مجهول الطبقة"
+    norm = normalize_arabic(name)
+    cid = make_canonical_id(norm)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            _bio_date_row(
+                bio_id="itqan:454b",
+                source="itqan",
+                name_ar=name,
+                name_ar_normalized=norm,
+                death_year_ah=805,
+                death_year_ah_earliest=805,
+                death_year_ah_latest=805,
+                death_date_precision="exact",
+            )
+        ],
+    )
+    _write_canonical(
+        curated,
+        [
+            {
+                "canonical_id": cid,
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                # generation left unset — the absolute envelope still applies.
+                "source_corpus": "itqan",
+                "source_corpora": ["itqan"],
+                "mention_count": 0,
+            }
+        ],
+    )
+
+    out = reconcile_canonical_dates(staging, curated)
+    assert out is not None
+    rec = next(r for r in pq.read_table(out).to_pylist() if r["canonical_id"] == cid)
+    assert rec["death_year_ah"] is None
+    assert rec["death_date_precision"] == "unknown"
+
+
+def test_stage_keeps_plausible_attested_death_for_generation(tmp_path: Path) -> None:
+    """Regression: a plausible generation-consistent death is reconciled as before."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    curated = tmp_path / "curated"
+    curated.mkdir()
+
+    name = "تابعي حقيقي"
+    norm = normalize_arabic(name)
+    cid = make_canonical_id(norm)
+    _write_bios(
+        staging,
+        "itqan",
+        [
+            _bio_date_row(
+                bio_id="itqan:454c",
+                source="itqan",
+                name_ar=name,
+                name_ar_normalized=norm,
+                death_year_ah=110,
+                death_year_ah_earliest=110,
+                death_year_ah_latest=110,
+                death_date_precision="exact",
+            )
+        ],
+    )
+    _write_canonical(
+        curated,
+        [
+            {
+                "canonical_id": cid,
+                "name_ar": name,
+                "name_ar_normalized": norm,
+                "generation": "tabii",
+                "source_corpus": "itqan",
+                "source_corpora": ["itqan"],
+                "mention_count": 0,
+            }
+        ],
+    )
+
+    out = reconcile_canonical_dates(staging, curated)
+    assert out is not None
+    rec = next(r for r in pq.read_table(out).to_pylist() if r["canonical_id"] == cid)
+    assert rec["death_year_ah"] == 110
+    assert rec["death_date_precision"] == "exact"

--- a/tests/test_resolve/test_disambiguate.py
+++ b/tests/test_resolve/test_disambiguate.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from src.parse.identity import CANONICAL_NAMESPACE
+from src.parse.schemas import NARRATOR_BIO_SCHEMA
 from src.resolve.disambiguate import (
     Candidate,
     ChainContext,
@@ -19,6 +23,7 @@ from src.resolve.disambiguate import (
     _fuzzy_match,
     _fuzzy_match_blocked,
     _geographic_filter,
+    _load_candidates,
     _make_canonical_id,
     _temporal_filter,
     _upsert_canonical,
@@ -451,3 +456,49 @@ class TestUpsertAliasDeixisScrub:
         aliases = canonical_map[cid]["aliases"]
         assert aliases == ["عاءشه ابنه ابي بكر"]
         assert "خالته" not in aliases  # deixis dropped
+
+
+def _write_bio_row(staging: Path, **row: object) -> None:
+    """Write a single-row narrators_bio_*.parquet, schema defaults filled in."""
+    base = {f.name: None for f in NARRATOR_BIO_SCHEMA}
+    base.update(row)
+    arrays = {f.name: [base[f.name]] for f in NARRATOR_BIO_SCHEMA}
+    table = pa.table(arrays, schema=NARRATOR_BIO_SCHEMA)
+    pq.write_table(table, staging / "narrators_bio_itqan.parquet")
+
+
+class TestLoadCandidatesDeathYearScrub:
+    """da#454: an implausible attested death year must never enter the candidate
+    pool ``_load_candidates`` builds — it feeds ``_temporal_filter`` and
+    ``_bio_corroborated`` (and, via ``death_year_index``, narrator_split's
+    neighbour-death evidence), so a corrupt year here propagates into identity
+    decisions, not just display."""
+
+    def test_implausible_death_year_is_scrubbed(self, tmp_path: Path) -> None:
+        _write_bio_row(
+            tmp_path,
+            bio_id="itqan:454",
+            source="itqan",
+            name_ar="صحابي ملوث",
+            name_ar_normalized="صحابي ملوث",
+            death_year_ah=720,  # impossible for a Companion (sahabi)
+            generation="sahabi",
+        )
+        candidates = _load_candidates(tmp_path)
+        assert len(candidates) == 1
+        assert candidates[0].death_year_ah is None
+        assert candidates[0].generation == "sahabi"
+
+    def test_plausible_death_year_is_kept(self, tmp_path: Path) -> None:
+        _write_bio_row(
+            tmp_path,
+            bio_id="itqan:455",
+            source="itqan",
+            name_ar="تابعي حقيقي",
+            name_ar_normalized="تابعي حقيقي",
+            death_year_ah=150,
+            generation="tabii",
+        )
+        candidates = _load_candidates(tmp_path)
+        assert len(candidates) == 1
+        assert candidates[0].death_year_ah == 150

--- a/tests/test_resolve/test_narrator_split.py
+++ b/tests/test_resolve/test_narrator_split.py
@@ -906,3 +906,93 @@ def test_split_adjacency_matches_loader_transmitted_to(tmp_path: Path) -> None:
 
     # The two notions of adjacency AGREE (the da#439 invariant).
     assert split_neighbours == loader_neighbours
+
+
+def test_split_adjacency_matches_loader_transmitted_to_multi_isnad(tmp_path: Path) -> None:
+    """da#453: extend the da#439 cross-function invariant across the multi-isnad
+    grouping boundary.
+
+    `test_split_adjacency_matches_loader_transmitted_to` proves splitter/loader
+    agreement by calling `_build_chain_pairs` directly on one chain's mentions — the
+    per-chain pairing unit. Production never calls it that way: `_load_transmitted_to`
+    first buckets mentions by the composite ``(hadith_id, chain_index)`` key
+    (``by_chain``, keyed via `_chain_index`) and calls `_build_chain_pairs` once PER
+    GROUP. The single-chain test can't reach that grouping step at all, so a defect
+    that flattened two isnads together before pairing would pass it and still corrupt
+    a multi-isnad hadith (da#411's failure class).
+
+    One ``hadith_id``, two ``chain_index`` chains, the candidate present in both —
+    mirrors `test_multi_isnad_no_cross_chain_neighbour` but cross-checks the
+    splitter against the loader's actual grouped-pairing path (built the same way
+    `_load_transmitted_to` builds it) instead of the splitter alone.
+    """
+    from src.graph.load_edges import _build_chain_pairs, _chain_index
+    from src.resolve.narrator_split import _build_chain_index, _collect_datable
+
+    cand = make_canonical_id(_ABU_ABDALLAH)
+    teacher_a = _anchor_row("nar:teacher_a", 100)
+    student_a = _anchor_row("nar:student_a", 180)
+    teacher_b = _anchor_row("nar:teacher_b", 250)
+    student_b = _anchor_row("nar:student_b", 320)
+    canonical = [
+        _canonical_row(cand, _ABU_ABDALLAH, 2),
+        teacher_a,
+        student_a,
+        teacher_b,
+        student_b,
+    ]
+    hid = "hdt:bukhari:9"
+    mention_rows = [
+        # Chain 0 — gappy (mirrors da#439): candidate at position 2, two dropped
+        # unresolved mentions opening a gap to each attested neighbour.
+        _mention_row("m-teacher-a", hid, 0, "nar:teacher_a", chain_index=0),
+        _mention_row("m-gap-a1", hid, 1, None, chain_index=0),
+        _mention_row("m-cand-0", hid, 2, cand, chain_index=0),
+        _mention_row("m-gap-a3", hid, 3, None, chain_index=0),
+        _mention_row("m-student-a", hid, 4, "nar:student_a", chain_index=0),
+        # Chain 1 — the SAME hadith's other isnad, contiguous. Position values (0/1/2)
+        # overlap with chain 0's, so a defect that paired the flattened mention list
+        # instead of grouping by (hadith_id, chain_index) first would collide the two
+        # isnads' positions.
+        _mention_row("m-teacher-b", hid, 0, "nar:teacher_b", chain_index=1),
+        _mention_row("m-cand-1", hid, 1, cand, chain_index=1),
+        _mention_row("m-student-b", hid, 2, "nar:student_b", chain_index=1),
+    ]
+    out = tmp_path / "curated"
+    _write(out, canonical, mention_rows)
+
+    # Loader side — group by the composite key exactly as `_load_transmitted_to`
+    # does (`by_chain.setdefault((hid, _chain_index(row)), []).append(row)`), THEN
+    # pair each group — never the flattened list.
+    by_chain: dict[tuple[str, int], list[dict[str, Any]]] = {}
+    for row in mention_rows:
+        by_chain.setdefault((row["hadith_id"], _chain_index(row)), []).append(row)
+    loader_neighbours_by_chain: dict[int, set[str]] = {}
+    for chain_idx in (0, 1):
+        chain_pairs = _build_chain_pairs(by_chain[(hid, chain_idx)])
+        loader_neighbours_by_chain[chain_idx] = {
+            p["to_id"] for p in chain_pairs if p["from_id"] == cand
+        } | {p["from_id"] for p in chain_pairs if p["to_id"] == cand}
+    assert loader_neighbours_by_chain[0] == {"nar:teacher_a", "nar:student_a"}
+    assert loader_neighbours_by_chain[1] == {"nar:teacher_b", "nar:student_b"}
+
+    # Splitter side: build the chain index over BOTH chains at once, as the real
+    # stage does (one parquet file, every chain_index mixed together).
+    attested_by_id = {
+        r["canonical_id"]: r["death_year_ah"] for r in (teacher_a, student_a, teacher_b, student_b)
+    }
+    name_by_id = {r["canonical_id"]: r["name_ar_normalized"] for r in canonical}
+    id_by_name = {v: k for k, v in name_by_id.items()}
+    chains, candidate_mentions = _build_chain_index(
+        out / "narrator_mentions_resolved.parquet", {cand}
+    )
+    datable = _collect_datable(candidate_mentions[cand], chains, attested_by_id, name_by_id)
+    by_mention = {d.mention_id: {id_by_name[n] for n in d.anchor_names} for d in datable}
+
+    # The da#439 invariant, extended across the grouping boundary: each of the
+    # candidate's two mentions draws its splitter neighbours from ONLY its own
+    # chain's grouped-loader neighbours — never the other isnad's.
+    assert by_mention["m-cand-0"] == loader_neighbours_by_chain[0]
+    assert by_mention["m-cand-1"] == loader_neighbours_by_chain[1]
+    assert not (by_mention["m-cand-0"] & loader_neighbours_by_chain[1])
+    assert not (by_mention["m-cand-1"] & loader_neighbours_by_chain[0])

--- a/tests/test_resolve/test_tabaqa_dates.py
+++ b/tests/test_resolve/test_tabaqa_dates.py
@@ -29,6 +29,7 @@ from src.resolve.tabaqa_dates import (
     estimate_death_window,
     generation_from_value,
     is_plausible_narrator_death_ah,
+    plausible_attested_death_year,
 )
 from src.utils.hijri import ah_year_to_ce_range
 
@@ -151,6 +152,34 @@ def test_clamp_death_ah_bounds_axis_estimates() -> None:
     assert clamp_death_ah(805) == NARRATOR_DEATH_MAX_AH == 450
     assert clamp_death_ah(497) == 450  # student-of-latest-plausible boundary overflow
     assert clamp_death_ah(256) == 256
+
+
+# --------------------------------------------------------------------------- #
+# da#454 — plausible_attested_death_year, the stamp-time companion to the
+# da#446 output-side scrub: bio_promote/disambiguate call this so an implausible
+# attested year never enters narrators_canonical or the candidate pool.
+# --------------------------------------------------------------------------- #
+def test_plausible_attested_death_year_passes_through_valid_year() -> None:
+    assert plausible_attested_death_year(256) == 256
+    assert plausible_attested_death_year(160, "sahabi") == 160
+
+
+def test_plausible_attested_death_year_none_is_none() -> None:
+    # A bio with no attested death stays None — never fabricated.
+    assert plausible_attested_death_year(None) is None
+    assert plausible_attested_death_year(None, "sahabi") is None
+
+
+def test_plausible_attested_death_year_scrubs_absolute_envelope_violation() -> None:
+    assert plausible_attested_death_year(805) is None
+    assert plausible_attested_death_year(754, "unknown") is None
+
+
+def test_plausible_attested_death_year_scrubs_generation_mismatch() -> None:
+    # 300 AH sits inside the loose absolute envelope but is impossible for a
+    # Companion (sahabi) — matches is_plausible_narrator_death_ah's own gate.
+    assert plausible_attested_death_year(300, "sahabi") is None
+    assert plausible_attested_death_year(300, "later") == 300
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Phase 9 Wave 27 → main (data-acquisition). All 4 wave-27 PRs reviewed (2 reviewers each, including an Opus merge-gate reviewer) and merged into the wave branch.

- #484 (da#454) — **sole Tier-1 cutover gater.** Bounds attested `death_year_ah` to the isnad-plausibility envelope at stamp time. Merge-gate reviewer held it on a genuine must-fix (the back-fill guard swallowed the scrub's point-null over a pre-existing corrupt point → half-scrubbed record survives; reachable on both the idempotent-resume AND from-scratch cutover paths). Fixed via an explicit `scrub_cleared` clear-intent sentinel + regression test; re-approved fresh. Tech-debt #486 filed then closed as resolved-in-PR.
- #481 (da#464) — share the resolve-stage death-year spread band constant.
- #482 (da#477) — record the ى→ي fold full-corpus A/B artifact.
- #483 (da#453) — extend the da#439 adjacency invariant across the multi-isnad grouping boundary.

Merge with `--merge` (never squash). Wave branch retained.