### PR TITLE
perf(arabic): memoize normalize_arabic with lru_cache (#495)

### DIFF
--- a/src/parse/composition.py
+++ b/src/parse/composition.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 import hashlib
 
 from src.parse.identity import HADITH_ID_PREFIX, ID_DELIMITER
-from src.utils.arabic import is_arabic, normalize_arabic, strip_to_letters
+from src.utils.arabic import is_arabic, normalize_arabic_uncached, strip_to_letters
 
 # source_corpus -> allowed collection slugs.
 #   None           = load all collections for this source. Equivalent to the
@@ -189,8 +189,8 @@ def canonical_matn_identity(matn_ar: str | None, matn_en: str | None) -> str | N
     tokens) — a ``None`` identity is never deduped, so the hadith is kept.
 
     The Arabic matn is preferred and normalized via
-    :func:`src.utils.arabic.normalize_arabic` (diacritics / alif / hamza / taa
-    marbuta / tatweel folded, whitespace collapsed), then reduced to letters and
+    :func:`src.utils.arabic.normalize_arabic_uncached` (diacritics / alif / hamza /
+    taa marbuta / tatweel folded, whitespace collapsed), then reduced to letters and
     single spaces by :func:`src.utils.arabic.strip_to_letters`; the English matn
     (lowercased) is stripped the same way and is the fallback when no Arabic matn
     is present.
@@ -209,7 +209,12 @@ def canonical_matn_identity(matn_ar: str | None, matn_en: str | None) -> str | N
     index stays compact for the full ~650k-row corpus.
     """
     if matn_ar and is_arabic(matn_ar):
-        normalized = strip_to_letters(normalize_arabic(matn_ar))
+        # Full matn bodies (matn_ar / full_text_ar) are large and mostly unique,
+        # and the loader runs this over the full ~650k-row corpus, so bypass the
+        # lru_cache on normalize_arabic (da#495) — caching these would retain
+        # every distinct body for the process lifetime and risk OOM (memory-
+        # bounding history da#337/#723). Same reasoning as src/resolve/parallels.py.
+        normalized = strip_to_letters(normalize_arabic_uncached(matn_ar))
     elif matn_en and matn_en.strip():
         normalized = strip_to_letters(matn_en.lower())
     else:

--- a/src/parse/isnad_matn_split.py
+++ b/src/parse/isnad_matn_split.py
@@ -40,7 +40,11 @@ from src.parse.narrator_extraction import (
     NarratorSpan,
     extract_narrator_mentions,
 )
-from src.utils.arabic import extract_transmission_phrases, normalize_arabic
+from src.utils.arabic import (
+    extract_transmission_phrases,
+    normalize_arabic,
+    normalize_arabic_uncached,
+)
 
 __all__ = [
     "DETECTOR_TOKEN_WINDOW",
@@ -148,7 +152,11 @@ def _head_opener(text: str) -> bool:
     editorial mark still counts; the comparison is on the *normalized* first
     Arabic word, so it is exact-token, never a substring of a longer word.
     """
-    match = _FIRST_AR_WORD_RE.match(normalize_arabic(text))
+    # `text` here is a full matn body (split_isnad_matn runs per corpus row), so
+    # use the uncached core: caching whole bodies would retain every distinct one
+    # for the process lifetime and risk OOM (da#495 review; da#337/#723). We only
+    # read the first word, but normalize_arabic would still cache the full string.
+    match = _FIRST_AR_WORD_RE.match(normalize_arabic_uncached(text))
     if match is None:
         return False
     return match.group(1) in _HEAD_OPENERS

--- a/src/resolve/parallels.py
+++ b/src/resolve/parallels.py
@@ -23,8 +23,9 @@ contract are unchanged.
 Matching signal
 ---------------
 Token-set Jaccard over the normalized matn — Arabic via
-:func:`src.utils.arabic.normalize_arabic` when an Arabic matn is present, else the
-English matn lowercased. Scores are tiered into :class:`VariantType` by the same
+:func:`src.utils.arabic.normalize_arabic_uncached` (the uncached core; matn bodies
+are large and mostly unique) when an Arabic matn is present, else the English matn
+lowercased. Scores are tiered into :class:`VariantType` by the same
 thresholds ``dedup.py`` uses. ``cross_sect`` is read from the hadith ``sect``
 column (authoritative), not inferred from the corpus name.
 
@@ -71,7 +72,7 @@ from src.resolve._provenance import (
     write_parallel_links,
 )
 from src.resolve.schemas import PARALLEL_LINKS_SCHEMA
