### PR TITLE
da#490: edge_load_conformance false-positive + GRADED_BY orphan gap

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -387,8 +387,11 @@ def _cmd_load(
             f" invalid_source_ids={nr.invalid_source_ids})"
         )
     for er in summary.edge_results:
+        # already_present distinguishes an idempotent re-load (created=0,
+        # already_present>0 — benign) from a genuine empty load (da#490).
         print(
-            f"    {er.edge_type}: created={er.created} skipped={er.skipped}"
+            f"    {er.edge_type}: created={er.created} already_present={er.already_present}"
+            f" skipped={er.skipped}"
             f" missing_endpoints={er.missing_endpoints} malformed_ids={er.malformed_ids}"
         )
 

--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -48,6 +48,16 @@ class EdgeLoadResult:
     missing_endpoints: int
     # Edges refused because an endpoint id violates the id grammar (da#359).
     malformed_ids: int = 0
+    # Edges whose BOTH endpoints resolved but that MERGE did NOT newly create,
+    # because the relationship was already present from an earlier load (da#490).
+    # ``created`` counts only ``relationships_created`` (execute_write_batch ->
+    # ``summary.counters.relationships_created``), so an idempotent re-load onto a
+    # graph that already carries the edges returns ``created == 0`` for a perfectly
+    # healthy load. Tracking already-present separately lets the zero-count
+    # conformance check distinguish "0 created because already present" (benign)
+    # from "0 created because 0 endpoints resolved" (a genuine gap) — the da#490
+    # APPEARS_IN false-positive that pushed every clean reload to rc=5.
+    already_present: int = 0
 
     @property
     def refused(self) -> int:
