### PR TITLE
fix(da#490): edge_load_conformance false-positive + GRADED_BY composition gap

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -388,8 +388,9 @@ def _cmd_load(
         )
     for er in summary.edge_results:
         print(
-            f"    {er.edge_type}: created={er.created} skipped={er.skipped}"
-            f" missing_endpoints={er.missing_endpoints} malformed_ids={er.malformed_ids}"
+            f"    {er.edge_type}: created={er.created} attempted={er.attempted}"
+            f" skipped={er.skipped} missing_endpoints={er.missing_endpoints}"
+            f" malformed_ids={er.malformed_ids}"
         )
 
     if summary.validation_results:

--- a/src/graph/load_edges.py
+++ b/src/graph/load_edges.py
@@ -48,6 +48,18 @@ class EdgeLoadResult:
     missing_endpoints: int
     # Edges refused because an endpoint id violates the id grammar (da#359).
     malformed_ids: int = 0
+    # da#490: edges whose BOTH endpoints resolved and were submitted to the
+    # write query, regardless of whether Neo4j actually created a new
+    # relationship for them (``created``) or the MERGE found it already present
+    # (an idempotent re-load). This is the field ``created == 0`` alone cannot
+    # distinguish: an edge type that loaded 650,983 edges last run and 0 THIS
+    # run because every one of them already exists (``attempted`` > 0,
+    # ``created`` == 0) is a correct idempotent no-op, not a load failure —
+    # unlike an edge type with ``attempted`` == 0, which never had a single
+    # valid endpoint pair to submit in the first place. See
+    # :func:`load_all_edges`'s conformance check, which keys on this rather
+    # than on ``created``.
+    attempted: int = 0
 
     @property
     def refused(self) -> int:
@@ -415,7 +427,14 @@ def _load_transmitted_to(
         total_pairs=len(all_pairs),
         dropped_noncanonical=dropped_noncanonical,
     )
-    return EdgeLoadResult("TRANSMITTED_TO", created, 0, missing, malformed_ids=malformed_ids)
+    return EdgeLoadResult(
+        "TRANSMITTED_TO",
+        created,
+        0,
+        missing,
+        malformed_ids=malformed_ids,
+        attempted=len(valid_batch),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -552,7 +571,9 @@ def _load_narrated(
         missing_endpoints=missing,
         dropped_noncanonical=dropped_noncanonical,
     )
-    return EdgeLoadResult("NARRATED", created, 0, missing, malformed_ids=malformed_ids)
+    return EdgeLoadResult(
+        "NARRATED", created, 0, missing, malformed_ids=malformed_ids, attempted=len(valid_batch)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -668,7 +689,14 @@ def _load_appears_in(
         else 0
     )
     logger.info("appears_in_loaded", created=created, skipped=skipped, missing_endpoints=missing)
-    return EdgeLoadResult("APPEARS_IN", created, skipped, missing, malformed_ids=malformed_ids)
+    return EdgeLoadResult(
+        "APPEARS_IN",
+        created,
+        skipped,
+        missing,
+        malformed_ids=malformed_ids,
+        attempted=len(valid_batch),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -730,6 +758,7 @@ def _load_parallel_of(
     missing = 0
     created = 0
     malformed_ids = 0
+    attempted = 0
     for rows in _iter_parquet_row_batches(path):
         batch: list[dict[str, Any]] = []
         for row in rows:
@@ -777,6 +806,7 @@ def _load_parallel_of(
                 missing += 1
 
         if valid_batch:
+            attempted += len(valid_batch)
             created += client.execute_write_batch(
                 _PARALLEL_OF_QUERY, valid_batch, batch_size=batch_size
             )
@@ -796,8 +826,12 @@ def _load_parallel_of(
 
     # Detected links that resolved to zero loaded edges is a silent-failure mode
     # (every endpoint missing — e.g. an id-scheme mismatch): warn, do not pass it
-    # by at INFO (da#160).
-    if created == 0:
+    # by at INFO (da#160). da#490: keyed on ``attempted`` (valid pairs actually
+    # submitted to the MERGE), not ``created`` — a re-load onto a graph that
+    # already carries every PARALLEL_OF edge is a correct idempotent no-op
+    # (attempted > 0, created == 0), not the da#160 silent-failure this warning
+    # exists to catch (attempted == 0: every pair's endpoints were missing).
+    if attempted == 0:
         logger.warning(
             "parallel_of_loaded_zero",
             candidates=candidates,
@@ -807,9 +841,15 @@ def _load_parallel_of(
         )
     else:
         logger.info(
-            "parallel_of_loaded", created=created, skipped=skipped, missing_endpoints=missing
+            "parallel_of_loaded",
+            created=created,
+            skipped=skipped,
+            missing_endpoints=missing,
+            attempted=attempted,
         )
-    return EdgeLoadResult("PARALLEL_OF", created, skipped, missing, malformed_ids=malformed_ids)
+    return EdgeLoadResult(
+        "PARALLEL_OF", created, skipped, missing, malformed_ids=malformed_ids, attempted=attempted
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -964,7 +1004,7 @@ def _load_studied_under(
         else 0
     )
     logger.info("studied_under_loaded", created=created, skipped=skipped, missing_endpoints=missing)
-    return EdgeLoadResult("STUDIED_UNDER", created, skipped, missing)
+    return EdgeLoadResult("STUDIED_UNDER", created, skipped, missing, attempted=len(valid_batch))
 
 
 # ---------------------------------------------------------------------------
@@ -995,11 +1035,24 @@ def _load_graded_by(
     *,
     strict: bool = True,
     batch_size: int = DEFAULT_BATCH_SIZE,
+    loaded_hadith_ids: set[str] | None = None,
 ) -> EdgeLoadResult:
     """Load GRADED_BY edges from hadith staging data.
 
     Gracefully skips if no hadiths with grades exist.
+
+    *loaded_hadith_ids* is the node loader's real kept set (da#373); when the
+    caller does not supply it, it is derived from *staging_dir*'s hadith files.
+    See :func:`_mention_hadith_survives`. da#490: a graded hadith the node
+    loader composed away (the per-source/collection allowlist or the
+    cross-edition matn dedup, ``src.parse.composition``) has no Hadith node to
+    attach to — routing through the same gate the chain edges (TRANSMITTED_TO /
+    NARRATED) already use turns that into an accounted-for ``dropped_composed``
+    drop instead of an opaque ``missing_endpoints`` count indistinguishable from
+    a genuine id mismatch.
     """
+    if loaded_hadith_ids is None:
+        loaded_hadith_ids = _staging_loaded_hadith_ids(staging_dir)
     files = _parquet_files(staging_dir, "hadiths_")
     if not files:
         logger.info("graded_by_skipped", reason="no_hadith_files")
@@ -1008,6 +1061,7 @@ def _load_graded_by(
     batch: list[dict[str, Any]] = []
     skipped = 0
     malformed_ids = 0
+    dropped_composed = 0
 
     for fp in files:
         rows = _read_parquet_rows(fp)
@@ -1028,32 +1082,70 @@ def _load_graded_by(
                 skipped += 1
                 malformed_ids += 1
                 continue
+            if not _mention_hadith_survives(sid, loaded_hadith_ids):
+                dropped_composed += 1
+                continue
             batch.append({"hadith_id": hid, "grading_id": gid})
 
     if malformed_ids:
         logger.warning("graded_by_malformed_ids_quarantined", rows=malformed_ids)
 
     if not batch:
-        logger.info("graded_by_no_edges")
+        logger.info("graded_by_no_edges", dropped_composed=dropped_composed)
         return EdgeLoadResult("GRADED_BY", 0, skipped, 0, malformed_ids=malformed_ids)
 
     # Check endpoints
     check_results = _chunked_read(client, _GRADED_BY_CHECK, batch, batch_size)
     valid_batch: list[dict[str, Any]] = []
     missing = 0
+    # da#490: hadith_node_id/grading_node_id are otherwise identical between this
+    # loader and the node loaders that mint each side, so a mismatch here is the
+    # only way to tell "graph never had this hadith" from "graph never had this
+    # grading" — the split that turns the issue's "likely grading_node_id !=
+    # loaded Grading.id" into a confirmed answer on the next reload, without a
+    # live Cypher session.
+    missing_hadith_only = 0
+    missing_grading_only = 0
+    missing_both = 0
     for item, check in zip(batch, check_results):
-        if check.get("hadith_exists") and check.get("grading_exists"):
+        hadith_exists = bool(check.get("hadith_exists"))
+        grading_exists = bool(check.get("grading_exists"))
+        if hadith_exists and grading_exists:
             valid_batch.append(item)
+            continue
+        missing += 1
+        if hadith_exists:
+            missing_grading_only += 1
+            logger.debug("graded_by_missing_grading", id=item["grading_id"])
+        elif grading_exists:
+            missing_hadith_only += 1
+            logger.debug("graded_by_missing_hadith", id=item["hadith_id"])
         else:
-            missing += 1
+            missing_both += 1
 
     created = (
         client.execute_write_batch(_GRADED_BY_QUERY, valid_batch, batch_size=batch_size)
         if valid_batch
         else 0
     )
-    logger.info("graded_by_loaded", created=created, skipped=skipped, missing_endpoints=missing)
-    return EdgeLoadResult("GRADED_BY", created, skipped, missing, malformed_ids=malformed_ids)
+    logger.info(
+        "graded_by_loaded",
+        created=created,
+        skipped=skipped,
+        missing_endpoints=missing,
+        missing_hadith_only=missing_hadith_only,
+        missing_grading_only=missing_grading_only,
+        missing_both=missing_both,
+        dropped_composed=dropped_composed,
+    )
+    return EdgeLoadResult(
+        "GRADED_BY",
+        created,
+        skipped,
+        missing,
+        malformed_ids=malformed_ids,
+        attempted=len(valid_batch),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1094,7 +1186,9 @@ def load_all_edges(
     # chain-edge loaders, so they gate on the same set the node loader loaded —
     # composition AND cross-edition matn dedup — instead of re-deriving a partial
     # gate from the id string. This is what stops a repaired matn key from
-    # re-orphaning ~196k dangling chains.
+    # re-orphaning ~196k dangling chains. GRADED_BY shares it too (da#490): a
+    # graded hadith the node loader composed away has no home for its grade
+    # either.
     loaded_hadith_ids = _staging_loaded_hadith_ids(staging_dir)
 
     results.append(
@@ -1120,7 +1214,15 @@ def load_all_edges(
     results.append(_load_appears_in(client, staging_dir, strict=strict, batch_size=batch_size))
     results.append(_load_parallel_of(client, staging_dir, strict=strict, batch_size=batch_size))
     results.append(_load_studied_under(client, staging_dir, batch_size=batch_size))
-    results.append(_load_graded_by(client, staging_dir, strict=strict, batch_size=batch_size))
+    results.append(
+        _load_graded_by(
+            client,
+            staging_dir,
+            strict=strict,
+            batch_size=batch_size,
+            loaded_hadith_ids=loaded_hadith_ids,
+        )
+    )
 
     total_created = sum(r.created for r in results)
     total_missing = sum(r.missing_endpoints for r in results)
@@ -1131,16 +1233,25 @@ def load_all_edges(
         edge_types=len(results),
     )
 
-    # Conformance counter: an edge type that loaded zero edges is a product-level
-    # red flag worth surfacing on its own — PARALLEL_OF=0 is exactly the da#160
-    # regression (/compare Browse Parallels permanently empty). Emit a WARNING per
-    # zero-count type so an empty load is never silent in the run logs.
-    zero_types = [r.edge_type for r in results if r.created == 0]
+    # Conformance counter: an edge type that never had a single valid endpoint
+    # pair to submit is a product-level red flag worth surfacing on its own —
+    # PARALLEL_OF=0 is exactly the da#160 regression (/compare Browse Parallels
+    # permanently empty). Emit a WARNING per zero-count type so an empty load is
+    # never silent in the run logs.
+    #
+    # da#490: keyed on ``attempted`` (edges whose both endpoints resolved),
+    # never on ``created`` alone. A re-load onto a graph that already carries
+    # every edge of a type MERGEs zero *new* relationships — ``created == 0``
+    # with ``attempted > 0`` — which is the correct idempotent outcome, not a
+    # load failure, and flagging it false-alarmed on every clean reload
+    # (APPEARS_IN, 07-25 cutover). ``attempted == 0`` is the genuine "0 valid
+    # endpoints" case da#160 exists to catch.
+    zero_types = [r.edge_type for r in results if r.attempted == 0]
     if zero_types:
         logger.warning(
             "edge_load_conformance",
             zero_count_edge_types=zero_types,
-            msg="edge type(s) loaded 0 edges",
+            msg="edge type(s) had zero valid endpoint pairs to load",
         )
 
     return results

--- a/tests/test_graph/conftest.py
+++ b/tests/test_graph/conftest.py
@@ -21,7 +21,7 @@ from src.resolve.schemas import (
 class MockNeo4jClient:
     """Records calls instead of hitting a real Neo4j instance."""
 
-    def __init__(self, *, nodes_created_per_batch: int = 0) -> None:
+    def __init__(self, *, nodes_created_per_batch: int | None = None) -> None:
         self.calls: list[tuple[str, dict[str, Any] | list[dict[str, Any]]]] = []
         self.constraints_ensured = False
         self.fulltext_indexes_ensured = False
@@ -38,7 +38,13 @@ class MockNeo4jClient:
         self, query: str, batch: list[dict[str, Any]], batch_size: int = 1000
     ) -> int:
         self.calls.append((query, batch))
-        return self._nodes_created if self._nodes_created else len(batch)
+        # Unset (None) simulates "every row in the batch is newly created" — the
+        # default every pre-existing test relies on. An explicit override,
+        # INCLUDING 0 (da#490: an idempotent re-MERGE onto edges that already
+        # exist), must be honored as given rather than falling back to
+        # ``len(batch)`` — the pre-da#490 ``... if self._nodes_created else ...``
+        # truthy check could never express "0 created" because 0 is falsy.
+        return self._nodes_created if self._nodes_created is not None else len(batch)
 
     def execute_read(
         self,

--- a/tests/test_graph/test_load_edges.py
+++ b/tests/test_graph/test_load_edges.py
@@ -13,6 +13,7 @@ from src.graph.load_edges import (
     _APPEARS_IN_QUERY,
     EdgeLoadResult,
     _build_chain_pairs,
+    _load_graded_by,
     _load_studied_under,
     _studied_under_endpoint,
     load_all_edges,
@@ -1632,3 +1633,165 @@ class TestCrossEditionDedupVisibleToEdges:
         results = load_all_edges(mock_client, staging_dir, curated_dir, strict=False)
         tt = next(r for r in results if r.edge_type == "TRANSMITTED_TO")
         assert tt.created == 1
+
+
+class TestEdgeLoadConformanceAttempted:
+    """da#490 — the conformance counter must key on ``attempted`` (valid endpoint
+    pairs submitted), not ``created``: an idempotent re-load onto a graph that
+    already carries every edge of a type correctly reports ``created == 0`` and
+    must NOT false-positive as a load failure."""
+
+    def test_idempotent_reload_is_not_flagged(self, staging_dir: Path, curated_dir: Path) -> None:
+        # A production-shaped APPEARS_IN batch whose endpoints already exist, and
+        # whose MERGE creates 0 *new* relationships (nodes_created_per_batch=0) —
+        # exactly the 07-25 cutover reload the issue reports (created=0,
+        # missing_endpoints=75,380 unrelated/unchanged from the prior run).
+        write_hadiths(staging_dir, [{"source_id": "sunnah:bukhari:1"}])
+        client = MockNeo4jClient(nodes_created_per_batch=0)
+        client.set_read_results([{"hadith_exists": True, "collection_exists": True}])
+
+        with structlog.testing.capture_logs() as logs:
+            results = load_all_edges(client, staging_dir, curated_dir, strict=False)
+
+        ai = next(r for r in results if r.edge_type == "APPEARS_IN")
+        assert ai.created == 0
+        assert ai.attempted == 1
+        conformance = [e for e in logs if e["event"] == "edge_load_conformance"]
+        if conformance:
+            assert "APPEARS_IN" not in conformance[0]["zero_count_edge_types"]
+
+    def test_genuine_zero_valid_endpoints_is_still_flagged(
+        self, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        # The da#160 case this counter exists to catch: a batch of candidates
+        # whose endpoints are ALL missing. attempted == 0 (nothing was ever
+        # submitted to the write query), so the flag must still fire.
+        write_hadiths(staging_dir, [{"source_id": "sunnah:bukhari:1"}])
+        client = MockNeo4jClient()
+        client.set_read_results([{"hadith_exists": False, "collection_exists": False}])
+
+        with structlog.testing.capture_logs() as logs:
+            results = load_all_edges(client, staging_dir, curated_dir, strict=False)
+
+        ai = next(r for r in results if r.edge_type == "APPEARS_IN")
+        assert ai.created == 0
+        assert ai.attempted == 0
+        conformance = next(e for e in logs if e["event"] == "edge_load_conformance")
+        assert "APPEARS_IN" in conformance["zero_count_edge_types"]
+
+    def test_edge_load_result_attempted_defaults_to_zero(self) -> None:
+        # Positional-4-arg construction (every pre-da#490 call site in this test
+        # file and in src) must still work unchanged.
+        r = EdgeLoadResult("NARRATED", 5, 1, 0)
+        assert r.attempted == 0
+
+
+class TestLoadGradedByCompositionGate:
+    """da#490 — GRADED_BY shares the da#373 canonical-hadith gate: a graded
+    hadith the node loader composed away (per-source/collection allowlist or
+    cross-edition matn dedup) has no Hadith node to attach to, and must be
+    counted as a deliberate drop, not an opaque ``missing_endpoints``."""
+
+    def test_composed_away_graded_hadith_is_dropped_not_missing(
+        self, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        # fawaz:bukhari is the standard composed-away fixture (da#333): fawaz's
+        # HADITH_COMPOSITION allowlist keeps only nawawi/dehlawi/qudsi, so its
+        # six-books editions (bukhari included) mint no Hadith node.
+        write_hadiths(
+            staging_dir,
+            [
+                {
+                    "source_id": "fawaz:bukhari:1",
+                    "source_corpus": "fawaz",
+                    "collection_name": "bukhari",
+                    "grade": "sahih",
+                }
+            ],
+        )
+        client = MockNeo4jClient()
+
+        results = load_all_edges(client, staging_dir, curated_dir, strict=False)
+
+        gb = next(r for r in results if r.edge_type == "GRADED_BY")
+        # Dropped at the source: no candidate built, so no endpoint check ever ran
+        # for it, and it is never counted as a "missing" (mysterious) endpoint.
+        assert gb.created == 0
+        assert gb.missing_endpoints == 0
+        assert gb.attempted == 0
+        assert not any("GRADED_BY" in str(q) and "MERGE" in str(q) for q, _ in client.calls)
+
+    def test_canonical_graded_hadith_loads(self, staging_dir: Path, curated_dir: Path) -> None:
+        write_hadiths(
+            staging_dir,
+            [{"source_id": "sunnah:bukhari:1", "grade": "sahih"}],
+        )
+        client = MockNeo4jClient()
+        client.set_read_results([{"hadith_exists": True, "grading_exists": True}])
+
+        results = load_all_edges(client, staging_dir, curated_dir, strict=False)
+
+        gb = next(r for r in results if r.edge_type == "GRADED_BY")
+        assert gb.created == 1
+        assert gb.attempted == 1
+        assert gb.missing_endpoints == 0
+
+    def test_missing_grading_only_is_distinguished_in_logs(
+        self, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        # da#490's diagnostic: the hadith side resolves but the grading side does
+        # not — this is the exact shape the issue's "likely grading_node_id !=
+        # loaded Grading.id" hypothesis predicts, now directly observable.
+        write_hadiths(
+            staging_dir,
+            [{"source_id": "sunnah:bukhari:1", "grade": "sahih"}],
+        )
+        client = MockNeo4jClient()
+        client.set_read_results([{"hadith_exists": True, "grading_exists": False}])
+
+        with structlog.testing.capture_logs() as logs:
+            results = load_all_edges(client, staging_dir, curated_dir, strict=False)
+
+        gb = next(r for r in results if r.edge_type == "GRADED_BY")
+        assert gb.created == 0
+        assert gb.missing_endpoints == 1
+        loaded_event = next(e for e in logs if e["event"] == "graded_by_loaded")
+        assert loaded_event["missing_grading_only"] == 1
+        assert loaded_event["missing_hadith_only"] == 0
+        assert loaded_event["missing_both"] == 0
+
+    def test_missing_hadith_only_is_distinguished_in_logs(
+        self, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        write_hadiths(
+            staging_dir,
+            [{"source_id": "sunnah:bukhari:1", "grade": "sahih"}],
+        )
+        client = MockNeo4jClient()
+        client.set_read_results([{"hadith_exists": False, "grading_exists": True}])
+
+        with structlog.testing.capture_logs() as logs:
+            load_all_edges(client, staging_dir, curated_dir, strict=False)
+
+        loaded_event = next(e for e in logs if e["event"] == "graded_by_loaded")
+        assert loaded_event["missing_hadith_only"] == 1
+        assert loaded_event["missing_grading_only"] == 0
+        assert loaded_event["missing_both"] == 0
+
+    def test_graded_by_idempotent_reload_reports_attempted(
+        self, staging_dir: Path, curated_dir: Path
+    ) -> None:
+        # Mirrors TestEdgeLoadConformanceAttempted for GRADED_BY specifically:
+        # both endpoints resolve, but the MERGE creates 0 *new* relationships.
+        write_hadiths(
+            staging_dir,
+            [{"source_id": "sunnah:bukhari:1", "grade": "sahih"}],
+        )
+        client = MockNeo4jClient(nodes_created_per_batch=0)
+        client.set_read_results([{"hadith_exists": True, "grading_exists": True}])
+
+        result = _load_graded_by(client, staging_dir, strict=False)
+
+        assert result.created == 0
+        assert result.attempted == 1
+        assert result.missing_endpoints == 0


### PR DESCRIPTION
## Summary

Closes #490. Tier 3 tech-debt, non-blocking, surfaced during the Phase-9 re-cutover (#978).

### Finding A — `edge_load_conformance` false-positive on idempotent reload

`load_all_edges`'s conformance check flagged *any* edge type with `created == 0` as a load failure. That conflates two distinct situations:

- a genuine "0 valid endpoints" (the da#160 PARALLEL_OF regression this check exists to catch), and
- a correct idempotent re-MERGE onto a graph that already carries every edge of that type — Neo4j's own `relationships_created` counter is legitimately 0 on a re-run, by design.

This false-alarmed on `APPEARS_IN` in the 07-25 cutover reload (`created=0`, but 650,983 edges from the prior run were still there, untouched).

**Fix:** added `EdgeLoadResult.attempted` — edges whose both endpoints resolved and were submitted to the write query, regardless of whether the MERGE created something new — and keyed the conformance check (and PARALLEL_OF's own sibling da#160 zero-check) on `attempted` instead of `created`. `attempted` is now threaded through all 6 edge loaders and surfaced in the CLI's per-edge-type load summary.

### Finding B — GRADED_BY never loads a single edge (0/21,185 endpoints resolve)

`_load_graded_by` and the Grading node loader (`_load_gradings`) mint identical ids (`grading_node_id(sid)`/`hadith_node_id(sid)`) from the exact same `hadiths_*.parquet` `source_id` column — I traced this by hand and ruled out a code-level id-scheme drift between the two producers.

What both *do* skip is the da#373 canonical-hadith gate the chain edges (TRANSMITTED_TO / NARRATED) already apply: a graded hadith the node loader composed away (the per-source/collection `HADITH_COMPOSITION` allowlist, or the cross-edition matn dedup) has no Hadith node to attach to. Without the gate, that case was silently inflating `missing_endpoints` indistinguishably from a genuine id mismatch.

**Fix:**
- Route `_load_graded_by` through the same `_staging_loaded_hadith_ids` / `_mention_hadith_survives` gate already shared by TRANSMITTED_TO/NARRATED, so a composed-away graded hadith is now an accounted-for `dropped_composed` drop, not a mystery miss.
- Split the *remaining* endpoint-check failures into `missing_hadith_only` / `missing_grading_only` / `missing_both`, logged on `graded_by_loaded`. This turns the issue's own "likely grading_node_id != loaded Grading.id" into something the next real reload's structured logs will *confirm*, not guess at — I don't have access to the live stg graph to do that comparison myself.

### Incidental: test-mock gap

`MockNeo4jClient.execute_write_batch`'s `self._nodes_created if self._nodes_created else len(batch)` could never express "0 created" (0 is falsy in Python) — so no existing test in the suite could simulate an idempotent re-load at all, which is exactly the scenario Finding A needed to cover. Switched the default to `None` with an `is not None` check; no existing caller passes the kwarg, so this is behavior-preserving for every current test.

## Test plan

- [x] New tests in `tests/test_graph/test_load_edges.py`:
  - `TestEdgeLoadConformanceAttempted`: idempotent reload not flagged, genuine zero-endpoint case still flagged, `EdgeLoadResult.attempted` defaults to 0.
  - `TestLoadGradedByCompositionGate`: composed-away graded hadith dropped (not missing), canonical graded hadith loads, missing-grading-only vs missing-hadith-only distinguished in logs, idempotent GRADED_BY reload reports `attempted` correctly.
- [x] Full suite green: `uv run pytest tests/ -m "not integration"` (2539 passed, 10 skipped, 58 deselected — integration needs Docker).
- [x] `pre-commit run --all-files` and `--hook-stage push` (ruff-format, ruff-lint, gitleaks, actionlint, cspell, mypy-strict, pytest) all green.

Merge-gate: Nikolaos Papadopoulos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z