### PR TITLE
fix(da#489): leaderboard projects name_en (always-populated) instead of never-written name_arabic

### DIFF
--- a/src/enrich/metrics.py
+++ b/src/enrich/metrics.py
@@ -192,7 +192,7 @@ def run_metrics(
         top5 = client.execute_read(
             "MATCH (n:Narrator)"
             " WHERE n.betweenness_centrality IS NOT NULL"
-            " RETURN n.id AS id, n.name_arabic AS name, n.betweenness_centrality AS bc"
+            " RETURN n.id AS id, n.name_en AS name, n.betweenness_centrality AS bc"
             " ORDER BY bc DESC LIMIT 5"
         )
         for row in top5:

--- a/tests/test_enrich/test_metrics.py
+++ b/tests/test_enrich/test_metrics.py
@@ -181,3 +181,49 @@ class TestBetweennessSampling:
 
         call = _betweenness_call(mock_client)
         assert "samplingSize" not in call.args[0]
+
+
+def _leaderboard_query(client: MagicMock) -> str:
+    """Return the top-5 betweenness leaderboard read query string."""
+    calls = [
+        c
+        for c in client.execute_read.call_args_list
+        if "ORDER BY bc" in c.args[0] and "LIMIT 5" in c.args[0]
+    ]
+    assert len(calls) == 1, f"expected exactly one top-5 leaderboard query, got {len(calls)}"
+    return calls[0].args[0]
+
+
+class TestLeaderboardName:
+    """da#489 — top-5 leaderboard must project the always-populated name_en.
+
+    The Narrator loader writes n.name_en (guaranteed non-empty via the
+    transliteration fallback) and n.name_ar, but never n.name_arabic. Guard
+    against a future rename silently reintroducing blank leaderboard names.
+    """
+
+    def _gds_up(self, mock_client: MagicMock) -> None:
+        """Prime read side-effects so run_metrics reaches the top-5 query."""
+        mock_client.execute_read.side_effect = [
+            [{"version": "2.13.8"}],  # gds.version()
+            [{"exists": False}],  # gds.graph.exists
+            [{"cnt": 7}],  # count enriched
+            [{"id": "nar:1", "name": "Test", "bc": 0.9}],  # top-5
+        ]
+        mock_client.execute_write.return_value = [{"communityCount": 2, "nodePropertiesWritten": 7}]
+
+    def test_leaderboard_projects_name_en(self, mock_client: MagicMock) -> None:
+        self._gds_up(mock_client)
+
+        run_metrics(mock_client)
+
+        query = _leaderboard_query(mock_client)
+        assert "n.name_en AS name" in query
+
+    def test_leaderboard_never_references_name_arabic(self, mock_client: MagicMock) -> None:
+        self._gds_up(mock_client)
+
+        run_metrics(mock_client)
+
+        query = _leaderboard_query(mock_client)
+        assert "name_arabic" not in query


### PR DESCRIPTION
## Summary
The enrich choke-point leaderboard logged blank narrator names. This changes the top-5 betweenness query to project `n.name_en` — the always-populated display name — instead of `n.name_arabic`, a property that is never written.

## Root cause
`src/enrich/metrics.py` top-5 leaderboard query selected `n.name_arabic AS name`. The Narrator loader (`src/graph/load_nodes.py`) only ever writes:
- `n.name_ar` — raw Arabic (may be empty)
- `n.name_en` — English display name, **guaranteed non-empty** via the transliteration fallback in `_narrator_name_en` (`load_nodes.py:260-282`, applied at `:354`)

It never writes `name_arabic`, so `n.name_arabic` resolved to null and every leaderboard name logged blank.

## The fix (one line)
```
- RETURN n.id AS id, n.name_arabic AS name, n.betweenness_centrality AS bc
+ RETURN n.id AS id, n.name_en AS name, n.betweenness_centrality AS bc
```
`name_en` is the always-populated display name (the recommended fix per the issue). No other change to the query.

## Regression test
The metrics tests are mock-based unit tests, so the achievable guard is on the query string. Added `TestLeaderboardName` in `tests/test_enrich/test_metrics.py`, priming `run_metrics` to reach the top-5 query and asserting the leaderboard query:
- **projects** `n.name_en AS name`
- **never references** `name_arabic`

so a future property rename can't silently reintroduce blank names.

## Verification
- `uv run pytest tests/test_enrich/test_metrics.py -q` → **13 passed**
- `ruff check` / `ruff format --check` clean; `mypy src/` clean

## Notes
Step-7 leaderboard sign-off (main#1087) depends on this fix.

Closes #489