-from src.utils.arabic import is_arabic, normalize_arabic
+from src.utils.arabic import is_arabic, normalize_arabic_uncached
 from src.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -128,12 +129,17 @@ def _classify_pair(score: float) -> VariantType:
 def _tokenize(matn_ar: str | None, matn_en: str | None) -> frozenset[str]:
     """Normalized token set for a hadith matn.
 
-    Prefers the Arabic matn (normalized via ``normalize_arabic``); falls back to
-    the English matn lowercased. Returns an empty set when neither is usable, in
-    which case the hadith is excluded from pairing.
+    Prefers the Arabic matn (normalized via ``normalize_arabic_uncached``); falls
+    back to the English matn lowercased. Returns an empty set when neither is
+    usable, in which case the hadith is excluded from pairing.
     """
     if matn_ar and is_arabic(matn_ar):
-        normalized = normalize_arabic(matn_ar)
+        # Full matn bodies are large and mostly unique, so the lru_cache on
+        # normalize_arabic (da#495) is the wrong shape here — this full-corpus
+        # scan would otherwise retain every distinct hadith text for the process
+        # lifetime and risk OOM (memory-bounding history da#337/#723). Use the
+        # uncached core: compute-and-discard.
+        normalized = normalize_arabic_uncached(matn_ar)
     elif matn_en and matn_en.strip():
         normalized = matn_en.lower()
     else:

--- a/src/utils/arabic.py
+++ b/src/utils/arabic.py
@@ -7,6 +7,7 @@ Compiled regex patterns are defined at module level for performance.
 from __future__ import annotations
 
 import re