@@ -59,6 +69,18 @@ class EdgeLoadResult:
         refusal upstream rather than a defect in the edge row itself.
         """
         return self.malformed_ids
+
+    @property
+    def resolved(self) -> int:
+        """Edges present in the graph after this load — newly created PLUS those an
+        earlier load already created (the re-MERGE matched, da#490).
+
+        This is the honest "did any edge actually land" signal the zero-count
+        conformance check keys on, so an idempotent re-load (``created == 0``,
+        ``already_present > 0``) is never mistaken for an empty load. ``created``
+        alone cannot answer that: it counts only *newly* created relationships.
+        """
+        return self.created + self.already_present
 
 
 # ---------------------------------------------------------------------------
@@ -408,14 +430,23 @@ def _load_transmitted_to(
         if valid_batch
         else 0
     )
+    already_present = len(valid_batch) - created
     logger.info(
         "transmitted_to_loaded",
         created=created,
+        already_present=already_present,
         missing_endpoints=missing,
         total_pairs=len(all_pairs),
         dropped_noncanonical=dropped_noncanonical,
     )
-    return EdgeLoadResult("TRANSMITTED_TO", created, 0, missing, malformed_ids=malformed_ids)
+    return EdgeLoadResult(
+        "TRANSMITTED_TO",
+        created,
+        0,
+        missing,
+        malformed_ids=malformed_ids,
+        already_present=already_present,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -546,13 +577,22 @@ def _load_narrated(
         if valid_batch
         else 0
     )
+    already_present = len(valid_batch) - created
     logger.info(
         "narrated_loaded",
         created=created,
+        already_present=already_present,
         missing_endpoints=missing,
         dropped_noncanonical=dropped_noncanonical,
     )
-    return EdgeLoadResult("NARRATED", created, 0, missing, malformed_ids=malformed_ids)
+    return EdgeLoadResult(
+        "NARRATED",
+        created,
+        0,
+        missing,
+        malformed_ids=malformed_ids,
+        already_present=already_present,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -667,8 +707,22 @@ def _load_appears_in(
         if valid_batch
         else 0
     )
-    logger.info("appears_in_loaded", created=created, skipped=skipped, missing_endpoints=missing)
-    return EdgeLoadResult("APPEARS_IN", created, skipped, missing, malformed_ids=malformed_ids)
+    already_present = len(valid_batch) - created
+    logger.info(
+        "appears_in_loaded",
+        created=created,
+        already_present=already_present,
+        skipped=skipped,
+        missing_endpoints=missing,
+    )
+    return EdgeLoadResult(
+        "APPEARS_IN",
+        created,
+        skipped,
+        missing,
+        malformed_ids=malformed_ids,
+        already_present=already_present,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -729,6 +783,7 @@ def _load_parallel_of(
     skipped = 0
     missing = 0
     created = 0
+    resolved = 0
     malformed_ids = 0
     for rows in _iter_parquet_row_batches(path):
         batch: list[dict[str, Any]] = []
@@ -777,9 +832,12 @@ def _load_parallel_of(
                 missing += 1
 
         if valid_batch:
+            resolved += len(valid_batch)
             created += client.execute_write_batch(
                 _PARALLEL_OF_QUERY, valid_batch, batch_size=batch_size
             )
+
+    already_present = resolved - created
 
     if malformed_ids:
         logger.warning("parallel_of_malformed_ids_quarantined", pairs=malformed_ids)
@@ -794,22 +852,36 @@ def _load_parallel_of(
         )
         return EdgeLoadResult("PARALLEL_OF", 0, skipped, 0, malformed_ids=malformed_ids)
 
-    # Detected links that resolved to zero loaded edges is a silent-failure mode
+    # Detected links that resolved to zero PRESENT edges is a silent-failure mode
     # (every endpoint missing — e.g. an id-scheme mismatch): warn, do not pass it
-    # by at INFO (da#160).
-    if created == 0:
+    # by at INFO (da#160). Key on ``resolved`` (created + already-present), not
+    # ``created`` alone: an idempotent re-load onto a graph that already carries
+    # the edges has ``created == 0`` yet is perfectly healthy, and flagging it here
+    # was the same false-positive as the da#490 edge_load_conformance one.
+    if resolved == 0:
         logger.warning(
             "parallel_of_loaded_zero",
             candidates=candidates,
             skipped=skipped,
             missing_endpoints=missing,
-            msg="parallel links present but 0 PARALLEL_OF edges loaded",
+            msg="parallel links present but 0 PARALLEL_OF edges resolved",
         )
     else:
         logger.info(
-            "parallel_of_loaded", created=created, skipped=skipped, missing_endpoints=missing
+            "parallel_of_loaded",
+            created=created,
+            already_present=already_present,
+            skipped=skipped,
+            missing_endpoints=missing,
         )
-    return EdgeLoadResult("PARALLEL_OF", created, skipped, missing, malformed_ids=malformed_ids)
+    return EdgeLoadResult(
+        "PARALLEL_OF",
+        created,
+        skipped,
+        missing,
+        malformed_ids=malformed_ids,
+        already_present=already_present,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -963,8 +1035,17 @@ def _load_studied_under(
         if valid_batch
         else 0
     )
-    logger.info("studied_under_loaded", created=created, skipped=skipped, missing_endpoints=missing)
-    return EdgeLoadResult("STUDIED_UNDER", created, skipped, missing)
+    already_present = len(valid_batch) - created
+    logger.info(
+        "studied_under_loaded",
+        created=created,
+        already_present=already_present,
+        skipped=skipped,
+        missing_endpoints=missing,
+    )
+    return EdgeLoadResult(
+        "STUDIED_UNDER", created, skipped, missing, already_present=already_present
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -995,8 +1076,29 @@ def _load_graded_by(
     *,
     strict: bool = True,
     batch_size: int = DEFAULT_BATCH_SIZE,
+    loaded_hadith_ids: set[str] | None = None,
 ) -> EdgeLoadResult:
-    """Load GRADED_BY edges from hadith staging data.
+    """Load GRADED_BY edges (Hadith -> Grading) from hadith staging data.
+
+    *loaded_hadith_ids* is the node loader's real kept set (da#373/da#490); when
+    the caller does not supply it, it is derived from *staging_dir*'s hadith files.
+    A grade whose Hadith the node loader did NOT keep — a non-canonical edition
+    (``fawaz``'s six-books, da#191/da#333) or a cross-edition-deduped tradition
+    (da#220) — is dropped here, mirroring how the chain edges drop the same
+    hadiths (:func:`_mention_hadith_survives`) and how :func:`_load_gradings` now
+    declines to mint an orphan Grading node for one.
+
+    This is the da#490 Finding-B fix, and it names the real root cause: the 21,185
+    ``GRADED_BY`` endpoints that "never resolved" were never a *Grading*-id-scheme
+    mismatch — this loader and the node loader (:func:`_load_gradings`) derive the
+    Grading id from ONE ``grading_node_id(sid)`` on the SAME ``source_id``, so the
+    Grading side cannot disagree — but a missing *Hadith* endpoint. All 21,185 are
+    ``fawaz`` six-books grades whose Hadith node ``_load_hadiths`` drops as a
+    non-canonical duplicate of the ``lk`` spine, so counting them as
+    ``missing_endpoints`` mislabelled a deliberate composition drop as a load
+    failure. Gating them out here (as ``dropped_noncanonical``, exactly like the
+    ~196k chain drops) leaves ``GRADED_BY`` resolving against the canonical ``lk``
+    grades and ``missing_endpoints`` reporting only genuine mismatches.
 
     Gracefully skips if no hadiths with grades exist.
     """
@@ -1005,9 +1107,13 @@ def _load_graded_by(
         logger.info("graded_by_skipped", reason="no_hadith_files")
         return EdgeLoadResult("GRADED_BY", 0, 0, 0)
 
+    if loaded_hadith_ids is None:
+        loaded_hadith_ids = _staging_loaded_hadith_ids(staging_dir)
+
     batch: list[dict[str, Any]] = []
     skipped = 0
     malformed_ids = 0
+    dropped_noncanonical = 0
 
     for fp in files:
         rows = _read_parquet_rows(fp)
@@ -1028,13 +1134,28 @@ def _load_graded_by(
                 skipped += 1
                 malformed_ids += 1
                 continue
+            # da#490: drop a grade whose Hadith the node loader did not keep, so a
+            # GRADED_BY edge is never attempted against a Hadith node that was
+            # deliberately dropped (fawaz six-books / cross-edition dedup). Gate on
+            # the node loader's real kept set — the SAME set the chain edges use —
+            # falling back to the id-grammar composition gate when it is
+            # unavailable (no staging hadith files; unreachable here since we
+            # returned early above, kept as defence-in-depth mirroring
+            # :func:`_mention_hadith_survives`).
+            if loaded_hadith_ids is not None:
+                survives = hid in loaded_hadith_ids
+            else:
+                survives = is_canonical_hadith_id(hid)
+            if not survives:
+                dropped_noncanonical += 1
+                continue
             batch.append({"hadith_id": hid, "grading_id": gid})
 
     if malformed_ids:
         logger.warning("graded_by_malformed_ids_quarantined", rows=malformed_ids)
 
     if not batch:
-        logger.info("graded_by_no_edges")
+        logger.info("graded_by_no_edges", dropped_noncanonical=dropped_noncanonical)
         return EdgeLoadResult("GRADED_BY", 0, skipped, 0, malformed_ids=malformed_ids)
 
     # Check endpoints
@@ -1052,8 +1173,23 @@ def _load_graded_by(
         if valid_batch
         else 0
     )
-    logger.info("graded_by_loaded", created=created, skipped=skipped, missing_endpoints=missing)
-    return EdgeLoadResult("GRADED_BY", created, skipped, missing, malformed_ids=malformed_ids)
+    already_present = len(valid_batch) - created
+    logger.info(
+        "graded_by_loaded",
+        created=created,
+        already_present=already_present,
+        skipped=skipped,
+        missing_endpoints=missing,
+        dropped_noncanonical=dropped_noncanonical,
+    )
+    return EdgeLoadResult(
+        "GRADED_BY",
+        created,
+        skipped,
+        missing,
+        malformed_ids=malformed_ids,
+        already_present=already_present,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1120,7 +1256,15 @@ def load_all_edges(
     results.append(_load_appears_in(client, staging_dir, strict=strict, batch_size=batch_size))
     results.append(_load_parallel_of(client, staging_dir, strict=strict, batch_size=batch_size))
     results.append(_load_studied_under(client, staging_dir, batch_size=batch_size))
-    results.append(_load_graded_by(client, staging_dir, strict=strict, batch_size=batch_size))
+    results.append(
+        _load_graded_by(
+            client,
+            staging_dir,
+            strict=strict,
+            batch_size=batch_size,
+            loaded_hadith_ids=loaded_hadith_ids,
+        )
+    )
 
     total_created = sum(r.created for r in results)
     total_missing = sum(r.missing_endpoints for r in results)
@@ -1131,16 +1275,25 @@ def load_all_edges(
         edge_types=len(results),
     )
 
-    # Conformance counter: an edge type that loaded zero edges is a product-level
+    # Conformance counter: an edge type that resolved ZERO edges is a product-level
     # red flag worth surfacing on its own — PARALLEL_OF=0 is exactly the da#160
     # regression (/compare Browse Parallels permanently empty). Emit a WARNING per
-    # zero-count type so an empty load is never silent in the run logs.
-    zero_types = [r.edge_type for r in results if r.created == 0]
+    # zero-resolve type so an empty load is never silent in the run logs.
+    #
+    # Key on ``resolved`` (created + already-present), NOT ``created`` alone
+    # (da#490): ``created`` counts only *newly* MERGE'd relationships, so an
+    # idempotent re-load onto a graph that already carries the edges reports
+    # ``created == 0`` for a perfectly healthy edge type — the APPEARS_IN /
+    # GRADED_BY false-positive that pushed every clean stg reload to rc=5. An edge
+    # type that resolved even one endpoint pair (``resolved > 0``) has NOT loaded
+    # zero edges; only ``resolved == 0`` — no endpoint pair present, whether newly
+    # or already — is the genuine gap this check exists to catch.
+    zero_types = [r.edge_type for r in results if r.resolved == 0]
     if zero_types:
         logger.warning(
             "edge_load_conformance",
             zero_count_edge_types=zero_types,
-            msg="edge type(s) loaded 0 edges",
+            msg="edge type(s) resolved 0 edges (none present after load)",
         )
 
     return results

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -793,9 +793,20 @@ def _load_gradings(
 ) -> LoadResult:
     """Load Grading nodes from hadith staging data.
 
-    Gradings are extracted from the ``grade`` column of hadiths_*.parquet.
-    Each hadith with a non-null grade produces a single Grading node
-    attributed to the collection compiler.
+    Gradings are extracted from the ``grade`` column of hadiths_*.parquet. Each
+    graded hadith that the node loader actually keeps produces a single Grading
+    node attributed to the collection compiler.
+
+    A grade is minted ONLY for a hadith whose keep-decision is ``_KEEP`` — the
+    SAME :func:`_hadith_load_outcome` gate :func:`_load_hadiths` applies (da#490).
+    A grade on a hadith the loader drops (a non-canonical edition — ``fawaz``'s
+    six-books, da#191/da#333 — or a cross-edition-deduped tradition, da#220) would
+    otherwise create an ORPHAN Grading node whose ``hadith_id`` points at a Hadith
+    that never loads: dead data, and the endpoint the ``GRADED_BY`` edge then fails
+    to resolve (the da#490 "0 of 21,185" gap). Declining it here mirrors da#191's
+    drop of non-canonical Collection nodes "so they don't outlive their Hadith",
+    and keeps the Grading node set in lock-step with the Hadith set the
+    ``GRADED_BY`` edge loader gates on.
     """
     files = _filter_parquet_files(_parquet_files(staging_dir, "hadiths_"), staging_dir, skip_files)
     if not files:
@@ -805,11 +816,16 @@ def _load_gradings(
         logger.warning("grading_files_missing", dir=str(staging_dir))
         return LoadResult("Grading", 0, 0, 0)
 
+    # Same cross-edition canonical-identity index the Hadith loader builds, so the
+    # keep-decision here is byte-for-byte the one _load_hadiths makes (da#490).
+    curated_identities = _build_curated_identity_index(files)
+
     batch: list[dict[str, Any]] = []
     errors: list[str] = []
     skipped = 0
     malformed = 0
     invalid_sid = 0
+    dropped_noncanonical = 0
 
     for fp in files:
         rows = _read_parquet_rows(fp)
@@ -817,27 +833,45 @@ def _load_gradings(
             grade = row.get("grade")
             if not grade:
                 continue
-            sid = row.get("source_id")
-            if not sid:
+            # ONE keep-decision, shared with _load_hadiths / build_loaded_hadith_ids
+            # so a Grading node exists iff its Hadith node does (da#490). Applies the
+            # same gates in the same order — invalid source_id, composition (da#191),
+            # cross-edition matn dedup (da#220), id well-formedness.
+            node_id, reason = _hadith_load_outcome(row, curated_identities)
+            if reason == _DROP_INVALID_SID:
                 errors.append(f"{fp.name} row {i}: grade present but no source_id")
                 skipped += 1
                 invalid_sid += 1
                 continue
-            # da#355: quarantine a malformed id, never abort the load.
-            try:
-                gid = grading_node_id(sid)
-                grading_hadith_id = hadith_node_id(sid)
-            except DoubledCorpusPrefixError as exc:
-                if strict:
-                    raise
-                errors.append(f"{fp.name} row {i}: {exc}")
+            if reason in (_DROP_NONCANONICAL, _DROP_CROSS_EDITION):
+                # A grade on a hadith the loader deliberately drops — no orphan
+                # Grading node (da#490). Counted as a deliberate skip, NOT a
+                # refusal, exactly like the Hadith loader's own drops.
+                skipped += 1
+                dropped_noncanonical += 1
+                continue
+            if reason == _DROP_MALFORMED:
+                # da#355: quarantine a malformed id, never abort the load — but
+                # strict still makes it fatal. Re-mint so the original
+                # DoubledCorpusPrefixError propagates unchanged under strict and is
+                # recorded verbatim under non-strict.
+                try:
+                    grading_node_id(row["source_id"])
+                except DoubledCorpusPrefixError as exc:
+                    if strict:
+                        raise
+                    errors.append(f"{fp.name} row {i}: {exc}")
                 skipped += 1
                 malformed += 1
                 continue
+            # KEEP. node_id is the hdt: Hadith node id; the grading's own id is the
+            # grd: sibling from the same bare source_id (so grading_node_id here and
+            # in the GRADED_BY edge loader can never disagree — da#490).
+            sid = row["source_id"]
             batch.append(
                 {
-                    "id": gid,
-                    "hadith_id": grading_hadith_id,
+                    "id": grading_node_id(sid),
+                    "hadith_id": node_id,
                     "scholar_name": _val(row, "collection_name", "unknown"),
                     "grade": grade,
                     # Normalized display grade (da#148): the raw ``grade`` may be
@@ -858,6 +892,7 @@ def _load_gradings(
         skipped=skipped,
         malformed_ids=malformed,
         invalid_source_ids=invalid_sid,
+        dropped_noncanonical=dropped_noncanonical,
     )
     return LoadResult(
         "Grading",

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -1632,3 +1632,227 @@ class TestCrossEditionDedupVisibleToEdges:
         results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
         tt = next(r for r in results if r.edge_type == "TRANSMITTED_TO")
         assert tt.created == 1
+
+
+class _IdempotentClient(MockNeo4jClient):
+    """A client whose writes report 0 newly-created relationships.
+
+    Simulates an idempotent re-load onto a graph that ALREADY carries the edges:
+    the re-MERGE matches existing relationships, so
+    ``summary.counters.relationships_created`` is 0 even though every endpoint
+    resolved. This is the exact da#490 Finding-A condition — ``created == 0`` for a
+    perfectly healthy edge type — which the default ``MockNeo4jClient`` (returns
+    ``len(batch)``) cannot reproduce.
+    """
+
+    def execute_write_batch(
+        self, query: str, batch: list[dict[str, object]], batch_size: int = 1000
+    ) -> int:
+        self.calls.append((query, batch))
+        return 0
+
+
+class TestGradedByCompositionGate:
+    """da#490 Finding B — GRADED_BY gated on the node loader's kept hadith set.
+
+    The 21,185 GRADED_BY endpoints that "never resolved" were never a Grading-id
+    mismatch: this loader and ``_load_gradings`` derive the grading id from ONE
+    ``grading_node_id(sid)`` on the SAME ``source_id``, so the Grading side cannot
+    disagree. They are ``fawaz`` six-books grades whose *Hadith* node the loader
+    drops as a non-canonical duplicate of the ``lk`` spine — a missing Hadith
+    endpoint. Gating them out (as the chain edges already gate the same hadiths)
+    keeps GRADED_BY resolving against the canonical grades and stops mislabelling a
+    deliberate composition drop as ``missing_endpoints``.
+    """
+
+    def test_fawaz_six_books_grade_dropped_not_missing(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        # The fawaz Hadith node is NOT loaded, so its endpoint check would fail. If
+        # the gate did not drop it first, it would be counted as a missing endpoint
+        # — this second read entry is what makes the missing_endpoints assertion
+        # bite (without the gate it would be 1, not 0).
+        mock_client.set_read_results(
+            [
+                {
+                    "hadith_id": "hdt:lk:bukhari:1",
+                    "grading_id": "grd:lk:bukhari:1",
+                    "hadith_exists": True,
+                    "grading_exists": True,
+                },
+                {
+                    "hadith_id": "hdt:fawaz:bukhari:1",
+                    "grading_id": "grd:fawaz:bukhari:1",
+                    "hadith_exists": False,
+                    "grading_exists": True,
+                },
+            ]
+        )
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "lk:bukhari:1",
+                    "source_corpus": "lk",
+                    "collection_name": "bukhari",
+                    "grade": "sahih",
+                },
+                {
+                    "source_id": "fawaz:bukhari:1",
+                    "source_corpus": "fawaz",
+                    "collection_name": "bukhari",
+                    "grade": "sahih",
+                },
+            ],
+        )
+        results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        gb = next(r for r in results if r.edge_type == "GRADED_BY")
+        # The canonical lk grade resolves; the dropped fawaz six-books grade is NOT
+        # counted as a missing endpoint (it never reaches the endpoint check).
+        assert gb.resolved == 1
+        assert gb.missing_endpoints == 0
+        # Only the canonical grade is written to GRADED_BY.
+        graded_writes = [
+            b
+            for q, b in mock_client.calls
+            if isinstance(b, list) and b and "grading_id" in b[0] and "GRADED_BY" in str(q)
+        ]
+        sent = {r["grading_id"] for b in graded_writes for r in b}
+        assert sent == {"grd:lk:bukhari:1"}
+
+    def test_fawaz_unique_collection_grade_kept(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        # fawaz's UNIQUE collections (nawawi/dehlawi/qudsi) DO load Hadith nodes, so
+        # a grade on one must survive the gate — only the six-books duplicates drop.
+        mock_client.set_read_results(
+            [
+                {
+                    "hadith_id": "hdt:fawaz:nawawi:5",
+                    "grading_id": "grd:fawaz:nawawi:5",
+                    "hadith_exists": True,
+                    "grading_exists": True,
+                }
+            ]
+        )
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "fawaz:nawawi:5",
+                    "source_corpus": "fawaz",
+                    "collection_name": "nawawi",
+                    "grade": "sahih",
+                }
+            ],
+        )
+        results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        gb = next(r for r in results if r.edge_type == "GRADED_BY")
+        assert gb.resolved == 1
+        assert gb.missing_endpoints == 0
+
+    def test_cross_edition_deduped_grade_dropped(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        # da#373 axis: the gate uses the node loader's REAL kept set, so a sanadset
+        # grade whose matn is deduped to a curated lk edition is dropped too — not
+        # just the id-grammar composition drops. lk keeps its grade and resolves.
+        shared_matn = "انما الاعمال بالنيات"
+        mock_client.set_read_results(
+            [
+                {
+                    "hadith_id": "hdt:lk:bukhari:1",
+                    "grading_id": "grd:lk:bukhari:1",
+                    "hadith_exists": True,
+                    "grading_exists": True,
+                }
+            ]
+        )
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "lk:bukhari:1",
+                    "source_corpus": "lk",
+                    "matn_ar": shared_matn,
+                    "grade": "sahih",
+                }
+            ],
+            suffix="lk",
+        )
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "sanadset:1:dup",
+                    "source_corpus": "sanadset",
+                    "matn_ar": shared_matn,
+                    "grade": "hasan",
+                }
+            ],
+            suffix="sanadset_dup",
+        )
+        results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
+        gb = next(r for r in results if r.edge_type == "GRADED_BY")
+        assert gb.resolved == 1
+        assert gb.missing_endpoints == 0
+        graded_writes = [
+            b
+            for q, b in mock_client.calls
+            if isinstance(b, list) and b and "grading_id" in b[0] and "GRADED_BY" in str(q)
+        ]
+        sent = {r["grading_id"] for b in graded_writes for r in b}
+        assert "grd:sanadset:1:dup" not in sent
+
+
+class TestIdempotentReloadConformance:
+    """da#490 Finding A — ``created == 0`` on a re-load is idempotency, not a gap.
+
+    ``execute_write_batch`` returns only ``relationships_created``, so an
+    idempotent re-load onto a graph that already carries the edges reports
+    ``created == 0`` for a healthy edge type. The zero-count conformance check must
+    key on ``resolved`` (created + already-present), never on ``created`` alone,
+    or it false-flags every clean reload and pushes the loader to rc=5.
+    """
+
+    def _write_one_appears_in(self, staging_dir: Path) -> None:
+        write_hadiths(staging_dir, [{"source_id": "h-1", "collection_name": "bukhari"}])
+
+    def _resolving_read(self) -> list[dict[str, object]]:
+        return [
+            {
+                "hadith_id": "hdt:h-1",
+                "collection_id": "col:sunnah:bukhari",
+                "hadith_exists": True,
+                "collection_exists": True,
+            }
+        ]
+
+    def test_appears_in_reports_already_present(self, staging_dir: Path, curated_dir: Path) -> None:
+        client = _IdempotentClient()
+        client.set_read_results(self._resolving_read())
+        self._write_one_appears_in(staging_dir)
+        results = load_all_edges(client, staging_dir, curated_dir, strict=False)
+        ai = next(r for r in results if r.edge_type == "APPEARS_IN")
+        assert ai.created == 0
+        assert ai.already_present == 1
+        assert ai.resolved == 1
+
+    def test_idempotent_reload_not_flagged_by_conformance(
+        self, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        client = _IdempotentClient()
+        client.set_read_results(self._resolving_read())
+        self._write_one_appears_in(staging_dir)
+        with structlog.testing.capture_logs() as logs:
+            load_all_edges(client, staging_dir, curated_dir, strict=False)
+        conformance = [e for e in logs if e["event"] == "edge_load_conformance"]
+        # Other edge types have no input here and DO flag (genuinely empty); the
+        # point is APPEARS_IN — which resolved one already-present edge — must not.
+        assert conformance
+        assert "APPEARS_IN" not in conformance[0]["zero_count_edge_types"]
+
+    def test_resolved_property_counts_created_plus_present(self) -> None:
+        assert EdgeLoadResult("APPEARS_IN", 0, 0, 0, already_present=5).resolved == 5
+        # A genuine gap — nothing created, nothing already present — still reads 0.
+        assert EdgeLoadResult("GRADED_BY", 0, 0, 21185).resolved == 0

--- a/tests/test_graph/test_load_nodes.py
+++ b/tests/test_graph/test_load_nodes.py
@@ -911,6 +911,77 @@ class TestLoadGradings:
         assert by_hadith["hdt:h-1"]["grade_normalized"] == "sahih"
         assert by_hadith["hdt:h-2"]["grade_normalized"] == "daif"
 
+    def _minted_grading_ids(self, mock_client: MockNeo4jClient) -> set[str]:
+        return {
+            r["id"]
+            for _query, batch in mock_client.calls
+            if isinstance(batch, list) and batch and str(batch[0].get("id", "")).startswith("grd:")
+            for r in batch
+        }
+
+    def test_noncanonical_grade_mints_no_orphan_grading_node(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """da#490: a grade on a hadith the loader drops mints no Grading node.
+
+        ``fawaz``'s six-books editions (e.g. ``fawaz:bukhari``) are non-canonical
+        duplicates of the ``lk`` spine and load no Hadith node, so a Grading node
+        for one would be an orphan whose GRADED_BY edge can never resolve — the
+        da#490 "0 of 21,185" gap. Only the kept (lk) grade produces a Grading node.
+        """
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "lk:bukhari:1",
+                    "source_corpus": "lk",
+                    "collection_name": "bukhari",
+                    "grade": "sahih",
+                },
+                {
+                    "source_id": "fawaz:bukhari:1",
+                    "source_corpus": "fawaz",
+                    "collection_name": "bukhari",
+                    "grade": "sahih",
+                },
+            ],
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        minted = self._minted_grading_ids(mock_client)
+        assert "grd:lk:bukhari:1" in minted
+        assert "grd:fawaz:bukhari:1" not in minted
+
+    def test_cross_edition_deduped_grade_mints_no_grading_node(
+        self, mock_client: MockNeo4jClient, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        """da#490 + da#220: a grade on a cross-edition-deduped hadith mints none.
+
+        A ``sanadset`` hadith whose normalized matn matches a curated ``lk`` edition
+        is dropped at load (curated wins), so its grade must not become an orphan
+        Grading node either — the gate uses the node loader's REAL kept set, not the
+        id-grammar composition slice alone.
+        """
+        shared_matn = "انما الاعمال بالنيات"
+        write_hadiths(
+            staging_dir,
+            [{"source_id": "lk:bukhari:1", "source_corpus": "lk", "matn_ar": shared_matn}],
+            suffix="lk",
+        )
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "sanadset:1:dup",
+                    "source_corpus": "sanadset",
+                    "matn_ar": shared_matn,
+                    "grade": "hasan",
+                }
+            ],
+            suffix="sanadset_dup",
+        )
+        load_all_nodes(mock_client, staging_dir, curated_dir, strict=False)
+        assert "grd:sanadset:1:dup" not in self._minted_grading_ids(mock_client)
+
 
 class TestLoadHistoricalEvents:
     def test_valid_events(


### PR DESCRIPTION
Closes #490.

## Root cause (both findings)

### Finding A — `APPEARS_IN created=0` is benign idempotency, not a gap
`execute_write_batch` returns only `summary.counters.relationships_created`. On a
re-load onto a graph that already carries the edges, the re-`MERGE` creates **0
new** relationships — the correct idempotent outcome. `edge_load_conformance`
(and PARALLEL_OF's own da#160 zero-warning) keyed on `created == 0`, so they
false-alarmed on every clean reload and needlessly drove the loader toward rc=5.

**Fix:** `EdgeLoadResult` now carries `already_present` (endpoints resolved but
not newly created) and a `resolved` property (`created + already_present`). Every
edge loader computes `already_present = len(valid_batch) - created`. Both
zero-count checks now key on `resolved == 0` — *no endpoint pair present, whether
newly or already* — which is the only genuine gap. `already_present` is also
surfaced in the CLI load summary.

### Finding B — GRADED_BY 0/21,185: the failing endpoint is the **Hadith**, not the Grading
The issue hypothesised a `grading_node_id` scheme mismatch. **It is not.**
`_load_gradings` (node) and `_load_graded_by` (edge) both derive the grading id
from **one** `grading_node_id(sid)` on the **same** `source_id`, so the Grading
side cannot disagree — proven by code inspection and a bite-test.

The real cause: all 21,185 grades are **fawaz six-books editions** (bukhari,
muslim, …), which `_load_hadiths` drops as **non-canonical duplicates of the lk
spine** (`HADITH_COMPOSITION["fawaz"] = {nawawi, dehlawi, qudsi}`, da#191/da#333).
Their **Hadith node never loads**, so:
- `_load_graded_by` counted the deliberate composition drop as `missing_endpoints`
  (21,185, every run), and
- `_load_gradings` still minted an **orphan Grading node** whose `hadith_id`
  points at a Hadith that never loads.

Reconciling the issue's own numbers confirms it: `gradings_loaded merged=69,575`
with `GRADED_BY missing=21,185` means ~48k **lk** grades already resolve
(created=0 on reload = Finding-A idempotency) while the 21,185 fawaz orphans fail
every run.

**Fix:** gate `_load_gradings` and `_load_graded_by` on the node loader's **real
kept set** — the same `build_loaded_hadith_ids` / `_hadith_load_outcome` decision
`_load_hadiths` makes and the chain edges (da#333/da#373) already use. A grade is
minted/edged **iff** its Hadith loads. GRADED_BY now resolves against the
canonical lk grades; the fawaz duplicates are dropped **consistently with the
~196k da#333/#373 chain drops** (drop, not re-point — mirroring the established
cross-edition precedent), and `missing_endpoints` reports only genuine mismatches.
The da#355 malformed-id quarantine is preserved on both the node and edge path.

## Tests
- `TestGradedByCompositionGate`: fawaz six-books grade dropped (not counted
  missing — bite-verified: reverting the gate yields `missing_endpoints=1`),
  fawaz-unique (nawawi) grade kept, cross-edition sanadset-dedup grade dropped
  (exercises the real kept set, not just id-grammar).
- `TestIdempotentReloadConformance`: `already_present`/`resolved` accounting; an
  idempotent APPEARS_IN reload is **not** flagged by conformance.
- `_load_gradings` node regressions: no orphan Grading node for a dropped
  (non-canonical / cross-edition) hadith.
- Full `tests/test_graph` suite green (304); ruff + mypy clean.

**Not exercised here:** the Docker/Neo4j `tests/integration` graph-loading suite —
no Docker daemon in the sandbox (all setup-errored on container unavailability).
Its `test_graded_by_edges` uses `source_corpus="sunnah"` (kept), so the gate does
not alter its expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)