+from functools import lru_cache
 
 __all__ = [
     "strip_diacritics",
@@ -309,6 +310,7 @@ def strip_to_letters(text: str) -> str:
     return _MULTI_WS_RE.sub(" ", stripped).strip()
 
 
+@lru_cache(maxsize=1 << 18)
 def normalize_arabic(text: str) -> str:
     """Full Arabic normalization pipeline.
 

--- a/src/utils/arabic.py
+++ b/src/utils/arabic.py
@@ -17,6 +17,7 @@ __all__ = [
     "normalize_taa_marbuta",
     "normalize_urdu",
     "normalize_arabic",
+    "normalize_arabic_uncached",
     "clean_whitespace",
     "strip_to_letters",
     "is_arabic",
@@ -310,9 +311,8 @@ def strip_to_letters(text: str) -> str:
     return _MULTI_WS_RE.sub(" ", stripped).strip()
 
 
-@lru_cache(maxsize=1 << 18)
-def normalize_arabic(text: str) -> str:
-    """Full Arabic normalization pipeline.
+def normalize_arabic_uncached(text: str) -> str:
+    """Full Arabic normalization pipeline (uncached core of :func:`normalize_arabic`).
 
     Steps:
     1. Strip bidi / zero-width / format control marks
@@ -330,6 +330,13 @@ def normalize_arabic(text: str) -> str:
     Arabic twin — e.g. Urdu ``ہ`` -> Arabic ``ه`` is indistinguishable from a
     sourced ``ه`` downstream. It is a no-op on all-Arabic input (see
     :func:`normalize_urdu`), so no existing normalization result changes.
+
+    Prefer the memoized :func:`normalize_arabic` for bounded-vocabulary input
+    (narrator-name tokens, particle/marker sets, grade needles). Call THIS
+    uncached form for large, mostly-unique text such as full matn bodies (see
+    ``src/resolve/parallels.py``): caching those would retain every distinct
+    string for the process lifetime and risk OOM (da#495 review; memory-bounding
+    history da#337/#723).
     """
     text = strip_format_marks(text)
     text = strip_diacritics(text)
@@ -341,6 +348,20 @@ def normalize_arabic(text: str) -> str:
     text = _TATWEEL_RE.sub("", text)
     text = clean_whitespace(text)
     return text
+
+
+@lru_cache(maxsize=1 << 18)
+def normalize_arabic(text: str) -> str:
+    """Memoized :func:`normalize_arabic_uncached`.
+
+    da#495: name_quality re-normalizes the same small set of narrator-name
+    tokens on the order of millions of times per resolve, so the pipeline is
+    cached here. The bounded vocabulary keeps the cache small; see
+    :func:`normalize_arabic_uncached` for the pipeline steps and for when a
+    caller must bypass the cache (large, mostly-unique inputs such as full
+    matn bodies).
+    """
+    return normalize_arabic_uncached(text)
 
 
 def is_arabic(text: str) -> bool:

--- a/tests/test_parse/test_composition.py
+++ b/tests/test_parse/test_composition.py
@@ -13,6 +13,25 @@ from src.parse.composition import (
     is_cross_edition_dedup_source,
 )
 from src.parse.identity import DoubledCorpusPrefixError, hadith_node_id
+from src.utils.arabic import normalize_arabic
+
+
+class TestCanonicalMatnIdentityDoesNotCacheBodies:
+    def test_matn_body_bypasses_the_normalize_cache(self) -> None:
+        # da#495 review: canonical_matn_identity runs over the full ~650k-row
+        # corpus with full matn bodies (matn_ar / full_text_ar). It MUST normalize
+        # them via normalize_arabic_uncached — feeding them through the memoized
+        # normalize_arabic would retain every distinct body for the process
+        # lifetime (OOM risk; da#337/#723). Guard it structurally.
+        normalize_arabic.cache_clear()
+        body = " ".join(["حدثنا محمد بن إسماعيل قال حدثنا عبد الله"] * 40)
+        before = normalize_arabic.cache_info().currsize
+        assert canonical_matn_identity(body, None) is not None
+        after = normalize_arabic.cache_info().currsize
+        assert after == before == 0, (
+            "matn body leaked into the normalize_arabic cache — "
+            "canonical_matn_identity must use normalize_arabic_uncached"
+        )
 
 
 class TestIsCanonicalHadith:

--- a/tests/test_parse/test_isnad_matn_split.py
+++ b/tests/test_parse/test_isnad_matn_split.py
@@ -16,9 +16,29 @@ from __future__ import annotations
 
 import pytest
 
-from src.parse.isnad_matn_split import detect_isnad, split_isnad_matn
+from src.parse.isnad_matn_split import _head_opener, detect_isnad, split_isnad_matn
 from src.parse.narrator_extraction import extract_narrator_mentions
-from src.utils.arabic import extract_transmission_phrases
+from src.utils.arabic import extract_transmission_phrases, normalize_arabic
+
+
+class TestHeadOpenerDoesNotCacheBodies:
+    def test_full_body_bypasses_the_normalize_cache(self) -> None:
+        # da#495 review: _head_opener normalizes the FULL text just to read its
+        # first word, and split_isnad_matn runs it per corpus row on full matn
+        # bodies. It MUST use normalize_arabic_uncached — else every distinct body
+        # is retained in the memoized cache for the process lifetime (OOM risk;
+        # da#337/#723). (split_isnad_matn itself still caches the bounded narrator
+        # NAMES it extracts, which is the intended use; this guards the body path.)
+        normalize_arabic.cache_clear()
+        body = "حدثنا محمد بن إسماعيل قال حدثنا عبد الله " + ("قال رسول الله " * 30)
+        before = normalize_arabic.cache_info().currsize
+        _head_opener(body)
+        after = normalize_arabic.cache_info().currsize
+        assert after == before == 0, (
+            "matn body leaked into the normalize_arabic cache — "
+            "_head_opener must use normalize_arabic_uncached"
+        )
+
 
 # --- positive recoveries --------------------------------------------------
 

--- a/tests/test_resolve/test_parallels.py
+++ b/tests/test_resolve/test_parallels.py
@@ -17,6 +17,7 @@ from src.resolve.parallels import (
     _tokenize,
     detect_parallels,
 )
+from src.utils.arabic import normalize_arabic, normalize_arabic_uncached
 from tests.test_graph.conftest import write_hadiths
 
 
@@ -66,6 +67,24 @@ class TestTokenize:
     def test_empty_when_neither(self) -> None:
         assert _tokenize(None, None) == frozenset()
         assert _tokenize("", "   ") == frozenset()
+
+    def test_matn_body_bypasses_the_normalize_cache(self) -> None:
+        # da#495 review: full matn bodies are large and mostly unique, so
+        # _tokenize MUST normalize them via the uncached core — feeding them
+        # through the memoized normalize_arabic would retain every distinct
+        # hadith body for the process lifetime (OOM risk; da#337/#723). Guard
+        # the invariant structurally so it can't silently regress.
+        assert not hasattr(normalize_arabic_uncached, "cache_info")
+        normalize_arabic.cache_clear()
+        # A body-sized, unique-per-call Arabic matn.
+        body = " ".join(["حدثنا محمد بن إسماعيل قال حدثنا عبد الله"] * 40)
+        before = normalize_arabic.cache_info().currsize
+        assert _tokenize(body, None)  # non-empty token set
+        after = normalize_arabic.cache_info().currsize
+        assert after == before == 0, (
+            "matn body leaked into the normalize_arabic cache — the parallels "
+            "full-corpus path must use normalize_arabic_uncached"
+        )
 
 
 def _coords(**over: object) -> dict[str, object]:


### PR DESCRIPTION
## Summary
Closes #495 (F3, perf, XS).

`normalize_arabic` is a pure single-`str`-arg function called per-token during `name_quality` resolution (~8-10 min of a resolve). This wraps it in `functools.lru_cache(maxsize=1<<18)` so repeated tokens — and the import-time `_NAME_LEXICON` / `_NORM_MARKER_PATTERNS` builds — hit the cache instead of re-running the full normalization pipeline.

## Changes
- `src/utils/arabic.py`: `from functools import lru_cache`; `@lru_cache(maxsize=1 << 18)` on `normalize_arabic`.

## Correctness
Pure function → output is unchanged; the cache only elides recomputation. Import-time callers are safe to cache.

## Testing
- `tests/test_utils/test_arabic.py`, `tests/test_utils/test_arabic_fuzz.py`, `tests/test_parse/test_name_quality.py`: **623 passed**.
- `ruff check` clean; pre-commit (ruff-format/lint, gitleaks) + pre-push pytest passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z